### PR TITLE
feat(contracts): implement attestation registry duplicate-key protection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "contracts/aggregated-attestations",
     "contracts/attestation",
+    "contracts/attestation-registry",
     "contracts/attestation-snapshot",
     "contracts/attestor-staking",
     "contracts/audit-log",

--- a/contracts/attestation-registry/src/lib.rs
+++ b/contracts/attestation-registry/src/lib.rs
@@ -12,6 +12,7 @@
 //! - Version metadata for tracking upgrades
 //! - Migration hooks for upgrade coordination
 //! - Governance-controlled upgrade mechanism
+//! - Duplicate-key protection for attestation keys
 //!
 //! ## Upgrade Process
 //!
@@ -21,12 +22,20 @@
 //! 4. Optional migration hook is called on new implementation
 //! 5. Version metadata is updated
 //!
+//! ## Duplicate-Key Protection
+//!
+//! The registry enforces that each `(attester, key)` pair can only be registered
+//! once. Callers invoke `register_attestation_key` before writing to the
+//! implementation contract; the registry rejects any attempt to reuse a key.
+//! This prevents replay attacks and accidental overwrites at the registry layer.
+//!
 //! ## Safety Constraints
 //!
 //! - Only the admin (governance) can perform upgrades
 //! - Registry must be initialized before use
 //! - Version numbers must be strictly increasing
 //! - Previous implementation address is preserved for rollback scenarios
+//! - Attestation keys are globally unique per `(attester, key)` pair
 //!
 //! ## Trust Model
 //!
@@ -60,6 +69,9 @@ pub enum DataKey {
     PreviousVersion,
     /// Initialization flag.
     Initialized,
+    /// Duplicate-key guard: marks a `(attester, key)` pair as registered.
+    /// Value is the ledger timestamp at registration time.
+    AttestationKey(Address, String),
 }
 
 /// Version metadata for an implementation.
@@ -103,12 +115,7 @@ impl AttestationRegistry {
     /// # Safety
     ///
     /// This is a one-time setup. The admin must be a trusted governance address.
-    pub fn initialize(
-        env: Env,
-        admin: Address,
-        initial_impl: Address,
-        initial_version: u32,
-    ) {
+    pub fn initialize(env: Env, admin: Address, initial_impl: Address, initial_version: u32) {
         if env.storage().instance().has(&DataKey::Initialized) {
             panic!("registry already initialized");
         }
@@ -148,12 +155,7 @@ impl AttestationRegistry {
     ///
     /// Only the admin (governance) can perform upgrades. The new implementation
     /// should be thoroughly tested before upgrade.
-    pub fn upgrade(
-        env: Env,
-        new_impl: Address,
-        new_version: u32,
-        _migration_data: Option<Bytes>,
-    ) {
+    pub fn upgrade(env: Env, new_impl: Address, new_version: u32, _migration_data: Option<Bytes>) {
         Self::require_initialized(&env);
         let _admin = Self::require_admin(&env);
 
@@ -226,10 +228,7 @@ impl AttestationRegistry {
             .storage()
             .instance()
             .get(&DataKey::PreviousImplementation);
-        let prev_version: Option<u32> = env
-            .storage()
-            .instance()
-            .get(&DataKey::PreviousVersion);
+        let prev_version: Option<u32> = env.storage().instance().get(&DataKey::PreviousVersion);
 
         if prev_impl.is_none() || prev_version.is_none() {
             panic!("no previous implementation to rollback to");
@@ -274,7 +273,9 @@ impl AttestationRegistry {
         if !env.storage().instance().has(&DataKey::Initialized) {
             return None;
         }
-        env.storage().instance().get(&DataKey::CurrentImplementation)
+        env.storage()
+            .instance()
+            .get(&DataKey::CurrentImplementation)
     }
 
     /// Get the current version number.
@@ -298,7 +299,9 @@ impl AttestationRegistry {
         if !env.storage().instance().has(&DataKey::Initialized) {
             return None;
         }
-        env.storage().instance().get(&DataKey::PreviousImplementation)
+        env.storage()
+            .instance()
+            .get(&DataKey::PreviousImplementation)
     }
 
     /// Get the previous version number.
@@ -364,6 +367,57 @@ impl AttestationRegistry {
             migration_data: None, // Migration data is not stored, only used during upgrade
             activated_at: env.ledger().timestamp(),
         })
+    }
+
+    // ── Duplicate-key protection ────────────────────────────────────
+
+    /// Register an attestation key for `(attester, key)`, enforcing uniqueness.
+    ///
+    /// This is the registry-layer duplicate-key guard. Call this before writing
+    /// an attestation to the implementation contract. The registry records the
+    /// `(attester, key)` pair and rejects any future attempt to register the
+    /// same pair, preventing replay attacks and accidental overwrites.
+    ///
+    /// # Arguments
+    ///
+    /// * `attester` - The address submitting the attestation (must authorize)
+    /// * `key`      - Opaque string key identifying the attestation (e.g. period, subject ID)
+    ///
+    /// # Panics
+    ///
+    /// * If registry is not initialized
+    /// * If `attester` does not authorize the call
+    /// * If `(attester, key)` has already been registered
+    ///
+    /// # Security
+    ///
+    /// Authorization is required from `attester` so that no third party can
+    /// pre-emptively occupy a key on behalf of another address.
+    pub fn register_attestation_key(env: Env, attester: Address, key: String) {
+        Self::require_initialized(&env);
+        attester.require_auth();
+
+        let dk = DataKey::AttestationKey(attester, key);
+        if env.storage().persistent().has(&dk) {
+            panic!("attestation key already registered");
+        }
+        env.storage()
+            .persistent()
+            .set(&dk, &env.ledger().timestamp());
+    }
+
+    /// Check whether an `(attester, key)` pair has already been registered.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the key exists, `false` otherwise.
+    pub fn has_attestation_key(env: Env, attester: Address, key: String) -> bool {
+        if !env.storage().instance().has(&DataKey::Initialized) {
+            return false;
+        }
+        env.storage()
+            .persistent()
+            .has(&DataKey::AttestationKey(attester, key))
     }
 
     // ── Admin management ────────────────────────────────────────────

--- a/contracts/attestation-registry/src/test.rs
+++ b/contracts/attestation-registry/src/test.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 //! Comprehensive test suite for the Attestation Registry contract.
 //!
 //! Tests cover:
@@ -43,14 +41,13 @@ fn setup_uninitialized() -> (Env, AttestationRegistryClient<'static>) {
     (env, client)
 }
 
-
 // ════════════════════════════════════════════════════════════════════
 //  Initialization tests
 // ════════════════════════════════════════════════════════════════════
 
 #[test]
 fn initialize_success() {
-    let (env, client, admin, initial_impl) = setup();
+    let (_env, client, admin, initial_impl) = setup();
 
     assert!(client.is_initialized());
     assert_eq!(client.get_admin(), Some(admin));
@@ -63,7 +60,7 @@ fn initialize_success() {
 #[test]
 #[should_panic(expected = "already initialized")]
 fn double_initialize_panics() {
-    let (env, client, admin, initial_impl) = setup();
+    let (_env, client, admin, initial_impl) = setup();
     client.initialize(&admin, &initial_impl, &1u32);
 }
 
@@ -77,13 +74,13 @@ fn operations_before_initialization_panic() {
 
 #[test]
 fn is_initialized_returns_false_when_uninitialized() {
-    let (env, client) = setup_uninitialized();
+    let (_env, client) = setup_uninitialized();
     assert!(!client.is_initialized());
 }
 
 #[test]
 fn query_functions_return_none_when_uninitialized() {
-    let (env, client) = setup_uninitialized();
+    let (_env, client) = setup_uninitialized();
     assert_eq!(client.get_admin(), None);
     assert_eq!(client.get_current_implementation(), None);
     assert_eq!(client.get_current_version(), None);
@@ -98,7 +95,7 @@ fn query_functions_return_none_when_uninitialized() {
 
 #[test]
 fn upgrade_success() {
-    let (env, client, admin, initial_impl) = setup();
+    let (env, client, _admin, initial_impl) = setup();
     let new_impl = Address::generate(&env);
     let new_version = 2u32;
 
@@ -112,7 +109,7 @@ fn upgrade_success() {
 
 #[test]
 fn upgrade_with_migration_data() {
-    let (env, client, admin, _initial_impl) = setup();
+    let (env, client, _admin, _initial_impl) = setup();
     let new_impl = Address::generate(&env);
     let migration_data = Bytes::from_array(&env, &[1u8, 2u8, 3u8]);
 
@@ -127,7 +124,7 @@ fn upgrade_with_migration_data() {
 
 #[test]
 fn upgrade_multiple_versions() {
-    let (env, client, admin, impl_v1) = setup();
+    let (env, client, _admin, _impl_v1) = setup();
     let impl_v2 = Address::generate(&env);
     let impl_v3 = Address::generate(&env);
     let impl_v4 = Address::generate(&env);
@@ -153,7 +150,7 @@ fn upgrade_multiple_versions() {
 #[test]
 #[should_panic(expected = "new version must be greater than current version")]
 fn upgrade_with_same_version_panics() {
-    let (env, client, admin, _initial_impl) = setup();
+    let (env, client, _admin, _initial_impl) = setup();
     let new_impl = Address::generate(&env);
     client.upgrade(&new_impl, &1u32, &None); // Same as initial version
 }
@@ -161,7 +158,7 @@ fn upgrade_with_same_version_panics() {
 #[test]
 #[should_panic(expected = "new version must be greater than current version")]
 fn upgrade_with_lower_version_panics() {
-    let (env, client, admin, _initial_impl) = setup();
+    let (env, client, _admin, _initial_impl) = setup();
     let new_impl = Address::generate(&env);
     client.upgrade(&new_impl, &2u32, &None); // Upgrade to v2
     client.upgrade(&new_impl, &1u32, &None); // Try to downgrade to v1
@@ -177,7 +174,7 @@ fn upgrade_before_initialization_panics() {
 
 #[test]
 fn upgrade_preserves_previous_implementation() {
-    let (env, client, admin, impl_v1) = setup();
+    let (env, client, _admin, impl_v1) = setup();
     let impl_v2 = Address::generate(&env);
     let impl_v3 = Address::generate(&env);
 
@@ -192,7 +189,7 @@ fn upgrade_preserves_previous_implementation() {
 
 #[test]
 fn upgrade_allows_skipping_versions() {
-    let (env, client, admin, _initial_impl) = setup();
+    let (env, client, _admin, _initial_impl) = setup();
     let new_impl = Address::generate(&env);
 
     // Skip from v1 to v5
@@ -207,12 +204,15 @@ fn upgrade_allows_skipping_versions() {
 
 #[test]
 fn rollback_success() {
-    let (env, client, admin, impl_v1) = setup();
+    let (env, client, _admin, impl_v1) = setup();
     let impl_v2 = Address::generate(&env);
     let impl_v2_clone = impl_v2.clone();
 
     client.upgrade(&impl_v2, &2u32, &None);
-    assert_eq!(client.get_current_implementation(), Some(impl_v2_clone.clone()));
+    assert_eq!(
+        client.get_current_implementation(),
+        Some(impl_v2_clone.clone())
+    );
     assert_eq!(client.get_current_version(), Some(2u32));
 
     client.rollback();
@@ -225,7 +225,7 @@ fn rollback_success() {
 
 #[test]
 fn rollback_multiple_times() {
-    let (env, client, admin, impl_v1) = setup();
+    let (env, client, _admin, _impl_v1) = setup();
     let impl_v2 = Address::generate(&env);
     let impl_v3 = Address::generate(&env);
 
@@ -246,14 +246,14 @@ fn rollback_multiple_times() {
 #[test]
 #[should_panic(expected = "no previous implementation to rollback to")]
 fn rollback_on_first_version_panics() {
-    let (env, client, admin, _initial_impl) = setup();
+    let (_env, client, _admin, _initial_impl) = setup();
     client.rollback(); // No previous version exists
 }
 
 #[test]
 #[should_panic(expected = "registry not initialized")]
 fn rollback_before_initialization_panics() {
-    let (env, client) = setup_uninitialized();
+    let (_env, client) = setup_uninitialized();
     client.rollback();
 }
 
@@ -273,7 +273,7 @@ fn rollback_before_initialization_panics() {
 
 #[test]
 fn transfer_admin_success() {
-    let (env, client, admin, _initial_impl) = setup();
+    let (env, client, _admin, _initial_impl) = setup();
     let new_admin = Address::generate(&env);
 
     client.transfer_admin(&new_admin);
@@ -282,7 +282,7 @@ fn transfer_admin_success() {
 
 #[test]
 fn new_admin_can_upgrade() {
-    let (env, client, admin, _initial_impl) = setup();
+    let (env, client, _admin, _initial_impl) = setup();
     let new_admin = Address::generate(&env);
     let new_impl = Address::generate(&env);
 
@@ -298,11 +298,11 @@ fn admin_transfer_changes_admin() {
     let new_admin = Address::generate(&env);
 
     client.transfer_admin(&new_admin);
-    
+
     // Verify admin changed
     assert_eq!(client.get_admin(), Some(new_admin));
     assert_ne!(client.get_admin(), Some(admin));
-    
+
     // New admin should be able to upgrade
     let new_impl = Address::generate(&env);
     client.upgrade(&new_impl, &2u32, &None);
@@ -310,12 +310,127 @@ fn admin_transfer_changes_admin() {
 }
 
 // ════════════════════════════════════════════════════════════════════
-//  Query function tests
+//  Duplicate-key protection tests
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn register_attestation_key_success() {
+    let (env, client, _admin, _initial_impl) = setup();
+    let attester = Address::generate(&env);
+    let key = soroban_sdk::String::from_str(&env, "2024-Q1");
+
+    client.register_attestation_key(&attester, &key);
+
+    assert!(client.has_attestation_key(&attester, &key));
+}
+
+#[test]
+#[should_panic(expected = "attestation key already registered")]
+fn register_duplicate_key_panics() {
+    let (env, client, _admin, _initial_impl) = setup();
+    let attester = Address::generate(&env);
+    let key = soroban_sdk::String::from_str(&env, "2024-Q1");
+
+    client.register_attestation_key(&attester, &key);
+    client.register_attestation_key(&attester, &key); // duplicate → panic
+}
+
+#[test]
+fn different_attesters_same_key_allowed() {
+    let (env, client, _admin, _initial_impl) = setup();
+    let attester_a = Address::generate(&env);
+    let attester_b = Address::generate(&env);
+    let key = soroban_sdk::String::from_str(&env, "2024-Q1");
+
+    // Same key string, different attester addresses → both succeed
+    client.register_attestation_key(&attester_a, &key);
+    client.register_attestation_key(&attester_b, &key);
+
+    assert!(client.has_attestation_key(&attester_a, &key));
+    assert!(client.has_attestation_key(&attester_b, &key));
+}
+
+#[test]
+fn same_attester_different_keys_allowed() {
+    let (env, client, _admin, _initial_impl) = setup();
+    let attester = Address::generate(&env);
+    let key_a = soroban_sdk::String::from_str(&env, "2024-Q1");
+    let key_b = soroban_sdk::String::from_str(&env, "2024-Q2");
+
+    client.register_attestation_key(&attester, &key_a);
+    client.register_attestation_key(&attester, &key_b);
+
+    assert!(client.has_attestation_key(&attester, &key_a));
+    assert!(client.has_attestation_key(&attester, &key_b));
+}
+
+#[test]
+fn has_attestation_key_returns_false_for_unregistered() {
+    let (env, client, _admin, _initial_impl) = setup();
+    let attester = Address::generate(&env);
+    let key = soroban_sdk::String::from_str(&env, "2024-Q1");
+
+    assert!(!client.has_attestation_key(&attester, &key));
+}
+
+#[test]
+fn has_attestation_key_returns_false_when_uninitialized() {
+    let (env, client) = setup_uninitialized();
+    let attester = Address::generate(&env);
+    let key = soroban_sdk::String::from_str(&env, "2024-Q1");
+
+    assert!(!client.has_attestation_key(&attester, &key));
+}
+
+#[test]
+#[should_panic(expected = "registry not initialized")]
+fn register_key_before_initialization_panics() {
+    let (env, client) = setup_uninitialized();
+    let attester = Address::generate(&env);
+    let key = soroban_sdk::String::from_str(&env, "2024-Q1");
+
+    client.register_attestation_key(&attester, &key);
+}
+
+#[test]
+fn duplicate_key_rejected_after_upgrade() {
+    // Duplicate-key protection persists across implementation upgrades.
+    let (env, client, _admin, _initial_impl) = setup();
+    let attester = Address::generate(&env);
+    let key = soroban_sdk::String::from_str(&env, "2024-Q1");
+
+    client.register_attestation_key(&attester, &key);
+
+    // Upgrade the implementation
+    let new_impl = Address::generate(&env);
+    client.upgrade(&new_impl, &2u32, &None);
+
+    // Key must still be blocked after upgrade
+    assert!(client.has_attestation_key(&attester, &key));
+}
+
+#[test]
+#[should_panic(expected = "attestation key already registered")]
+fn duplicate_key_still_rejected_after_upgrade() {
+    let (env, client, _admin, _initial_impl) = setup();
+    let attester = Address::generate(&env);
+    let key = soroban_sdk::String::from_str(&env, "2024-Q1");
+
+    client.register_attestation_key(&attester, &key);
+
+    let new_impl = Address::generate(&env);
+    client.upgrade(&new_impl, &2u32, &None);
+
+    client.register_attestation_key(&attester, &key); // must still panic
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Version info tests
 // ════════════════════════════════════════════════════════════════════
 
 #[test]
 fn get_version_info_returns_correct_data() {
-    let (env, client, admin, initial_impl) = setup();
+    let (env, client, _admin, initial_impl) = setup();
     let version_info = client.get_version_info().unwrap();
 
     assert_eq!(version_info.version, 1u32);
@@ -328,7 +443,7 @@ fn get_version_info_returns_correct_data() {
 
 #[test]
 fn get_version_info_after_upgrade() {
-    let (env, client, admin, _initial_impl) = setup();
+    let (env, client, _admin, _initial_impl) = setup();
     let new_impl = Address::generate(&env);
     let migration_data = Bytes::from_array(&env, &[42u8; 10]);
 
@@ -343,14 +458,17 @@ fn get_version_info_after_upgrade() {
 
 #[test]
 fn query_functions_work_after_multiple_upgrades() {
-    let (env, client, admin, impl_v1) = setup();
+    let (env, client, _admin, impl_v1) = setup();
     let impl_v2 = Address::generate(&env);
     let impl_v2_clone = impl_v2.clone();
     let impl_v3 = Address::generate(&env);
     let impl_v3_clone = impl_v3.clone();
 
     client.upgrade(&impl_v2, &2u32, &None);
-    assert_eq!(client.get_current_implementation(), Some(impl_v2_clone.clone()));
+    assert_eq!(
+        client.get_current_implementation(),
+        Some(impl_v2_clone.clone())
+    );
     assert_eq!(client.get_current_version(), Some(2u32));
     assert_eq!(client.get_previous_implementation(), Some(impl_v1));
     assert_eq!(client.get_previous_version(), Some(1u32));
@@ -368,7 +486,7 @@ fn query_functions_work_after_multiple_upgrades() {
 
 #[test]
 fn upgrade_to_same_implementation_allowed() {
-    let (env, client, admin, initial_impl) = setup();
+    let (_env, client, _admin, initial_impl) = setup();
     // Upgrading to the same implementation with a higher version is allowed
     // (though unusual, it might be used for version tracking)
     client.upgrade(&initial_impl, &2u32, &None);
@@ -378,7 +496,7 @@ fn upgrade_to_same_implementation_allowed() {
 
 #[test]
 fn upgrade_with_empty_migration_data() {
-    let (env, client, admin, _initial_impl) = setup();
+    let (env, client, _admin, _initial_impl) = setup();
     let new_impl = Address::generate(&env);
     let empty_data = Bytes::from_array(&env, &[]);
 
@@ -388,7 +506,7 @@ fn upgrade_with_empty_migration_data() {
 
 #[test]
 fn complex_upgrade_rollback_scenario() {
-    let (env, client, admin, impl_v1) = setup();
+    let (env, client, _admin, _impl_v1) = setup();
     let impl_v2 = Address::generate(&env);
     let impl_v3 = Address::generate(&env);
     let impl_v4 = Address::generate(&env);
@@ -415,7 +533,7 @@ fn complex_upgrade_rollback_scenario() {
 
 #[test]
 fn version_info_activated_at_is_reasonable() {
-    let (env, client, admin, _initial_impl) = setup();
+    let (env, client, _admin, _initial_impl) = setup();
     let version_info = client.get_version_info().unwrap();
     let ledger_time = env.ledger().timestamp();
 

--- a/docs/attestation-upgrades.md
+++ b/docs/attestation-upgrades.md
@@ -4,7 +4,72 @@
 
 The Attestation Registry contract provides a stable upgradeability pattern for the Veritasor attestation protocol. It separates contract address discovery from contract implementation, enabling controlled upgrades while maintaining a stable interface for callers.
 
-## Architecture
+## Duplicate-Key Protection
+
+### Overview
+
+The registry enforces that each `(attester, key)` pair can only be registered once. This prevents:
+
+- **Replay attacks**: An attester cannot re-submit an attestation for a period already recorded.
+- **Accidental overwrites**: Implementation upgrades cannot silently clobber existing attestation records.
+- **Front-running**: Authorization is required from `attester`, so no third party can pre-occupy a key on behalf of another address.
+
+### Storage
+
+Registered keys are stored in **persistent** storage under `DataKey::AttestationKey(attester, key)`. The value is the ledger timestamp at registration time. Persistent storage survives implementation upgrades, so protection is continuous across the full upgrade lifecycle.
+
+### API
+
+#### Register an Attestation Key
+
+```rust
+pub fn register_attestation_key(env: Env, attester: Address, key: String)
+```
+
+Call this before writing an attestation to the implementation contract.
+
+**Requirements:**
+- Registry must be initialized
+- `attester` must authorize the call
+- `(attester, key)` must not already be registered
+
+**Panics:** `"attestation key already registered"` on duplicate.
+
+#### Check Key Existence
+
+```rust
+pub fn has_attestation_key(env: Env, attester: Address, key: String) -> bool
+```
+
+Returns `true` if the pair is already registered, `false` otherwise (including when the registry is uninitialized).
+
+### Security Assumptions
+
+| Assumption | Enforcement |
+|---|---|
+| Only the attester can claim their own key | `attester.require_auth()` |
+| Keys survive implementation upgrades | Persistent storage |
+| Duplicate submissions are rejected | `has()` check before `set()` |
+| Uninitialized registry rejects writes | `require_initialized()` guard |
+
+### Integration Pattern
+
+```rust
+// 1. Check (optional, for pre-flight)
+if registry.has_attestation_key(&attester, &period) {
+    panic!("already submitted");
+}
+
+// 2. Register key (atomic guard)
+registry.register_attestation_key(&attester, &period);
+
+// 3. Write to implementation
+let impl_addr = registry.get_current_implementation().unwrap();
+let attestation = AttestationContractClient::new(&env, &impl_addr);
+attestation.submit_attestation(&attester, &period, ...);
+```
+
+---
 
 ### Registry Pattern
 
@@ -295,12 +360,13 @@ The registry contract includes comprehensive tests covering:
 - ✅ Query functions (all query methods, uninitialized behavior)
 - ✅ Admin management (transfer, new admin operations)
 - ✅ Edge cases (same implementation, empty data, complex scenarios)
+- ✅ Duplicate-key protection (register, reject duplicate, cross-attester isolation, persistence across upgrades)
 
 **Test Coverage: 95%+**
 
 Run tests:
 ```bash
-cargo test --package veritasor-attestation-registry
+cargo test -p veritasor-attestation-registry
 ```
 
 ### Test Scenarios


### PR DESCRIPTION
## Overview:
Adds registry-layer duplicate-key protection to prevent replay attacks and accidental overwrites when submitting 
attestations.

## Changes:
- DataKey::AttestationKey(Address, String) — new persistent storage variant for dedup tracking
- register_attestation_key(attester, key) — auth-gated write, panics "attestation key already registered" on 
duplicate
- has_attestation_key(attester, key) — read-only existence check
- 8 new tests: happy path, duplicate rejection, cross-attester isolation, uninitialized guards, persistence across
upgrades
- docs/attestation-upgrades.md — added Duplicate-Key Protection section with API reference, security table, and 
integration pattern
- contracts/attestation-registry added to workspace Cargo.toml members

## Closes: #105 