### PR TITLE
docs(protocol-dao): add proposal lifecycle docs and validate governan…

### DIFF
--- a/contracts/protocol-dao/src/lib.rs
+++ b/contracts/protocol-dao/src/lib.rs
@@ -332,10 +332,22 @@ fn apply_action(env: &Env, action: &ProposalAction) {
                 .set(&DataKey::AttestationFeeConfig, &cfg);
         }
         ProposalAction::UpdateGovernanceConfig(min_votes, duration) => {
-            env.storage().instance().set(&DataKey::MinVotes, min_votes);
+            validate_min_votes(*min_votes);
+            validate_proposal_duration(*duration);
+            let mv = if *min_votes == 0 {
+                DEFAULT_MIN_VOTES
+            } else {
+                *min_votes
+            };
+            let dur = if *duration == 0 {
+                DEFAULT_PROPOSAL_DURATION
+            } else {
+                *duration
+            };
+            env.storage().instance().set(&DataKey::MinVotes, &mv);
             env.storage()
                 .instance()
-                .set(&DataKey::ProposalDuration, duration);
+                .set(&DataKey::ProposalDuration, &dur);
         }
     }
 }
@@ -591,11 +603,25 @@ impl ProtocolDao {
         creator.require_auth();
         ensure_token_holder(&env, &creator);
 
+        validate_min_votes(min_votes);
+        validate_proposal_duration(proposal_duration);
+
+        let mv = if min_votes == 0 {
+            DEFAULT_MIN_VOTES
+        } else {
+            min_votes
+        };
+        let dur = if proposal_duration == 0 {
+            DEFAULT_PROPOSAL_DURATION
+        } else {
+            proposal_duration
+        };
+
         let id = next_proposal_id(&env);
         let proposal = Proposal {
             id,
             creator: creator.clone(),
-            action: ProposalAction::UpdateGovernanceConfig(min_votes, proposal_duration),
+            action: ProposalAction::UpdateGovernanceConfig(mv, dur),
             status: ProposalStatus::Pending,
             created_at: env.ledger().sequence(),
         };

--- a/contracts/protocol-dao/src/test.rs
+++ b/contracts/protocol-dao/src/test.rs
@@ -102,6 +102,31 @@ fn set_voting_config_by_non_admin_panics() {
 }
 
 #[test]
+#[should_panic(expected = "min_votes exceeds maximum allowed value")]
+fn create_gov_config_proposal_with_invalid_min_votes_panics() {
+    let (env, client, _admin, gov_token) = setup_with_token(1, 100);
+    let voter = Address::generate(&env);
+    mint(&env, &gov_token, &voter, 100);
+
+    client.create_gov_config_proposal(&voter, &(MAX_MIN_VOTES + 1), &100);
+}
+
+#[test]
+fn create_gov_config_proposal_with_zero_values_uses_defaults() {
+    let (env, client, admin, gov_token) = setup_with_token(1, 100);
+    let voter = Address::generate(&env);
+    mint(&env, &gov_token, &voter, 100);
+
+    let proposal_id = client.create_gov_config_proposal(&voter, &0, &0);
+    client.vote_for(&voter, &proposal_id);
+    client.execute_proposal(&admin, &proposal_id);
+
+    let (_, _, min_votes, duration) = client.get_config();
+    assert_eq!(min_votes, DEFAULT_MIN_VOTES);
+    assert_eq!(duration, DEFAULT_PROPOSAL_DURATION);
+}
+
+#[test]
 fn create_and_execute_fee_config_proposal() {
     let (env, client, admin, gov_token) = setup_with_token(1, 100);
 

--- a/docs/protocol-dao-lifecycle.md
+++ b/docs/protocol-dao-lifecycle.md
@@ -1,0 +1,81 @@
+# Protocol DAO Proposal Lifecycle
+
+Location: `contracts/protocol-dao/src/lib.rs`
+
+This document describes the governance proposal lifecycle for the Veritasor protocol DAO contract and the security assumptions that protect the vote and execution path.
+
+## Lifecycle Overview
+
+The protocol DAO implements a proposal lifecycle with these main phases:
+
+- `Pending`: A proposal has been created and is accepting votes.
+- `Executed`: The proposal has met quorum and majority and its action has been applied.
+- `Rejected`: The proposal has been canceled by the creator or admin.
+- `Expired`: The proposal is too old to be voted on or executed.
+
+## Proposal Creation
+
+A proposal is created by an authorized caller with `creator.require_auth()`.
+If a governance token is configured, the creator must also hold a positive balance of that token.
+
+The DAO supports three proposal actions:
+
+1. `SetAttestationFeeConfig(token, collector, base_fee, enabled)`
+2. `SetAttestationFeeEnabled(enabled)`
+3. `UpdateGovernanceConfig(min_votes, proposal_duration)`
+
+The `UpdateGovernanceConfig` action is validated at proposal creation and execution to preserve safe quorum parameters.
+
+## Voting and Quorum Rules
+
+To vote, a caller must authorize the call and, when a governance token is configured, hold a positive balance.
+
+A proposal can only be voted on while its status is `Pending` and it has not expired.
+
+Quorum is enforced as follows:
+
+- `votes_for + votes_against >= min_votes`
+- `votes_for > votes_against`
+
+This means a proposal with quorum but no majority will not execute.
+
+## Expiry and Cancellation
+
+Proposals expire when the current ledger sequence exceeds `created_at + proposal_duration`.
+Expired proposals cannot be voted on or executed, but they remain in storage for auditability.
+
+A pending proposal can be canceled by the proposal creator or the DAO admin. Cancellation changes its status to `Rejected`.
+
+## Execution
+
+Any caller may invoke `execute_proposal` for a pending proposal that has:
+
+- not expired
+- met quorum
+- achieved a strict majority of votes in favor
+
+Once executed, the proposal status changes to `Executed` and its action is applied atomically.
+
+## Security Assumptions
+
+- `require_auth()` is mandatory for all state-changing entry points.
+- Vote gating is optional and enforced using an on-chain governance token balance check.
+- Double-voting is prevented by `HasVoted(id, voter)` storage keys.
+- Proposal state is stored under distinct `DataKey` variants to avoid key collisions.
+- Quorum verification uses saturating arithmetic and explicit comparison checks.
+- The contract avoids implicit state changes during expiry checks; status transitions are explicit.
+
+## Testing and Coverage
+
+The `contracts/protocol-dao/src/test.rs` test suite covers:
+
+- initialization and admin access control
+- proposal creation and vote gating
+- quorum boundary conditions and majority enforcement
+- duplicate voting rejection
+- expired proposal handling
+- proposal cancellation and execution flow
+- governance config changes that raise or lower quorum
+- default-value normalization for zero input parameters
+
+The lifecycle is intentionally conservative: proposals only transition to `Executed` or `Rejected` through explicit actions, and expiration only affects allowed operations rather than forcing a status change.


### PR DESCRIPTION
Close #241 

## PR Document

**Title:** docs(protocol-dao): add lifecycle docs and harden governance config proposal handling

**Summary:**
- Hardened `create_gov_config_proposal` in lib.rs by validating `min_votes` and `proposal_duration` at creation and normalizing zero values to defaults.
- Added runtime validation during `UpdateGovernanceConfig` execution for safety and consistency.
- Extended tests in test.rs to cover invalid governance config input and zero-value default normalization.
- Added protocol-dao-lifecycle.md documenting proposal lifecycle, quorum rules, expiry/cancellation semantics, execution requirements, and security assumptions.

**Files changed:**
- lib.rs
- test.rs
- protocol-dao-lifecycle.md

**Testing:**
- Intended test command: `cd contracts/protocol-dao && cargo test`
- Note: unable to run due to missing Rust toolchain (`cargo` / `rustc` unavailable in current environment)

