### PR TITLE
feat(business-config): add explicit schema versioning and safe defaul…

### DIFF
--- a/contracts/business-config/src/lib.rs
+++ b/contracts/business-config/src/lib.rs
@@ -17,7 +17,11 @@
 //! - Readable by attestation and lender contracts
 
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec};
-
+const BUSINESS_CONFIG_SCHEMA_VERSION: u32 = 1;
+const DEFAULT_ANOMALY_ALERT_THRESHOLD: u32 = 70;
+const DEFAULT_ANOMALY_BLOCK_THRESHOLD: u32 = 90;
+const DEFAULT_EXPIRY_SECONDS: u64 = 31_536_000; // 1 year
+const DEFAULT_GRACE_PERIOD_SECONDS: u64 = 2_592_000; // 30 days
 // ════════════════════════════════════════════════════════════════════
 //  Storage Keys
 // ════════════════════════════════════════════════════════════════════
@@ -128,6 +132,8 @@ pub struct AnchorConfig {
 pub struct BusinessConfig {
     /// Business address this config applies to
     pub business: Address,
+    /// Schema version for compatibility and migration tracking
+    pub schema_version: u32,
     /// Anomaly detection policy
     pub anomaly_policy: AnomalyPolicy,
     /// Integration requirements
@@ -138,7 +144,7 @@ pub struct BusinessConfig {
     pub custom_fees: CustomFeeConfig,
     /// Compliance requirements
     pub compliance: ComplianceConfig,
-    /// Configuration version for migration tracking
+    /// Configuration instance version for update tracking
     pub version: u32,
     /// Timestamp when config was created
     pub created_at: u64,
@@ -211,6 +217,11 @@ impl BusinessConfigContract {
     /// - `business`: Business address to configure
     /// - `config`: Complete configuration to apply
     ///
+    /// # Behavior
+    /// - Preserves `created_at` for existing configs
+    /// - Increments `version` on every update
+    /// - Rejects an existing config if it contains an unsupported `schema_version`
+    ///
     /// # Panics
     /// - If caller is not admin
     /// - If configuration values are invalid
@@ -261,6 +272,11 @@ impl BusinessConfigContract {
 
         let (version, created_at) = match existing {
             Some(old) => {
+                assert!(
+                    old.schema_version <= BUSINESS_CONFIG_SCHEMA_VERSION,
+                    "unsupported business config schema version"
+                );
+
                 env.events().publish(
                     (TOPIC_CONFIG_UPDATED, business.clone()),
                     ConfigUpdatedEvent {
@@ -287,6 +303,7 @@ impl BusinessConfigContract {
 
         let config = BusinessConfig {
             business: business.clone(),
+            schema_version: BUSINESS_CONFIG_SCHEMA_VERSION,
             anomaly_policy,
             integrations,
             expiry,
@@ -444,6 +461,7 @@ impl BusinessConfigContract {
         // Use caller address as placeholder for global defaults
         let defaults = BusinessConfig {
             business: caller.clone(),
+            schema_version: BUSINESS_CONFIG_SCHEMA_VERSION,
             anomaly_policy,
             integrations,
             expiry,
@@ -506,6 +524,8 @@ impl BusinessConfigContract {
     }
 
     /// Get global default configuration.
+    ///
+    /// If global defaults have not been set, returns a runtime safe default config.
     pub fn get_global_defaults(env: Env) -> BusinessConfig {
         env.storage()
             .instance()
@@ -596,10 +616,18 @@ impl BusinessConfigContract {
         env.storage()
             .instance()
             .get::<ConfigKey, BusinessConfig>(&ConfigKey::BusinessConfig(business.clone()))
+            .map(|config| {
+                Self::validate_schema_version(&config);
+                config
+            })
             .unwrap_or_else(|| {
                 env.storage()
                     .instance()
-                    .get(&ConfigKey::GlobalDefaults)
+                    .get::<ConfigKey, BusinessConfig>(&ConfigKey::GlobalDefaults)
+                    .map(|config| {
+                        Self::validate_schema_version(&config);
+                        config
+                    })
                     .unwrap_or_else(|| Self::create_default_config(env))
             })
     }
@@ -610,9 +638,10 @@ impl BusinessConfigContract {
 
         BusinessConfig {
             business: contract_address,
+            schema_version: BUSINESS_CONFIG_SCHEMA_VERSION,
             anomaly_policy: AnomalyPolicy {
-                alert_threshold: 70,
-                block_threshold: 90,
+                alert_threshold: DEFAULT_ANOMALY_ALERT_THRESHOLD,
+                block_threshold: DEFAULT_ANOMALY_BLOCK_THRESHOLD,
                 required: false,
                 auto_revoke: false,
             },
@@ -622,9 +651,9 @@ impl BusinessConfigContract {
                 external_validation_required: false,
             },
             expiry: ExpiryConfig {
-                default_expiry_seconds: 31536000, // 1 year
+                default_expiry_seconds: DEFAULT_EXPIRY_SECONDS,
                 enforce_expiry: false,
-                grace_period_seconds: 2592000, // 30 days
+                grace_period_seconds: DEFAULT_GRACE_PERIOD_SECONDS,
             },
             custom_fees: CustomFeeConfig {
                 base_fee_override: None,
@@ -638,9 +667,14 @@ impl BusinessConfigContract {
                 metadata_required: false,
             },
             version: 0,
-            created_at: 0,
-            updated_at: 0,
+            created_at: env.ledger().timestamp(),
+            updated_at: env.ledger().timestamp(),
         }
+    }
+
+    /// Returns the current contract schema version for business config objects.
+    pub fn get_schema_version(_env: Env) -> u32 {
+        BUSINESS_CONFIG_SCHEMA_VERSION
     }
 
     fn validate_anomaly_policy(policy: &AnomalyPolicy) {
@@ -665,6 +699,13 @@ impl BusinessConfigContract {
         if let Some(fee) = fees.base_fee_override {
             assert!(fee >= 0, "base fee cannot be negative");
         }
+    }
+
+    fn validate_schema_version(config: &BusinessConfig) {
+        assert!(
+            config.schema_version <= BUSINESS_CONFIG_SCHEMA_VERSION,
+            "unsupported business config schema version"
+        );
     }
 }
 

--- a/contracts/business-config/src/test.rs
+++ b/contracts/business-config/src/test.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     AnchorConfig, AnomalyPolicy, BusinessConfig, BusinessConfigContract,
-    BusinessConfigContractClient, ComplianceConfig, CustomFeeConfig, ExpiryConfig,
-    IntegrationRequirements,
+    BusinessConfigContractClient, ConfigKey, BUSINESS_CONFIG_SCHEMA_VERSION,
+    ComplianceConfig, CustomFeeConfig, ExpiryConfig, IntegrationRequirements,
 };
 use soroban_sdk::{testutils::Address as _, Address, Env, String, Symbol, Vec};
 
@@ -93,6 +93,57 @@ fn test_global_defaults_set_on_init() {
     assert_eq!(defaults.anomaly_policy.alert_threshold, 70);
     assert_eq!(defaults.anomaly_policy.block_threshold, 90);
     assert_eq!(defaults.expiry.default_expiry_seconds, 31536000);
+}
+
+#[test]
+fn test_get_schema_version() {
+    let (env, admin, client) = create_test_env();
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    assert_eq!(client.get_schema_version(), BUSINESS_CONFIG_SCHEMA_VERSION);
+}
+
+#[test]
+fn test_get_config_returns_safe_defaults_before_initialize() {
+    let (env, _admin, client) = create_test_env();
+    env.mock_all_auths();
+
+    let business = Address::generate(&env);
+    let config = client.get_config(&business);
+
+    assert_eq!(config.schema_version, BUSINESS_CONFIG_SCHEMA_VERSION);
+    assert_eq!(config.version, 0);
+    assert_eq!(config.anomaly_policy.alert_threshold, 70);
+    assert_eq!(config.expiry.default_expiry_seconds, 31536000);
+}
+
+#[test]
+#[should_panic(expected = "unsupported business config schema version")]
+fn test_rejects_unsupported_stored_schema_version() {
+    let (env, admin, client) = create_test_env();
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    let business = Address::generate(&env);
+    let invalid_config = BusinessConfig {
+        business: business.clone(),
+        schema_version: BUSINESS_CONFIG_SCHEMA_VERSION + 1,
+        anomaly_policy: create_default_anomaly_policy(),
+        integrations: create_default_integrations(&env),
+        expiry: create_default_expiry(),
+        custom_fees: create_default_custom_fees(),
+        compliance: create_default_compliance(&env),
+        version: 1,
+        created_at: env.ledger().timestamp(),
+        updated_at: env.ledger().timestamp(),
+    };
+
+    env.storage()
+        .instance()
+        .set(&ConfigKey::BusinessConfig(business.clone()), &invalid_config);
+
+    client.get_config(&business);
 }
 
 // ════════════════════════════════════════════════════════════════════

--- a/docs/business-config-versioning.md
+++ b/docs/business-config-versioning.md
@@ -1,0 +1,73 @@
+# Business Config Schema Versioning and Safe Defaults
+
+This document explains the `BusinessConfig` contract schema versioning model and the safe defaulting behavior used by the business-config contract.
+
+## Goals
+
+- Ensure business configuration records are versioned explicitly.
+- Preserve stable default behavior when no business-specific or global defaults exist.
+- Protect against unsupported/future schema versions.
+- Keep update semantics predictable and auditable.
+
+## Key Concepts
+
+### Schema version vs instance version
+
+The contract tracks two distinct version values on each recorded business configuration:
+
+- `schema_version`: an explicit compatibility marker for the `BusinessConfig` structure itself. This is currently fixed at `1` and exposed through `get_schema_version()`.
+- `version`: a per-business update counter that increments whenever configuration is created or modified.
+
+This separation makes it possible to distinguish between the config data format and the number of updates applied to a business.
+
+## Safe defaults
+
+The contract guarantees safe fallback values when business-specific configuration is missing:
+
+- If a business has no custom config, the contract returns the current global defaults.
+- If global defaults are missing or not yet configured, the contract returns a runtime safe default configuration.
+- Safe defaults are explicitly defined by the contract and avoid uninitialized or unsafe values.
+
+### Default fields
+
+Default values include:
+
+- `anomaly_policy.alert_threshold = 70`
+- `anomaly_policy.block_threshold = 90`
+- `expiry.default_expiry_seconds = 31_536_000` (1 year)
+- `expiry.grace_period_seconds = 2_592_000` (30 days)
+- `custom_fees.fee_waived = false`
+- `compliance.kyc_required = false`
+
+A default configuration returned from fallback also carries:
+
+- `schema_version = 1`
+- `version = 0`
+
+## Compatibility rules
+
+The contract enforces compatibility on stored business configuration records:
+
+- Any stored `BusinessConfig` with `schema_version` greater than the contract's current schema version is rejected.
+- Business-specific and global default records are both validated when read.
+- This prevents future or unsupported schema changes from silently influencing business configuration behavior.
+
+## Security-sensitive behavior
+
+The following behaviors are important for security and upgrade safety:
+
+- Schema validation is performed on all reads of stored business configuration.
+- `set_business_config()` also validates an existing record before updating it.
+- Safe default fallbacks avoid panicking in read-only queries when a config record is absent.
+- `get_schema_version()` exposes the current compatibility marker so callers can verify the expected config schema.
+
+## Test coverage
+
+The contract includes regression coverage for:
+
+- `get_schema_version()` returning the current schema constant.
+- Safe default config fallback before initialization.
+- Rejection of unsupported stored schema versions.
+- Normal `version` tracking and update semantics.
+
+**Test Location**: `contracts/business-config/src/test.rs`


### PR DESCRIPTION
Close #238 

## PR Description

### Summary
This PR adds explicit schema versioning and safe defaulting behavior to the `business-config` contract.

### What changed
- Added `BUSINESS_CONFIG_SCHEMA_VERSION` constant.
- Extended `BusinessConfig` with `schema_version: u32`.
- Added `get_schema_version()` contract method.
- Added compatibility validation for stored business config records.
- Added safe runtime defaults when no global defaults are configured.
- Added explicit default constants for anomaly and expiry values.
- Added regression tests for:
  - schema version retrieval
  - safe defaults before initialization
  - rejection of unsupported stored schema versions

### Files changed
- lib.rs
- test.rs
- business-config-versioning.md

### Testing
- Static diagnostics on modified Rust files show no errors.
- Full `cargo test` could not be executed in the current container because Rust tooling (`cargo` / `rustup`) is not installed.

