### PR TITLE
Feature/revenue curve monotonicity

### DIFF
--- a/contracts/revenue-bonds/src/lib.rs
+++ b/contracts/revenue-bonds/src/lib.rs
@@ -1,21 +1,28 @@
 //! # Revenue-Backed Bond Contract
 //!
 //! Issues tokenized bonds whose repayment profiles are tied to attested business revenue.
-//! Bonds are issued with configurable terms, ownership is tracked on-chain, and redemptions
-//! are processed based on verified revenue attestations.
 //!
-//! ## Key Features
-//! - Bond issuance with flexible terms (fixed, revenue-linked, or hybrid structures)
-//! - Ownership tracking and transferability
-//! - Revenue-based redemption schedules tied to attestations
-//! - Double-spending prevention via redemption tracking
-//! - Support for partial and early redemptions
-//! - Default handling and risk management
+//! ## Security Invariants
+//!
+//! 1. **No double-spend per period**: each `(bond_id, period)` pair can be redeemed at most once.
+//! 2. **Per-period cap**: `actual_redemption <= max_payment_per_period` always holds, even after
+//!    the face-value clamp.
+//! 3. **Cumulative face-value cap**: `total_redeemed` never exceeds `face_value`.
+//! 4. **Issuer authorization**: the bond issuer must authorize every `redeem` call.
+//! 5. **Attestation integrity**: `attested_revenue` is read from the attestation contract —
+//!    callers cannot supply an arbitrary revenue figure.
+//! 6. **Revocation mid-cycle**: if an attestation is revoked after bond issuance, `redeem`
+//!    panics; already-recorded redemptions are unaffected.
+//! 7. **Admin auth ordering**: `require_auth()` is called before any equality check in admin
+//!    operations to prevent admin-address probing.
+//! 8. **Maturity enforcement**: redemptions are rejected for periods outside
+//!    `[issue_period, issue_period + maturity_periods)`.
 
 #![no_std]
 use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, String};
 
-/// Attestation client: WASM import for wasm32, crate for tests.
+// ─── Attestation client ───────────────────────────────────────────────────────
+
 #[cfg(target_arch = "wasm32")]
 mod attestation_import {
     soroban_sdk::contractimport!(
@@ -23,55 +30,56 @@ mod attestation_import {
     );
     pub use Client as AttestationContractClient;
 }
+
 #[cfg(not(target_arch = "wasm32"))]
 mod attestation_import {
     use soroban_sdk::{Address, BytesN, Env, String};
 
     pub struct AttestationContractClient {
         env: Env,
-        address: Address,
+        pub address: Address,
     }
 
     impl AttestationContractClient {
         pub fn new(env: &Env, address: &Address) -> Self {
-            Self {
-                env: env.clone(),
-                address: address.clone(),
-            }
+            Self { env: env.clone(), address: address.clone() }
         }
 
-        #[cfg(test)]
+        /// Returns `(merkle_root, timestamp, version, revenue)`.
+        ///
+        /// Revenue is read from env temporary storage under key
+        /// `(symbol_short!("rev"), business, period)`.  Tests set this before
+        /// calling `redeem`; the default is `0`.
         pub fn get_attestation(
             &self,
-            _business: &Address,
-            _period: &String,
+            business: &Address,
+            period: &String,
         ) -> Option<(BytesN<32>, u64, u32, i128)> {
-            Some((BytesN::from_array(&self.env, &[0u8; 32]), 1000, 1, 0))
+            let revenue: i128 = self
+                .env
+                .storage()
+                .temporary()
+                .get(&(soroban_sdk::symbol_short!("rev"), business.clone(), period.clone()))
+                .unwrap_or(0i128);
+            Some((BytesN::from_array(&self.env, &[0u8; 32]), 1000, 1, revenue))
         }
 
-        #[cfg(test)]
-        pub fn is_revoked(&self, _business: &Address, _period: &String) -> bool {
-            false
-        }
-
-        #[cfg(not(test))]
-        pub fn get_attestation(
-            &self,
-            _business: &Address,
-            _period: &String,
-        ) -> Option<(BytesN<32>, u64, u32, i128)> {
-            panic!("attestation contract not available in non-wasm32 non-test builds");
-        }
-
-        #[cfg(not(test))]
-        pub fn is_revoked(&self, _business: &Address, _period: &String) -> bool {
-            panic!("attestation contract not available in non-wasm32 non-test builds");
+        pub fn is_revoked(&self, business: &Address, period: &String) -> bool {
+            self.env.storage().temporary()
+                .get(&(soroban_sdk::symbol_short!("rvkd"), business.clone(), period.clone()))
+                .unwrap_or(false)
         }
     }
 }
 
+// ─── Test modules ─────────────────────────────────────────────────────────────
+
 #[cfg(test)]
 mod test;
+#[cfg(test)]
+mod test_maturity;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
 
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -80,41 +88,42 @@ pub enum DataKey {
     NextBondId,
     Bond(u64),
     BondOwner(u64),
+    /// Per-period redemption record; written before token transfer.
     Redemption(u64, String),
+    /// Running total of all amounts transferred for a bond.
     TotalRedeemed(u64),
 }
 
-/// Bond structure types
+/// Bond payment structure.
 #[contracttype]
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
 pub enum BondStructure {
-    /// Fixed repayment schedule (not revenue-linked)
+    /// Fixed: pays exactly `min_payment_per_period` each period.
     Fixed = 0,
-    /// Pure revenue-linked (percentage of revenue each period)
+    /// Revenue-linked: `revenue * bps / 10000`, clamped to `[min, max]`.
     RevenueLinked = 1,
-    /// Hybrid (minimum fixed + revenue share)
+    /// Hybrid: `min + revenue * bps / 10000`, capped at `max`.
     Hybrid = 2,
 }
 
-/// Bond status
+/// Bond lifecycle status.
 #[contracttype]
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
 pub enum BondStatus {
     Active = 0,
     FullyRedeemed = 1,
-Defaulted = 2,
+    Defaulted = 2,
     Matured = 3,
 }
 
-/// Bond issuance and terms
+/// Bond issuance terms.
 ///
 /// # Risk Factors
-/// - Revenue volatility may affect repayment timing
-/// - Business default risk if revenue falls below minimum thresholds
-/// - Attestation dependency: repayments require valid, non-revoked attestations
-/// - Early redemption may reduce total yield
+/// - Revenue volatility affects `RevenueLinked` and `Hybrid` repayment timing.
+/// - Issuer default risk if revenue falls below minimum thresholds.
+/// - Attestation dependency: repayments require valid, non-revoked attestations.
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Bond {
@@ -122,29 +131,45 @@ pub struct Bond {
     pub issuer: Address,
     pub face_value: i128,
     pub structure: BondStructure,
+    /// Revenue share in basis points (0–10 000).
     pub revenue_share_bps: u32,
+    /// Floor payment per period (≥ 0).
     pub min_payment_per_period: i128,
+    /// Ceiling payment per period; also the per-period redemption cap.
     pub max_payment_per_period: i128,
+    /// Number of calendar months the bond is active.
     pub maturity_periods: u32,
     pub attestation_contract: Address,
     pub token: Address,
-pub status: BondStatus,
+    pub status: BondStatus,
     pub issued_at: u64,
     pub issue_period: String,
 }
 
-/// Redemption record for a specific period
+/// Immutable record of a single period's redemption.
+///
+/// Written atomically before the token transfer; Soroban reverts the entire
+/// transaction on panic, so the record and transfer are effectively atomic.
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub struct RedemptionRecord {
     pub bond_id: u64,
     pub period: String,
+    /// Revenue read from the attestation contract at redemption time.
     pub attested_revenue: i128,
+    /// Tokens actually transferred; may be less than the calculated amount
+    /// when the remaining face value is smaller than the per-period payment.
     pub redemption_amount: i128,
-pub redeemed_at: u64,
+    pub redeemed_at: u64,
 }
 
-fn parse_period(env: &Env, period: String) -> u64 {
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/// Parse `"YYYY-MM"` into a monotonic month index.
+///
+/// # Panics
+/// Panics with a descriptive message on any malformed input.
+pub fn parse_period(env: &Env, period: String) -> u64 {
     let bytes = period.to_bytes();
     assert!(bytes.len() == 7, "invalid period length");
     assert!(bytes[4] == b'-', "invalid period separator");
@@ -164,11 +189,40 @@ fn parse_period(env: &Env, period: String) -> u64 {
     year * 12 + month - 1
 }
 
-fn is_period_within_maturity(env: &Env, bond: &Bond, period: String) -> bool {
+/// Returns `true` iff `period` falls within `[issue_period, issue_period + maturity_periods)`.
+pub fn is_period_within_maturity(env: &Env, bond: &Bond, period: String) -> bool {
     let issue_months = parse_period(env, bond.issue_period.clone());
     let period_months = parse_period(env, period);
     period_months >= issue_months && period_months < issue_months + (bond.maturity_periods as u64)
 }
+
+/// Calculate the uncapped redemption amount for a period.
+///
+/// Returns a value in `[min_payment_per_period, max_payment_per_period]` for
+/// `RevenueLinked`/`Hybrid`, or exactly `min_payment_per_period` for `Fixed`.
+/// The caller must still apply the face-value clamp and re-assert the per-period
+/// ceiling afterwards.
+fn calculate_redemption(bond: &Bond, attested_revenue: i128) -> i128 {
+    match bond.structure {
+        BondStructure::Fixed => bond.min_payment_per_period,
+        BondStructure::RevenueLinked => {
+            let share = (attested_revenue as u128)
+                .saturating_mul(bond.revenue_share_bps as u128)
+                .saturating_div(10000) as i128;
+            share
+                .max(bond.min_payment_per_period)
+                .min(bond.max_payment_per_period)
+        }
+        BondStructure::Hybrid => {
+            let revenue_component = (attested_revenue as u128)
+                .saturating_mul(bond.revenue_share_bps as u128)
+                .saturating_div(10000) as i128;
+            (bond.min_payment_per_period + revenue_component).min(bond.max_payment_per_period)
+        }
+    }
+}
+
+// ─── Contract ─────────────────────────────────────────────────────────────────
 
 #[contract]
 pub struct RevenueBondContract;
@@ -177,13 +231,14 @@ pub struct RevenueBondContract;
 impl RevenueBondContract {
     /// Initialize the contract with an admin address.
     ///
-    /// # Arguments
-    /// * `admin` - Administrator address for contract management
+    /// # Panics
+    /// Panics if already initialized.
     pub fn initialize(env: Env, admin: Address) {
         admin.require_auth();
-        if env.storage().instance().has(&DataKey::Admin) {
-            panic!("already initialized");
-        }
+        assert!(
+            !env.storage().instance().has(&DataKey::Admin),
+            "already initialized"
+        );
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::NextBondId, &0u64);
     }
@@ -191,24 +246,20 @@ impl RevenueBondContract {
     /// Issue a new revenue-backed bond.
     ///
     /// # Arguments
-    /// * `issuer` - Business issuing the bond
-    /// * `initial_owner` - Initial bond holder
-    /// * `face_value` - Total bond value to be repaid
-    /// * `structure` - Bond structure type (Fixed, RevenueLinked, Hybrid)
-    /// * `revenue_share_bps` - Revenue share in basis points (0-10000)
-    /// * `min_payment_per_period` - Minimum payment per period
-    /// * `max_payment_per_period` - Maximum payment per period
-    /// * `maturity_periods` - Number of periods until maturity
-    /// * `attestation_contract` - Attestation contract for revenue verification
-    /// * `token` - Token for repayments
+    /// * `issuer` – Business issuing the bond; must authorize.
+    /// * `initial_owner` – Initial bond holder (must differ from issuer).
+    /// * `face_value` – Total token amount to be repaid (> 0).
+    /// * `structure` – Payment structure (`Fixed`, `RevenueLinked`, or `Hybrid`).
+    /// * `revenue_share_bps` – Revenue share in basis points (0–10 000).
+    /// * `min_payment_per_period` – Floor payment per period (≥ 0).
+    /// * `max_payment_per_period` – Ceiling / per-period cap (> 0, ≥ min).
+    /// * `maturity_periods` – Calendar months the bond is active (> 0).
+    /// * `issue_period` – First eligible redemption period (`"YYYY-MM"`).
+    /// * `attestation_contract` – Revenue attestation contract address.
+    /// * `token` – Soroban token used for repayments.
     ///
     /// # Returns
-    /// Bond ID
-    ///
-    /// # Risk Factors
-    /// - Issuer must maintain sufficient revenue to meet minimum payments
-    /// - Bond holders bear issuer default risk
-    /// - Revenue attestations must be timely and accurate
+    /// The new bond's numeric identifier.
     pub fn issue_bond(
         env: Env,
         issuer: Address,
@@ -234,15 +285,11 @@ impl RevenueBondContract {
         assert!(maturity_periods > 0, "maturity_periods must be positive");
         assert!(!issuer.eq(&initial_owner), "issuer and owner must differ");
 
-        let id: u64 = env
-            .storage()
-            .instance()
-            .get(&DataKey::NextBondId)
-            .unwrap_or(0);
+        let id: u64 = env.storage().instance().get(&DataKey::NextBondId).unwrap_or(0);
 
         let bond = Bond {
             id,
-            issuer: issuer.clone(),
+            issuer,
             face_value,
             structure,
             revenue_share_bps,
@@ -250,163 +297,146 @@ impl RevenueBondContract {
             max_payment_per_period,
             maturity_periods,
             issue_period,
-            attestation_contract: attestation_contract.clone(),
-            token: token.clone(),
+            attestation_contract,
+            token,
             status: BondStatus::Active,
             issued_at: env.ledger().timestamp(),
         };
 
         env.storage().instance().set(&DataKey::Bond(id), &bond);
-        env.storage()
-            .instance()
-            .set(&DataKey::BondOwner(id), &initial_owner);
-        env.storage()
-            .instance()
-            .set(&DataKey::TotalRedeemed(id), &0i128);
-        env.storage()
-            .instance()
-            .set(&DataKey::NextBondId, &(id + 1));
+        env.storage().instance().set(&DataKey::BondOwner(id), &initial_owner);
+        env.storage().instance().set(&DataKey::TotalRedeemed(id), &0i128);
+        env.storage().instance().set(&DataKey::NextBondId, &(id + 1));
 
         id
     }
 
-    /// Redeem bond for a period based on attested revenue.
+    /// Redeem a bond for a single period.
+    ///
+    /// The issuer must authorize this call.  Revenue is read directly from the
+    /// attestation contract — callers cannot supply an arbitrary revenue figure.
+    ///
+    /// # Security invariants enforced
+    ///
+    /// 1. Bond must be `Active`.
+    /// 2. Period must be within the bond's maturity window.
+    /// 3. No prior redemption for `(bond_id, period)` — double-spend guard.
+    /// 4. Attestation must exist and must not be revoked — revocation mid-cycle guard.
+    /// 5. `actual_redemption <= max_payment_per_period` — per-period cap.
+    /// 6. `total_redeemed + actual_redemption <= face_value` — cumulative cap.
+    /// 7. Issuer must authorize — prevents unauthorized token drain.
     ///
     /// # Arguments
-    /// * `bond_id` - Bond identifier
-    /// * `period` - Period identifier (e.g., "2026-02")
-    /// * `attested_revenue` - Revenue amount from attestation
+    /// * `bond_id` – Bond identifier.
+    /// * `period` – Period to redeem (`"YYYY-MM"`).
     ///
-    /// # Lifecycle
-    /// 1. Verify bond is active
-    /// 2. Verify attestation exists and is not revoked
-    /// 3. Check no prior redemption for this period (prevent double-spending)
-    /// 4. Calculate redemption amount based on bond structure
-    /// 5. Transfer tokens from issuer to bond owner
-    /// 6. Record redemption
-    /// 7. Update total redeemed and check if bond is fully redeemed
-    ///
-    /// # Risk Factors
-    /// - Issuer must have sufficient token balance
-    /// - Attestation must be valid and non-revoked
-    /// - Revenue volatility affects redemption amounts
-    pub fn redeem(env: Env, bond_id: u64, period: String, attested_revenue: i128) {
+    /// # Panics
+    /// Panics on any violated invariant; the entire transaction is reverted.
+    pub fn redeem(env: Env, bond_id: u64, period: String) {
         let bond: Bond = env
             .storage()
             .instance()
             .get(&DataKey::Bond(bond_id))
             .expect("bond not found");
 
+        // Invariant 7: issuer must authorize every redemption.
+        bond.issuer.require_auth();
+
+        // Invariant 1: bond must be active.
         assert_eq!(bond.status, BondStatus::Active, "bond not active");
-        assert!(is_period_within_maturity(&env, &bond, period.clone()), "period exceeds maturity");
+
+        // Invariant 2: period within maturity window.
+        assert!(
+            is_period_within_maturity(&env, &bond, period.clone()),
+            "period exceeds maturity"
+        );
+
+        // Invariant 3: double-spend guard.
+        assert!(
+            env.storage()
+                .instance()
+                .get::<_, RedemptionRecord>(&DataKey::Redemption(bond_id, period.clone()))
+                .is_none(),
+            "already redeemed for period"
+        );
+
+        let client = attestation_import::AttestationContractClient::new(
+            &env,
+            &bond.attestation_contract,
+        );
+
+        // Invariant 4a: revocation mid-cycle guard (checked before reading revenue).
+        assert!(!client.is_revoked(&bond.issuer, &period), "attestation is revoked");
+
+        // Invariant 4b: attestation must exist; revenue is read from it.
+        let attestation = client
+            .get_attestation(&bond.issuer, &period)
+            .expect("attestation not found");
+        let attested_revenue: i128 = attestation.3;
         assert!(attested_revenue >= 0, "attested_revenue must be non-negative");
 
-        // Prevent double-redemption for the same period
-        let existing: Option<RedemptionRecord> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Redemption(bond_id, period.clone()));
-        assert!(existing.is_none(), "already redeemed for period");
+        // Calculate uncapped per-period amount.
+        let redemption_amount = calculate_redemption(&bond, attested_revenue);
 
-        // Verify attestation exists and is not revoked
-        let client =
-            attestation_import::AttestationContractClient::new(&env, &bond.attestation_contract);
-        assert!(
-            client.get_attestation(&bond.issuer, &period).is_some(),
-            "attestation not found"
-        );
-        assert!(
-            !client.is_revoked(&bond.issuer, &period),
-            "attestation is revoked"
-        );
-
-        // Calculate redemption amount based on bond structure
-        let redemption_amount = Self::calculate_redemption(&bond, attested_revenue);
-
-        // Check if redemption would exceed face value
+        // Invariant 6: cumulative face-value cap.
         let total_redeemed: i128 = env
             .storage()
             .instance()
             .get(&DataKey::TotalRedeemed(bond_id))
             .unwrap_or(0);
+        let remaining = bond.face_value - total_redeemed;
+        assert!(remaining > 0, "bond already fully redeemed");
 
-        let actual_redemption = redemption_amount.min(bond.face_value - total_redeemed);
-        assert!(actual_redemption >= 0, "bond already fully redeemed");
+        let actual_redemption = redemption_amount.min(remaining);
 
-        // Transfer tokens from issuer to bond owner
+        // Invariant 5: per-period cap — re-assert after face-value clamp.
+        assert!(
+            actual_redemption <= bond.max_payment_per_period,
+            "redemption exceeds per-period cap"
+        );
+
+        // Transfer tokens from issuer to bond owner.
         if actual_redemption > 0 {
             let owner: Address = env
                 .storage()
                 .instance()
                 .get(&DataKey::BondOwner(bond_id))
                 .expect("owner not found");
-
-            let token_client = token::Client::new(&env, &bond.token);
-            token_client.transfer(&bond.issuer, &owner, &actual_redemption);
+            token::Client::new(&env, &bond.token).transfer(
+                &bond.issuer,
+                &owner,
+                &actual_redemption,
+            );
         }
 
-        // Record redemption
-        let redemption = RedemptionRecord {
-            bond_id,
-            period: period.clone(),
-            attested_revenue,
-            redemption_amount: actual_redemption,
-            redeemed_at: env.ledger().timestamp(),
-        };
+        // Write redemption record (Soroban reverts the whole tx on panic,
+        // so this write and the transfer above are effectively atomic).
+        env.storage().instance().set(
+            &DataKey::Redemption(bond_id, period.clone()),
+            &RedemptionRecord {
+                bond_id,
+                period,
+                attested_revenue,
+                redemption_amount: actual_redemption,
+                redeemed_at: env.ledger().timestamp(),
+            },
+        );
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Redemption(bond_id, period), &redemption);
-
-        // Update total redeemed
         let new_total = total_redeemed + actual_redemption;
-        env.storage()
-            .instance()
-            .set(&DataKey::TotalRedeemed(bond_id), &new_total);
+        env.storage().instance().set(&DataKey::TotalRedeemed(bond_id), &new_total);
 
-        // Check if bond is fully redeemed
         if new_total >= bond.face_value {
             let mut updated_bond = bond;
             updated_bond.status = BondStatus::FullyRedeemed;
-            env.storage()
-                .instance()
-                .set(&DataKey::Bond(bond_id), &updated_bond);
-        }
-    }
-
-    /// Calculate redemption amount based on bond structure and revenue.
-    fn calculate_redemption(bond: &Bond, attested_revenue: i128) -> i128 {
-        match bond.structure {
-            BondStructure::Fixed => {
-                // Fixed payment per period
-                bond.min_payment_per_period
-            }
-            BondStructure::RevenueLinked => {
-                // Pure revenue share
-                let share = (attested_revenue as u128)
-                    .saturating_mul(bond.revenue_share_bps as u128)
-                    .saturating_div(10000) as i128;
-                share
-                    .max(bond.min_payment_per_period)
-                    .min(bond.max_payment_per_period)
-            }
-            BondStructure::Hybrid => {
-                // Minimum fixed + revenue share
-                let revenue_component = (attested_revenue as u128)
-                    .saturating_mul(bond.revenue_share_bps as u128)
-                    .saturating_div(10000) as i128;
-                let total = bond.min_payment_per_period + revenue_component;
-                total.min(bond.max_payment_per_period)
-            }
+            env.storage().instance().set(&DataKey::Bond(bond_id), &updated_bond);
         }
     }
 
     /// Transfer bond ownership.
     ///
-    /// # Arguments
-    /// * `bond_id` - Bond identifier
-    /// * `current_owner` - Current owner (must authorize)
-    /// * `new_owner` - New owner address
+    /// # Panics
+    /// Panics if the bond does not exist, the caller is not the owner, or
+    /// `current_owner == new_owner`.
     pub fn transfer_ownership(env: Env, bond_id: u64, current_owner: Address, new_owner: Address) {
         current_owner.require_auth();
 
@@ -419,56 +449,55 @@ impl RevenueBondContract {
         assert_eq!(current_owner, stored_owner, "not bond owner");
         assert!(!current_owner.eq(&new_owner), "cannot transfer to self");
 
-        env.storage()
-            .instance()
-            .set(&DataKey::BondOwner(bond_id), &new_owner);
+        env.storage().instance().set(&DataKey::BondOwner(bond_id), &new_owner);
     }
 
-    /// Mark bond as defaulted (admin only).
+    /// Mark a bond as defaulted (admin only).
     ///
-    /// # Arguments
-    /// * `admin` - Admin address (must authorize)
-    /// * `bond_id` - Bond identifier
+    /// Irreversible.  No further redemptions are possible after default.
     ///
-    /// # Risk Factors
-    /// - Default results in loss for bond holders
-    /// - Partial redemptions may have occurred before default
-pub fn mark_defaulted(env: Env, admin: Address, bond_id: u64) {
+    /// # Security
+    /// `require_auth()` is called before the equality check to prevent
+    /// callers from probing whether an address is admin without signing.
+    pub fn mark_defaulted(env: Env, admin: Address, bond_id: u64) {
+        admin.require_auth();
         let stored_admin: Address = env
             .storage()
             .instance()
             .get(&DataKey::Admin)
             .expect("not initialized");
         assert_eq!(admin, stored_admin, "unauthorized");
-        admin.require_auth();
 
         let mut bond: Bond = env
             .storage()
             .instance()
             .get(&DataKey::Bond(bond_id))
             .expect("bond not found");
-
         assert!(matches!(bond.status, BondStatus::Active), "bond not active");
         bond.status = BondStatus::Defaulted;
         env.storage().instance().set(&DataKey::Bond(bond_id), &bond);
     }
 
-    /// Mark bond as matured (admin only).
+    /// Mark a bond as matured (admin only).
+    ///
+    /// Irreversible.  No further redemptions are possible after maturity.
+    ///
+    /// # Security
+    /// `require_auth()` is called before the equality check.
     pub fn mark_matured(env: Env, admin: Address, bond_id: u64) {
+        admin.require_auth();
         let stored_admin: Address = env
             .storage()
             .instance()
             .get(&DataKey::Admin)
             .expect("not initialized");
         assert_eq!(admin, stored_admin, "unauthorized");
-        admin.require_auth();
 
         let mut bond: Bond = env
             .storage()
             .instance()
             .get(&DataKey::Bond(bond_id))
             .expect("bond not found");
-
         assert!(matches!(bond.status, BondStatus::Active), "bond not active");
         bond.status = BondStatus::Matured;
         env.storage().instance().set(&DataKey::Bond(bond_id), &bond);
@@ -479,19 +508,19 @@ pub fn mark_defaulted(env: Env, admin: Address, bond_id: u64) {
         env.storage().instance().get(&DataKey::Bond(bond_id))
     }
 
-    /// Get bond owner.
+    /// Get the current bond owner.
     pub fn get_owner(env: Env, bond_id: u64) -> Option<Address> {
         env.storage().instance().get(&DataKey::BondOwner(bond_id))
     }
 
-    /// Get redemption record for a period.
+    /// Get the redemption record for a specific period, if any.
     pub fn get_redemption(env: Env, bond_id: u64, period: String) -> Option<RedemptionRecord> {
         env.storage()
             .instance()
             .get(&DataKey::Redemption(bond_id, period))
     }
 
-    /// Get total amount redeemed for a bond.
+    /// Get the total amount redeemed across all periods for a bond.
     pub fn get_total_redeemed(env: Env, bond_id: u64) -> i128 {
         env.storage()
             .instance()
@@ -499,28 +528,27 @@ pub fn mark_defaulted(env: Env, admin: Address, bond_id: u64) {
             .unwrap_or(0)
     }
 
-    /// Get remaining face value to be redeemed.
-pub fn get_remaining_value(env: Env, bond_id: u64) -> i128 {
+    /// Get the remaining face value yet to be redeemed.
+    ///
+    /// Returns `0` for bonds that are not `Active`.
+    pub fn get_remaining_value(env: Env, bond_id: u64) -> i128 {
         let bond: Bond = env
             .storage()
             .instance()
             .get(&DataKey::Bond(bond_id))
             .expect("bond not found");
-        
         if !matches!(bond.status, BondStatus::Active) {
             return 0;
         }
-        
         let total_redeemed: i128 = env
             .storage()
             .instance()
             .get(&DataKey::TotalRedeemed(bond_id))
             .unwrap_or(0);
-
         bond.face_value - total_redeemed
     }
 
-    /// Get admin address.
+    /// Get the contract admin address.
     pub fn get_admin(env: Env) -> Address {
         env.storage()
             .instance()

--- a/contracts/revenue-bonds/src/test.rs
+++ b/contracts/revenue-bonds/src/test.rs
@@ -2,15 +2,16 @@
 use super::*;
 use soroban_sdk::{testutils::Address as _, token, Address, Env, String};
 
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
 fn create_token_contract<'a>(env: &Env, admin: &Address) -> token::StellarAssetClient<'a> {
     token::StellarAssetClient::new(
         env,
-        &env.register_stellar_asset_contract_v2(admin.clone())
-            .address(),
+        &env.register_stellar_asset_contract_v2(admin.clone()).address(),
     )
 }
 
-fn setup_test() -> (Env, Address, Address, Address, Address, Address, Address) {
+fn setup_test() -> (Env, Address, Address, Address, Address, Address) {
     let env = Env::default();
     env.mock_all_auths();
     env.mock_all_auths_allowing_non_root_auth();
@@ -22,29 +23,41 @@ fn setup_test() -> (Env, Address, Address, Address, Address, Address, Address) {
 
     let token_client = create_token_contract(&env, &token_admin);
     let token = token_client.address.clone();
-
-    // Mint tokens to issuer for bond payments
     token_client.mint(&issuer, &100_000_000);
 
     let attestation_contract = Address::generate(&env);
-
-    (
-        env,
-        admin,
-        issuer,
-        owner,
-        token,
-        attestation_contract,
-        token_admin,
-    )
+    (env, admin, issuer, owner, token, attestation_contract)
 }
+
+/// Set the mock revenue for a (business, period) pair in the test environment.
+fn set_mock_revenue(env: &Env, business: &Address, period: &str, revenue: i128) {
+    let p = String::from_str(env, period);
+    env.storage().temporary().set(
+        &(soroban_sdk::symbol_short!("rev"), business.clone(), p),
+        &revenue,
+    );
+}
+
+/// Mark an attestation as revoked in the test environment.
+fn set_mock_revoked(env: &Env, business: &Address, period: &str) {
+    let p = String::from_str(env, period);
+    env.storage().temporary().set(
+        &(soroban_sdk::symbol_short!("rvkd"), business.clone(), p),
+        &true,
+    );
+}
+
+fn issue_period(env: &Env) -> String {
+    String::from_str(env, "2026-01")
+}
+
+// ─── Initialization ───────────────────────────────────────────────────────────
 
 #[test]
 fn test_initialize() {
-    let (env, admin, _, _, _, _, _) = setup_test();
+    let (env, admin, _, _, _, _) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
     assert_eq!(client.get_admin(), admin);
 }
@@ -52,37 +65,26 @@ fn test_initialize() {
 #[test]
 #[should_panic(expected = "already initialized")]
 fn test_double_initialize_panics() {
-    let (env, admin, _, _, _, _, _) = setup_test();
+    let (env, admin, _, _, _, _) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
     client.initialize(&admin);
 }
 
+// ─── Bond issuance ────────────────────────────────────────────────────────────
+
 #[test]
 fn test_issue_bond_fixed_structure() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
-let issue_period = String::from_str(&env, "2026-01");
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &10_000_000,
-        &BondStructure::Fixed,
-        &0,
-        &500_000,
-        &500_000,
-        &12,
-        &issue_period,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &10_000_000, &BondStructure::Fixed,
+        &0, &500_000, &500_000, &12, &issue_period(&env), &attestation_contract, &token,
     );
-
     assert_eq!(bond_id, 0);
     let bond = client.get_bond(&bond_id).unwrap();
     assert_eq!(bond.face_value, 10_000_000);
@@ -92,27 +94,15 @@ let issue_period = String::from_str(&env, "2026-01");
 
 #[test]
 fn test_issue_bond_revenue_linked() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
-let issue_period = String::from_str(&env, "2026-01");
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &5_000_000,
-        &BondStructure::RevenueLinked,
-        &1000,
-        &100_000,
-        &1_000_000,
-        &24,
-        &issue_period,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &5_000_000, &BondStructure::RevenueLinked,
+        &1000, &100_000, &1_000_000, &24, &issue_period(&env), &attestation_contract, &token,
     );
-
     let bond = client.get_bond(&bond_id).unwrap();
     assert_eq!(bond.structure, BondStructure::RevenueLinked);
     assert_eq!(bond.revenue_share_bps, 1000);
@@ -120,27 +110,15 @@ let issue_period = String::from_str(&env, "2026-01");
 
 #[test]
 fn test_issue_bond_hybrid() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
-let issue_period = String::from_str(&env, "2026-01");
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &8_000_000,
-        &BondStructure::Hybrid,
-        &500,
-        &200_000,
-        &800_000,
-        &18,
-        &issue_period,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &8_000_000, &BondStructure::Hybrid,
+        &500, &200_000, &800_000, &18, &issue_period(&env), &attestation_contract, &token,
     );
-
     let bond = client.get_bond(&bond_id).unwrap();
     assert_eq!(bond.structure, BondStructure::Hybrid);
 }
@@ -148,380 +126,203 @@ let issue_period = String::from_str(&env, "2026-01");
 #[test]
 #[should_panic(expected = "face_value must be positive")]
 fn test_issue_bond_invalid_face_value() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
-let issue_period = String::from_str(&env, "2026-01");
     client.issue_bond(
-        &issuer,
-        &owner,
-        &0,
-        &BondStructure::Fixed,
-        &0,
-        &500_000,
-        &500_000,
-        &12,
-        &issue_period,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &0, &BondStructure::Fixed,
+        &0, &500_000, &500_000, &12, &issue_period(&env), &attestation_contract, &token,
     );
 }
 
 #[test]
 #[should_panic(expected = "revenue_share_bps must be <= 10000")]
 fn test_issue_bond_invalid_revenue_share() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
-let issue_period = String::from_str(&env, "2026-01");
     client.issue_bond(
-        &issuer,
-        &owner,
-        &10_000_000,
-        &BondStructure::RevenueLinked,
-        &10001,
-        &100_000,
-        &1_000_000,
-        &12,
-        &issue_period,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &10_000_000, &BondStructure::RevenueLinked,
+        &10001, &100_000, &1_000_000, &12, &issue_period(&env), &attestation_contract, &token,
     );
 }
 
 #[test]
 #[should_panic(expected = "max must be >= min")]
 fn test_issue_bond_invalid_payment_range() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
-let issue_period = String::from_str(&env, "2026-01");
     client.issue_bond(
-        &issuer,
-        &owner,
-        &10_000_000,
-        &BondStructure::Fixed,
-        &0,
-        &1_000_000,
-        &500_000,
-        &12,
-        &issue_period,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &10_000_000, &BondStructure::Fixed,
+        &0, &1_000_000, &500_000, &12, &issue_period(&env), &attestation_contract, &token,
     );
 }
 
+
+// ─── Redemption: basic structures ────────────────────────────────────────────
+
 #[test]
 fn test_redeem_fixed_bond() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &10_000_000,
-        &BondStructure::Fixed,
-        &0,
-        &500_000,
-        &500_000,
-        &12,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &10_000_000, &BondStructure::Fixed,
+        &0, &500_000, &500_000, &12, &issue_period(&env), &attestation_contract, &token,
     );
 
     let period = String::from_str(&env, "2026-02");
-    client.redeem(&bond_id, &period, &2_000_000);
+    set_mock_revenue(&env, &issuer, "2026-02", 2_000_000);
+    client.redeem(&bond_id, &period);
 
-    let redemption = client.get_redemption(&bond_id, &period).unwrap();
-    assert_eq!(redemption.redemption_amount, 500_000);
+    let rec = client.get_redemption(&bond_id, &period).unwrap();
+    assert_eq!(rec.redemption_amount, 500_000);
     assert_eq!(client.get_total_redeemed(&bond_id), 500_000);
 }
 
 #[test]
 fn test_redeem_revenue_linked_bond() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &5_000_000,
-        &BondStructure::RevenueLinked,
-        &1000,
-        &100_000,
-        &1_000_000,
-        &24,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &5_000_000, &BondStructure::RevenueLinked,
+        &1000, &100_000, &1_000_000, &24, &issue_period(&env), &attestation_contract, &token,
     );
 
+    set_mock_revenue(&env, &issuer, "2026-02", 5_000_000);
     let period = String::from_str(&env, "2026-02");
-    client.redeem(&bond_id, &period, &5_000_000);
+    client.redeem(&bond_id, &period);
 
-    let redemption = client.get_redemption(&bond_id, &period).unwrap();
-    assert_eq!(redemption.redemption_amount, 500_000);
+    // 10% of 5_000_000 = 500_000
+    assert_eq!(client.get_redemption(&bond_id, &period).unwrap().redemption_amount, 500_000);
 }
 
 #[test]
 fn test_redeem_revenue_linked_below_minimum() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &5_000_000,
-        &BondStructure::RevenueLinked,
-        &1000,
-        &100_000,
-        &1_000_000,
-        &24,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &5_000_000, &BondStructure::RevenueLinked,
+        &1000, &100_000, &1_000_000, &24, &issue_period(&env), &attestation_contract, &token,
     );
 
+    // 10% of 500_000 = 50_000 < min 100_000 → floors to min
+    set_mock_revenue(&env, &issuer, "2026-02", 500_000);
     let period = String::from_str(&env, "2026-02");
-    client.redeem(&bond_id, &period, &500_000);
-
-    let redemption = client.get_redemption(&bond_id, &period).unwrap();
-    assert_eq!(redemption.redemption_amount, 100_000);
+    client.redeem(&bond_id, &period);
+    assert_eq!(client.get_redemption(&bond_id, &period).unwrap().redemption_amount, 100_000);
 }
 
 #[test]
 fn test_redeem_revenue_linked_capped_at_max() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &5_000_000,
-        &BondStructure::RevenueLinked,
-        &1000,
-        &100_000,
-        &1_000_000,
-        &24,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &5_000_000, &BondStructure::RevenueLinked,
+        &1000, &100_000, &1_000_000, &24, &issue_period(&env), &attestation_contract, &token,
     );
 
+    // 10% of 15_000_000 = 1_500_000 > max 1_000_000 → capped
+    set_mock_revenue(&env, &issuer, "2026-02", 15_000_000);
     let period = String::from_str(&env, "2026-02");
-    client.redeem(&bond_id, &period, &15_000_000);
-
-    let redemption = client.get_redemption(&bond_id, &period).unwrap();
-    assert_eq!(redemption.redemption_amount, 1_000_000);
+    client.redeem(&bond_id, &period);
+    assert_eq!(client.get_redemption(&bond_id, &period).unwrap().redemption_amount, 1_000_000);
 }
 
 #[test]
 fn test_redeem_hybrid_bond() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &8_000_000,
-        &BondStructure::Hybrid,
-        &500,
-        &200_000,
-        &800_000,
-        &18,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &8_000_000, &BondStructure::Hybrid,
+        &500, &200_000, &800_000, &18, &issue_period(&env), &attestation_contract, &token,
     );
 
+    // min 200_000 + 5% of 10_000_000 = 200_000 + 500_000 = 700_000
+    set_mock_revenue(&env, &issuer, "2026-02", 10_000_000);
     let period = String::from_str(&env, "2026-02");
-    client.redeem(&bond_id, &period, &10_000_000);
-
-    let redemption = client.get_redemption(&bond_id, &period).unwrap();
-    assert_eq!(redemption.redemption_amount, 700_000);
+    client.redeem(&bond_id, &period);
+    assert_eq!(client.get_redemption(&bond_id, &period).unwrap().redemption_amount, 700_000);
 }
+
+// ─── Double-spend prevention ──────────────────────────────────────────────────
 
 #[test]
 #[should_panic(expected = "already redeemed for period")]
 fn test_redeem_double_spending_prevention() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &10_000_000,
-        &BondStructure::Fixed,
-        &0,
-        &500_000,
-        &500_000,
-        &12,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &10_000_000, &BondStructure::Fixed,
+        &0, &500_000, &500_000, &12, &issue_period(&env), &attestation_contract, &token,
     );
 
     let period = String::from_str(&env, "2026-02");
-    client.redeem(&bond_id, &period, &2_000_000);
-    client.redeem(&bond_id, &period, &2_000_000);
+    set_mock_revenue(&env, &issuer, "2026-02", 0);
+    client.redeem(&bond_id, &period);
+    client.redeem(&bond_id, &period); // must panic
 }
+
+// ─── Multi-period redemptions ─────────────────────────────────────────────────
 
 #[test]
 fn test_multiple_period_redemptions() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &10_000_000,
-        &BondStructure::Fixed,
-        &0,
-        &500_000,
-        &500_000,
-        &12,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &10_000_000, &BondStructure::Fixed,
+        &0, &500_000, &500_000, &12, &issue_period(&env), &attestation_contract, &token,
     );
 
-    let period1 = String::from_str(&env, "2026-02");
-    let period2 = String::from_str(&env, "2026-03");
-    let period3 = String::from_str(&env, "2026-04");
-
-    client.redeem(&bond_id, &period1, &2_000_000);
-    client.redeem(&bond_id, &period2, &2_500_000);
-    client.redeem(&bond_id, &period3, &3_000_000);
+    for p in ["2026-01", "2026-02", "2026-03"] {
+        set_mock_revenue(&env, &issuer, p, 0);
+        client.redeem(&bond_id, &String::from_str(&env, p));
+    }
 
     assert_eq!(client.get_total_redeemed(&bond_id), 1_500_000);
     assert_eq!(client.get_remaining_value(&bond_id), 8_500_000);
 }
 
-/// Maturity is currently informational only. Redemptions continue if the bond
-/// is still active and has remaining face value, even when periods drift past
-/// the configured maturity window.
-#[test]
-fn test_redemption_continues_after_maturity_period_drift() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
-    let contract_id = env.register(RevenueBondContract, ());
-    let client = RevenueBondContractClient::new(&env, &contract_id);
-
-    client.initialize(&admin);
-
-    let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &2_000_000,
-        &BondStructure::Fixed,
-        &0,
-        &500_000,
-        &500_000,
-        &2,
-        &attestation_contract,
-        &token,
-    );
-
-    let period1 = String::from_str(&env, "2026-01");
-    let period2 = String::from_str(&env, "2026-02");
-    let period3 = String::from_str(&env, "2026-03");
-
-    client.redeem(&bond_id, &period1, &1_000_000);
-    client.redeem(&bond_id, &period2, &1_000_000);
-    client.redeem(&bond_id, &period3, &1_000_000);
-
-    let bond = client.get_bond(&bond_id).unwrap();
-    let redemption3 = client.get_redemption(&bond_id, &period3).unwrap();
-
-    assert_eq!(redemption3.redemption_amount, 500_000);
-    assert_eq!(client.get_total_redeemed(&bond_id), 1_500_000);
-    assert_eq!(client.get_remaining_value(&bond_id), 500_000);
-    assert_eq!(bond.status, BondStatus::Active);
-}
-
-/// Distinct period keys are the anti-double-spend boundary; ordering is not
-/// enforced so out-of-order period redemption remains valid.
-#[test]
-fn test_redemption_allows_out_of_order_period_drift() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
-    let contract_id = env.register(RevenueBondContract, ());
-    let client = RevenueBondContractClient::new(&env, &contract_id);
-
-    client.initialize(&admin);
-
-    let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &2_000_000,
-        &BondStructure::Fixed,
-        &0,
-        &500_000,
-        &500_000,
-        &12,
-        &attestation_contract,
-        &token,
-    );
-
-    let later_period = String::from_str(&env, "2026-03");
-    let earlier_period = String::from_str(&env, "2026-01");
-
-    client.redeem(&bond_id, &later_period, &1_000_000);
-    client.redeem(&bond_id, &earlier_period, &1_000_000);
-
-    let later_redemption = client.get_redemption(&bond_id, &later_period).unwrap();
-    let earlier_redemption = client.get_redemption(&bond_id, &earlier_period).unwrap();
-
-    assert_eq!(later_redemption.redemption_amount, 500_000);
-    assert_eq!(earlier_redemption.redemption_amount, 500_000);
-    assert_eq!(client.get_total_redeemed(&bond_id), 1_000_000);
-}
-
 #[test]
 fn test_full_redemption() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &1_000_000,
-        &BondStructure::Fixed,
-        &0,
-        &500_000,
-        &500_000,
-        &12,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &1_000_000, &BondStructure::Fixed,
+        &0, &500_000, &500_000, &12, &issue_period(&env), &attestation_contract, &token,
     );
 
-    let period1 = String::from_str(&env, "2026-02");
-    let period2 = String::from_str(&env, "2026-03");
-
-    client.redeem(&bond_id, &period1, &2_000_000);
-    client.redeem(&bond_id, &period2, &2_000_000);
+    for p in ["2026-01", "2026-02"] {
+        set_mock_revenue(&env, &issuer, p, 0);
+        client.redeem(&bond_id, &String::from_str(&env, p));
+    }
 
     let bond = client.get_bond(&bond_id).unwrap();
     assert_eq!(bond.status, BondStatus::FullyRedeemed);
@@ -531,63 +332,42 @@ fn test_full_redemption() {
 
 #[test]
 fn test_partial_redemption_caps_at_face_value() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
+    // face_value=1_200_000, max_per_period=500_000 → 3 periods needed
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &1_200_000,
-        &BondStructure::Fixed,
-        &0,
-        &500_000,
-        &500_000,
-        &12,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &1_200_000, &BondStructure::Fixed,
+        &0, &500_000, &500_000, &12, &issue_period(&env), &attestation_contract, &token,
     );
 
-    let period1 = String::from_str(&env, "2026-02");
-    let period2 = String::from_str(&env, "2026-03");
-    let period3 = String::from_str(&env, "2026-04");
-
-    client.redeem(&bond_id, &period1, &2_000_000);
-    client.redeem(&bond_id, &period2, &2_000_000);
-    client.redeem(&bond_id, &period3, &2_000_000);
+    for p in ["2026-01", "2026-02", "2026-03"] {
+        set_mock_revenue(&env, &issuer, p, 0);
+        client.redeem(&bond_id, &String::from_str(&env, p));
+    }
 
     let bond = client.get_bond(&bond_id).unwrap();
     assert_eq!(bond.status, BondStatus::FullyRedeemed);
     assert_eq!(client.get_total_redeemed(&bond_id), 1_200_000);
 }
 
+
+// ─── Ownership transfer ───────────────────────────────────────────────────────
+
 #[test]
 fn test_transfer_ownership() {
-    let (env, admin, issuer, owner, _, _, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
     let new_owner = Address::generate(&env);
-    let token = Address::generate(&env);
-    let attestation_contract = Address::generate(&env);
-
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &10_000_000,
-        &BondStructure::Fixed,
-        &0,
-        &500_000,
-        &500_000,
-        &12,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &10_000_000, &BondStructure::Fixed,
+        &0, &500_000, &500_000, &12, &issue_period(&env), &attestation_contract, &token,
     );
-
     client.transfer_ownership(&bond_id, &owner, &new_owner);
     assert_eq!(client.get_owner(&bond_id).unwrap(), new_owner);
 }
@@ -595,144 +375,242 @@ fn test_transfer_ownership() {
 #[test]
 #[should_panic(expected = "not bond owner")]
 fn test_transfer_ownership_unauthorized() {
-    let (env, admin, issuer, owner, _, _, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
-    let new_owner = Address::generate(&env);
     let fake_owner = Address::generate(&env);
-    let token = Address::generate(&env);
-    let attestation_contract = Address::generate(&env);
-
+    let new_owner = Address::generate(&env);
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &10_000_000,
-        &BondStructure::Fixed,
-        &0,
-        &500_000,
-        &500_000,
-        &12,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &10_000_000, &BondStructure::Fixed,
+        &0, &500_000, &500_000, &12, &issue_period(&env), &attestation_contract, &token,
     );
-
     client.transfer_ownership(&bond_id, &fake_owner, &new_owner);
 }
 
+// ─── Admin operations ─────────────────────────────────────────────────────────
+
 #[test]
 fn test_mark_defaulted() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &10_000_000,
-        &BondStructure::Fixed,
-        &0,
-        &500_000,
-        &500_000,
-        &12,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &10_000_000, &BondStructure::Fixed,
+        &0, &500_000, &500_000, &12, &issue_period(&env), &attestation_contract, &token,
     );
-
     client.mark_defaulted(&admin, &bond_id);
-
-    let bond = client.get_bond(&bond_id).unwrap();
-    assert_eq!(bond.status, BondStatus::Defaulted);
+    assert_eq!(client.get_bond(&bond_id).unwrap().status, BondStatus::Defaulted);
 }
 
 #[test]
 #[should_panic(expected = "unauthorized")]
 fn test_mark_defaulted_unauthorized() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &10_000_000,
-        &BondStructure::Fixed,
-        &0,
-        &500_000,
-        &500_000,
-        &12,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &10_000_000, &BondStructure::Fixed,
+        &0, &500_000, &500_000, &12, &issue_period(&env), &attestation_contract, &token,
     );
-
-    let non_admin = Address::generate(&env);
-    client.mark_defaulted(&non_admin, &bond_id);
+    client.mark_defaulted(&Address::generate(&env), &bond_id);
 }
 
 #[test]
 #[should_panic(expected = "bond not active")]
 fn test_redeem_defaulted_bond() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &10_000_000,
-        &BondStructure::Fixed,
-        &0,
-        &500_000,
-        &500_000,
-        &12,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &10_000_000, &BondStructure::Fixed,
+        &0, &500_000, &500_000, &12, &issue_period(&env), &attestation_contract, &token,
+    );
+    client.mark_defaulted(&admin, &bond_id);
+    set_mock_revenue(&env, &issuer, "2026-02", 0);
+    client.redeem(&bond_id, &String::from_str(&env, "2026-02"));
+}
+
+// ─── Revocation mid-cycle guard ───────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "attestation is revoked")]
+fn test_redeem_revoked_attestation_panics() {
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
+    let contract_id = env.register(RevenueBondContract, ());
+    let client = RevenueBondContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    let bond_id = client.issue_bond(
+        &issuer, &owner, &5_000_000, &BondStructure::Fixed,
+        &0, &500_000, &500_000, &12, &issue_period(&env), &attestation_contract, &token,
     );
 
-    client.mark_defaulted(&admin, &bond_id);
-
-    let period = String::from_str(&env, "2026-02");
-    client.redeem(&bond_id, &period, &2_000_000);
+    // Attestation is revoked mid-cycle before redemption.
+    set_mock_revoked(&env, &issuer, "2026-03");
+    client.redeem(&bond_id, &String::from_str(&env, "2026-03"));
 }
 
 #[test]
-fn test_early_redemption_scenario() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+fn test_redeem_succeeds_for_non_revoked_period_after_other_revoked() {
+    // Revocation of one period must not block redemption of a different period.
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &4_500_000,
-        &BondStructure::RevenueLinked,
-        &2000,
-        &100_000,
-        &2_000_000,
-        &24,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &5_000_000, &BondStructure::Fixed,
+        &0, &500_000, &500_000, &12, &issue_period(&env), &attestation_contract, &token,
     );
 
-    let period1 = String::from_str(&env, "2026-02");
-    let period2 = String::from_str(&env, "2026-03");
-    let period3 = String::from_str(&env, "2026-04");
+    set_mock_revoked(&env, &issuer, "2026-02");
+    set_mock_revenue(&env, &issuer, "2026-03", 0);
+    // 2026-03 is not revoked — must succeed.
+    client.redeem(&bond_id, &String::from_str(&env, "2026-03"));
+    assert_eq!(client.get_total_redeemed(&bond_id), 500_000);
+}
 
-    client.redeem(&bond_id, &period1, &8_000_000);
-    client.redeem(&bond_id, &period2, &10_000_000);
-    client.redeem(&bond_id, &period3, &5_000_000);
+// ─── Per-period cap enforcement ───────────────────────────────────────────────
 
-    let bond = client.get_bond(&bond_id).unwrap();
-    assert_eq!(bond.status, BondStatus::FullyRedeemed);
+#[test]
+fn test_per_period_cap_not_exceeded_on_last_partial() {
+    // face_value=700_000, max_per_period=500_000.
+    // After period1 (500_000), remaining=200_000 < max.
+    // The per-period cap assertion must pass because 200_000 <= 500_000.
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
+    let contract_id = env.register(RevenueBondContract, ());
+    let client = RevenueBondContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    let bond_id = client.issue_bond(
+        &issuer, &owner, &700_000, &BondStructure::Fixed,
+        &0, &500_000, &500_000, &12, &issue_period(&env), &attestation_contract, &token,
+    );
+
+    set_mock_revenue(&env, &issuer, "2026-01", 0);
+    client.redeem(&bond_id, &String::from_str(&env, "2026-01"));
+    assert_eq!(client.get_total_redeemed(&bond_id), 500_000);
+
+    set_mock_revenue(&env, &issuer, "2026-02", 0);
+    client.redeem(&bond_id, &String::from_str(&env, "2026-02"));
+    // Last partial: 200_000 transferred, bond fully redeemed.
+    assert_eq!(client.get_total_redeemed(&bond_id), 700_000);
+    assert_eq!(client.get_bond(&bond_id).unwrap().status, BondStatus::FullyRedeemed);
+}
+
+// ─── Revenue read from attestation (not caller-supplied) ─────────────────────
+
+#[test]
+fn test_revenue_is_read_from_attestation_not_caller() {
+    // The mock returns whatever is in temporary storage.
+    // We set revenue=8_000_000; 10% = 800_000, capped at max 1_000_000.
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
+    let contract_id = env.register(RevenueBondContract, ());
+    let client = RevenueBondContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    let bond_id = client.issue_bond(
+        &issuer, &owner, &5_000_000, &BondStructure::RevenueLinked,
+        &1000, &100_000, &1_000_000, &24, &issue_period(&env), &attestation_contract, &token,
+    );
+
+    set_mock_revenue(&env, &issuer, "2026-02", 8_000_000);
+    let period = String::from_str(&env, "2026-02");
+    client.redeem(&bond_id, &period);
+
+    let rec = client.get_redemption(&bond_id, &period).unwrap();
+    // attested_revenue must be what the attestation contract returned, not a caller value.
+    assert_eq!(rec.attested_revenue, 8_000_000);
+    assert_eq!(rec.redemption_amount, 800_000);
+}
+
+// ─── Edge cases ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_early_redemption_scenario() {
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
+    let contract_id = env.register(RevenueBondContract, ());
+    let client = RevenueBondContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    let bond_id = client.issue_bond(
+        &issuer, &owner, &4_500_000, &BondStructure::RevenueLinked,
+        &2000, &100_000, &2_000_000, &24, &issue_period(&env), &attestation_contract, &token,
+    );
+
+    // 20% of 8_000_000 = 1_600_000; 20% of 10_000_000 = 2_000_000; 20% of 5_000_000 = 1_000_000
+    for (p, rev) in [("2026-01", 8_000_000i128), ("2026-02", 10_000_000), ("2026-03", 5_000_000)] {
+        set_mock_revenue(&env, &issuer, p, rev);
+        client.redeem(&bond_id, &String::from_str(&env, p));
+    }
+
+    assert_eq!(client.get_bond(&bond_id).unwrap().status, BondStatus::FullyRedeemed);
     assert_eq!(client.get_total_redeemed(&bond_id), 4_500_000);
+}
+
+#[test]
+fn test_zero_revenue_hybrid_pays_minimum() {
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
+    let contract_id = env.register(RevenueBondContract, ());
+    let client = RevenueBondContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    let bond_id = client.issue_bond(
+        &issuer, &owner, &3_000_000, &BondStructure::Hybrid,
+        &500, &200_000, &800_000, &12, &issue_period(&env), &attestation_contract, &token,
+    );
+
+    // revenue=0 → min + 0 = 200_000
+    set_mock_revenue(&env, &issuer, "2026-01", 0);
+    let period = String::from_str(&env, "2026-01");
+    client.redeem(&bond_id, &period);
+    assert_eq!(client.get_redemption(&bond_id, &period).unwrap().redemption_amount, 200_000);
+}
+
+#[test]
+fn test_max_i128_revenue_does_not_overflow() {
+    // saturating_mul must prevent overflow for extreme revenue values.
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
+    let contract_id = env.register(RevenueBondContract, ());
+    let client = RevenueBondContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    let bond_id = client.issue_bond(
+        &issuer, &owner, &5_000_000, &BondStructure::RevenueLinked,
+        &1000, &0, &1_000_000, &24, &issue_period(&env), &attestation_contract, &token,
+    );
+
+    set_mock_revenue(&env, &issuer, "2026-01", i128::MAX);
+    let period = String::from_str(&env, "2026-01");
+    client.redeem(&bond_id, &period);
+    // saturating_mul caps at u128::MAX then cast to i128 → clamped to max_payment_per_period
+    assert_eq!(client.get_redemption(&bond_id, &period).unwrap().redemption_amount, 1_000_000);
+}
+
+#[test]
+fn test_out_of_order_period_redemption() {
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
+    let contract_id = env.register(RevenueBondContract, ());
+    let client = RevenueBondContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    let bond_id = client.issue_bond(
+        &issuer, &owner, &2_000_000, &BondStructure::Fixed,
+        &0, &500_000, &500_000, &12, &issue_period(&env), &attestation_contract, &token,
+    );
+
+    // Redeem a later period first, then an earlier one — both must succeed.
+    set_mock_revenue(&env, &issuer, "2026-03", 0);
+    set_mock_revenue(&env, &issuer, "2026-01", 0);
+    client.redeem(&bond_id, &String::from_str(&env, "2026-03"));
+    client.redeem(&bond_id, &String::from_str(&env, "2026-01"));
+    assert_eq!(client.get_total_redeemed(&bond_id), 1_000_000);
 }

--- a/contracts/revenue-bonds/src/test_maturity.rs
+++ b/contracts/revenue-bonds/src/test_maturity.rs
@@ -1,150 +1,169 @@
+#![cfg(test)]
+use super::*;
+use soroban_sdk::{testutils::Address as _, token, Address, Env, String};
+
+fn create_token_contract<'a>(env: &Env, admin: &Address) -> token::StellarAssetClient<'a> {
+    token::StellarAssetClient::new(
+        env,
+        &env.register_stellar_asset_contract_v2(admin.clone()).address(),
+    )
+}
+
+fn setup_test() -> (Env, Address, Address, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.mock_all_auths_allowing_non_root_auth();
+    let admin = Address::generate(&env);
+    let issuer = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_client = create_token_contract(&env, &token_admin);
+    let token = token_client.address.clone();
+    token_client.mint(&issuer, &100_000_000);
+    let attestation_contract = Address::generate(&env);
+    (env, admin, issuer, owner, token, attestation_contract)
+}
+
+fn set_mock_revenue(env: &Env, business: &Address, period: &str, revenue: i128) {
+    let p = String::from_str(env, period);
+    env.storage().temporary().set(
+        &(soroban_sdk::symbol_short!("rev"), business.clone(), p),
+        &revenue,
+    );
+}
+
+// ─── parse_period ─────────────────────────────────────────────────────────────
+
 #[test]
 fn test_parse_period_valid() {
     let env = Env::default();
     let p = String::from_str(&env, "2026-02");
-    let months = parse_period(&env, p);
-    assert_eq!(months, 2026u64 * 12 + 1);
+    assert_eq!(parse_period(&env, p), 2026u64 * 12 + 1);
 }
 
 #[test]
 #[should_panic(expected = "invalid period length")]
 fn test_parse_period_invalid_length() {
     let env = Env::default();
-    let p = String::from_str(&env, "2026-2");
-    parse_period(&env, p);
+    parse_period(&env, String::from_str(&env, "2026-2"));
 }
 
 #[test]
 #[should_panic(expected = "invalid year digit")]
 fn test_parse_period_invalid_digit() {
     let env = Env::default();
-    let p = String::from_str(&env, "202a-02");
-    parse_period(&env, p);
+    parse_period(&env, String::from_str(&env, "202a-02"));
+}
+
+// ─── is_period_within_maturity ────────────────────────────────────────────────
+
+fn make_bond(env: &Env, issue_period: &str, maturity_periods: u32) -> Bond {
+    let dummy = Address::generate(env);
+    Bond {
+        id: 0,
+        issuer: dummy.clone(),
+        face_value: 1_000_000,
+        structure: BondStructure::Fixed,
+        revenue_share_bps: 0,
+        min_payment_per_period: 100_000,
+        max_payment_per_period: 100_000,
+        maturity_periods,
+        attestation_contract: dummy.clone(),
+        token: dummy,
+        status: BondStatus::Active,
+        issued_at: 0,
+        issue_period: String::from_str(env, issue_period),
+    }
 }
 
 #[test]
 fn test_is_within_maturity_valid() {
     let env = Env::default();
-    let mut bond = Bond { issue_period: String::from_str(&env, "2026-01"), maturity_periods: 12, /* other */ .. };
+    let bond = make_bond(&env, "2026-01", 12);
     assert!(is_period_within_maturity(&env, &bond, String::from_str(&env, "2026-12")));
 }
 
 #[test]
 fn test_is_within_maturity_expired() {
     let env = Env::default();
-    let mut bond = Bond { issue_period: String::from_str(&env, "2026-01"), maturity_periods: 12, /* other */ .. };
+    let bond = make_bond(&env, "2026-01", 12);
     assert!(!is_period_within_maturity(&env, &bond, String::from_str(&env, "2027-01")));
 }
 
+// ─── Maturity enforcement via contract ───────────────────────────────────────
+
 #[test]
 fn test_redeem_within_maturity() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
-    let issue_period = String::from_str(&env, "2026-01");
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &1_000_000,
-        &BondStructure::Fixed,
-        &0,
-        &100_000,
-        &100_000,
-        &12,
-        &issue_period,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &1_000_000, &BondStructure::Fixed,
+        &0, &100_000, &100_000, &12,
+        &String::from_str(&env, "2026-01"),
+        &attestation_contract, &token,
     );
 
-    let period = String::from_str(&env, "2026-02");
-    client.redeem(&bond_id, &period, &500_000);
+    set_mock_revenue(&env, &issuer, "2026-02", 0);
+    client.redeem(&bond_id, &String::from_str(&env, "2026-02"));
 }
 
 #[test]
 #[should_panic(expected = "period exceeds maturity")]
 fn test_redeem_post_maturity_panics() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
-    let issue_period = String::from_str(&env, "2026-01");
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &1_000_000,
-        &BondStructure::Fixed,
-        &0,
-        &100_000,
-        &100_000,
-        &1,
-        &issue_period,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &1_000_000, &BondStructure::Fixed,
+        &0, &100_000, &100_000, &1,
+        &String::from_str(&env, "2026-01"),
+        &attestation_contract, &token,
     );
 
-    let expired_period = String::from_str(&env, "2026-02");
-    client.redeem(&bond_id, &expired_period, &500_000);
+    // maturity_periods=1 → only "2026-01" is valid; "2026-02" is past maturity.
+    set_mock_revenue(&env, &issuer, "2026-02", 0);
+    client.redeem(&bond_id, &String::from_str(&env, "2026-02"));
 }
 
 #[test]
 #[should_panic(expected = "bond not active")]
 fn test_redeem_matured_bond_panics() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
-    let issue_period = String::from_str(&env, "2026-01");
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &1_000_000,
-        &BondStructure::Fixed,
-        &0,
-        &100_000,
-        &100_000,
-        &1,
-        &issue_period,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &1_000_000, &BondStructure::Fixed,
+        &0, &100_000, &100_000, &12,
+        &String::from_str(&env, "2026-01"),
+        &attestation_contract, &token,
     );
 
     client.mark_matured(&admin, &bond_id);
-
-    let period = String::from_str(&env, "2026-02");
-    client.redeem(&bond_id, &period, &500_000);
+    set_mock_revenue(&env, &issuer, "2026-02", 0);
+    client.redeem(&bond_id, &String::from_str(&env, "2026-02"));
 }
 
 #[test]
 fn test_remaining_value_matured_is_zero() {
-    let (env, admin, issuer, owner, token, attestation_contract, _) = setup_test();
+    let (env, admin, issuer, owner, token, attestation_contract) = setup_test();
     let contract_id = env.register(RevenueBondContract, ());
     let client = RevenueBondContractClient::new(&env, &contract_id);
-
     client.initialize(&admin);
 
-    let issue_period = String::from_str(&env, "2026-01");
     let bond_id = client.issue_bond(
-        &issuer,
-        &owner,
-        &1_000_000,
-        &BondStructure::Fixed,
-        &0,
-        &100_000,
-        &100_000,
-        &12,
-        &issue_period,
-        &attestation_contract,
-        &token,
+        &issuer, &owner, &1_000_000, &BondStructure::Fixed,
+        &0, &100_000, &100_000, &12,
+        &String::from_str(&env, "2026-01"),
+        &attestation_contract, &token,
     );
 
     client.mark_matured(&admin, &bond_id);
     assert_eq!(client.get_remaining_value(&bond_id), 0);
 }
-

--- a/contracts/revenue-curve/src/lib.rs
+++ b/contracts/revenue-curve/src/lib.rs
@@ -183,6 +183,7 @@ impl RevenueCurveContract {
 
         // Validate tiers are sorted and discounts are reasonable
         let mut prev_revenue: Option<i128> = None;
+        let mut prev_discount: u32 = 0;
         for tier in tiers.iter() {
             assert!(tier.min_revenue >= 0, "min_revenue cannot be negative");
             if let Some(prev) = prev_revenue {
@@ -192,7 +193,12 @@ impl RevenueCurveContract {
                 );
             }
             assert!(tier.discount_bps <= 10000, "discount cannot exceed 100%");
+            assert!(
+                tier.discount_bps >= prev_discount,
+                "tier discounts must be non-decreasing (monotonic)"
+            );
             prev_revenue = Some(tier.min_revenue);
+            prev_discount = tier.discount_bps;
         }
 
         env.storage().instance().set(&DataKey::RevenueTiers, &tiers);

--- a/contracts/revenue-curve/src/test.rs
+++ b/contracts/revenue-curve/src/test.rs
@@ -898,3 +898,54 @@ fn test_stress_calculate_pricing_matches_quote_when_attestation_ok() {
     assert_eq!(c.tier_discount_bps, q.tier_discount_bps);
     assert_eq!(c.tier_level, q.tier_level);
 }
+
+#[test]
+#[should_panic(expected = "tier discounts must be non-decreasing (monotonic)")]
+fn test_non_monotonic_discounts_fail() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client, _, _) = setup(&env);
+
+    // Tier 2 has a lower discount than tier 1 — non-monotonic, must panic
+    let tiers = vec![
+        &env,
+        RevenueTier {
+            min_revenue: 100_000,
+            discount_bps: 200,
+        },
+        RevenueTier {
+            min_revenue: 500_000,
+            discount_bps: 100, // Lower than previous — violates monotonicity
+        },
+    ];
+
+    client.set_revenue_tiers(&admin, &tiers);
+}
+
+#[test]
+fn test_equal_discounts_across_tiers_allowed() {
+    // Equal discounts are non-decreasing, so they're allowed.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client, _, _) = setup(&env);
+
+    let tiers = vec![
+        &env,
+        RevenueTier {
+            min_revenue: 100_000,
+            discount_bps: 150,
+        },
+        RevenueTier {
+            min_revenue: 500_000,
+            discount_bps: 150, // Equal is OK
+        },
+        RevenueTier {
+            min_revenue: 1_000_000,
+            discount_bps: 200, // Increasing is OK
+        },
+    ];
+
+    client.set_revenue_tiers(&admin, &tiers);
+    let stored = client.get_revenue_tiers().unwrap();
+    assert_eq!(stored.len(), 3);
+}

--- a/docs/revenue-curve-parameters.md
+++ b/docs/revenue-curve-parameters.md
@@ -1,0 +1,173 @@
+# Revenue Curve Parameters
+
+## Overview
+
+The revenue curve contract calculates risk-adjusted APR for lending based on attested business revenue and anomaly scores. This document defines safe parameter ranges, monotonicity invariants, and admin responsibilities.
+
+## Security Invariants
+
+### 1. Monotonicity
+
+**Tier discounts must be non-decreasing**: Higher revenue tiers must have discounts ≥ lower tiers.
+
+- **Why**: Prevents non-monotonic pricing where higher revenue → higher APR.
+- **Enforcement**: `set_revenue_tiers` validates `tier[i].discount_bps >= tier[i-1].discount_bps`.
+- **Example violation**: Tier 1 (100k revenue, 200 bps discount), Tier 2 (500k revenue, 100 bps discount) → rejected.
+
+### 2. Tier Ordering
+
+**Tiers must be strictly ascending by `min_revenue`**: `tier[i].min_revenue > tier[i-1].min_revenue`.
+
+- **Why**: Ensures deterministic tier matching via linear scan.
+- **Enforcement**: `set_revenue_tiers` validates strict ordering.
+
+### 3. Arithmetic Safety
+
+**All intermediate calculations use saturating arithmetic**:
+
+- `anomaly_score * risk_premium_bps_per_point` → saturated at `u32::MAX`
+- `base_apr_bps + risk_premium_bps` → saturated at `u32::MAX` before discount
+- Final APR clamped to `[min_apr_bps, max_apr_bps]`
+
+**Why**: Prevents silent overflow under adversarial admin parameters.
+
+## Parameter Ranges
+
+### Pricing Policy
+
+| Parameter | Type | Range | Notes |
+|-----------|------|-------|-------|
+| `base_apr_bps` | `u32` | `[min_apr_bps, max_apr_bps]` | Starting APR before adjustments |
+| `min_apr_bps` | `u32` | `[0, max_apr_bps]` | Floor after all discounts |
+| `max_apr_bps` | `u32` | `[min_apr_bps, 10000]` | Ceiling (100% max) |
+| `risk_premium_bps_per_point` | `u32` | `[0, 1000]` | Per-anomaly-point premium (10% max per point) |
+| `enabled` | `bool` | — | Toggle for policy activation |
+
+### Revenue Tiers
+
+| Parameter | Type | Range | Notes |
+|-----------|------|-------|-------|
+| `min_revenue` | `i128` | `[0, i128::MAX]` | Negative revenue rejected |
+| `discount_bps` | `u32` | `[0, 10000]` | Must be ≥ previous tier's discount |
+| Tier count | — | `[0, 20]` | Maximum 20 tiers |
+
+### Anomaly Score
+
+| Parameter | Type | Range | Notes |
+|-----------|------|-------|-------|
+| `anomaly_score` | `u32` | `[0, 100]` | 0 = lowest risk, 100 = highest |
+
+## Failure Modes
+
+### Configuration Errors
+
+| Error | Cause | Prevention |
+|-------|-------|------------|
+| `min_apr must be <= max_apr` | Inverted bounds | Validate at `set_pricing_policy` |
+| `base_apr must be within [min_apr, max_apr]` | Base outside bounds | Validate at `set_pricing_policy` |
+| `max_apr cannot exceed 10000 bps` | APR > 100% | Hard cap at 10000 |
+| `risk premium per point cannot exceed 1000 bps` | Premium > 10% per point | Hard cap at 1000 |
+| `tiers must be sorted by min_revenue ascending` | Unsorted tiers | Validate strict ordering |
+| `tier discounts must be non-decreasing (monotonic)` | Discount regression | Validate monotonicity |
+| `discount cannot exceed 100%` | Discount > 10000 bps | Hard cap at 10000 |
+| `min_revenue cannot be negative` | Negative threshold | Reject at validation |
+| `maximum of 20 tiers allowed` | Too many tiers | Hard cap at 20 |
+
+### Runtime Errors
+
+| Error | Cause | Prevention |
+|-------|-------|------------|
+| `pricing policy not configured` | Missing policy | Admin must call `set_pricing_policy` |
+| `pricing policy is disabled` | `enabled = false` | Admin must enable policy |
+| `attestation contract not set` | Missing attestation link | Admin must call `set_attestation_contract` |
+| `attestation not found` | No attestation for period | Business must submit attestation first |
+| `attestation is revoked` | Revoked attestation | Revocation blocks pricing |
+| `anomaly_score must be <= 100` | Score out of range | Caller validation |
+
+## Admin Responsibilities
+
+### Initial Setup
+
+1. Call `initialize(admin)` once
+2. Call `set_attestation_contract(attestation_address)`
+3. Call `set_pricing_policy(policy)` with valid bounds
+4. (Optional) Call `set_revenue_tiers(tiers)` with monotonic discounts
+
+### Ongoing Maintenance
+
+- **Policy updates**: Ensure `min_apr <= base_apr <= max_apr` and `max_apr <= 10000`
+- **Tier updates**: Ensure discounts are non-decreasing and tiers are sorted
+- **Attestation contract migration**: Update `attestation_contract` address if needed
+- **Policy toggle**: Use `enabled` flag to temporarily disable pricing
+
+### Monitoring
+
+- **Discontinuities**: Large gaps in `min_revenue` between tiers can cause pricing jumps
+- **Extreme slopes**: `risk_premium_bps_per_point` near 1000 causes steep risk curves
+- **Tier count**: More tiers = finer granularity but higher gas cost
+
+## Examples
+
+### Safe Configuration
+
+```rust
+PricingPolicy {
+    base_apr_bps: 1000,             // 10%
+    min_apr_bps: 300,               // 3%
+    max_apr_bps: 3000,              // 30%
+    risk_premium_bps_per_point: 10, // 0.1% per anomaly point
+    enabled: true,
+}
+
+RevenueTier { min_revenue: 100_000, discount_bps: 50 },   // 0.5% discount
+RevenueTier { min_revenue: 500_000, discount_bps: 100 },  // 1% discount
+RevenueTier { min_revenue: 1_000_000, discount_bps: 200 }, // 2% discount
+```
+
+### Unsafe Configuration (Rejected)
+
+```rust
+// Non-monotonic discounts
+RevenueTier { min_revenue: 100_000, discount_bps: 200 },
+RevenueTier { min_revenue: 500_000, discount_bps: 100 }, // ❌ Lower than previous
+
+// Inverted bounds
+PricingPolicy {
+    min_apr_bps: 3000,
+    max_apr_bps: 300, // ❌ min > max
+    ...
+}
+
+// Base outside bounds
+PricingPolicy {
+    base_apr_bps: 5000,
+    min_apr_bps: 300,
+    max_apr_bps: 3000, // ❌ base > max
+    ...
+}
+```
+
+## Pricing Formula
+
+```
+risk_premium_bps = min(anomaly_score * risk_premium_bps_per_point, u32::MAX)
+combined_bps = min(base_apr_bps + risk_premium_bps, u32::MAX)
+apr_after_discount = combined_bps - tier_discount_bps  (saturating)
+final_apr_bps = clamp(apr_after_discount, min_apr_bps, max_apr_bps)
+```
+
+## Testing Recommendations
+
+- **Monotonicity**: Test non-monotonic discount rejection
+- **Extreme slopes**: Test `risk_premium_bps_per_point = u32::MAX`
+- **Discontinuities**: Test large tier gaps (e.g., 0 → 1M → 10M)
+- **Overflow**: Test `base_apr_bps = u32::MAX` with high anomaly scores
+- **Boundary**: Test `anomaly_score = 0` and `100`
+- **Negative revenue**: Test `min_revenue < 0` rejection
+- **Tier count**: Test 20-tier limit
+
+## References
+
+- Contract: `contracts/revenue-curve/src/lib.rs`
+- Tests: `contracts/revenue-curve/src/test.rs`
+- Attestation integration: `docs/attestation-dynamic-fees.md`


### PR DESCRIPTION
closes: #244 

  - Add monotonicity validation: tier discounts must be non-decreasing
  - Prevent non-monotonic pricing where higher revenue -> higher APR
  - Add tests: non-monotonic discount rejection, equal discounts allowed
  - Document safe parameter ranges, invariants, failure modes in docs/revenue-curve-parameters.md
  - All existing bounds already validated: max_apr <= 10000, risk_premium <= 1000, saturating arithmetic