### PR TITLE
fix: formalize attestation event payload contract for indexers

### DIFF
--- a/contracts/attestation/src/events.rs
+++ b/contracts/attestation/src/events.rs
@@ -40,6 +40,26 @@
 //! | `BusinessSuspended`         | `biz_sus`      | `business`        |
 //! | `BusinessReactivated`       | `biz_rea`      | `business`        |
 //!
+//! ## Indexer Compatibility Contract
+//!
+//! The attestation lifecycle events in this module (`att_sub`, `att_rev`,
+//! `att_mig`) are a stable wire contract for off-chain indexers.
+//!
+//! Compatibility rules:
+//! - Topic symbols are stable identifiers and MUST NOT be repurposed.
+//! - Field order inside `#[contracttype]` structs is stable.
+//! - Backwards-compatible additions are append-only optional fields.
+//! - Removing, renaming, reordering, or changing field types is breaking.
+//!
+//! Breaking-change policy:
+//! - Increment `EVENT_SCHEMA_VERSION` for any breaking event-schema change.
+//! - Update indexer-facing documentation in `docs/attestation-events-indexer.md`.
+//! - Preserve old historical events; never rewrite or reinterpret ledger history.
+//!
+//! Duplicate-handling note for indexers:
+//! - Failed submissions/migrations do not emit attestation lifecycle events.
+//! - Replays are prevented via nonce checks at contract entrypoints.
+//!
 //! ## Security Notes
 //!
 //! - Only contract-internal logic calls these functions; no external caller can
@@ -59,6 +79,9 @@ use soroban_sdk::{contracttype, symbol_short, Address, BytesN, Env, String, Symb
 /// Increment this constant whenever a breaking field change is made to *any*
 /// event struct in this module so that off-chain indexers can detect and
 /// handle schema changes.
+///
+/// Non-breaking changes (for example, appending new optional fields at the
+/// end of a struct) MUST NOT increment this version.
 pub const EVENT_SCHEMA_VERSION: u32 = 1;
 
 // ════════════════════════════════════════════════════════════════════
@@ -120,6 +143,9 @@ pub const TOPIC_BIZ_REACTIVATE: Symbol = symbol_short!("biz_rea");
 /// Emitted once per successful `submit_attestation` call.  The
 /// `proof_hash` and `expiry_timestamp` fields are optional and will
 /// be `None` when the submitter did not provide them.
+///
+/// This struct is an indexer-facing wire contract; field order and types are
+/// part of compatibility guarantees.
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct AttestationSubmittedEvent {
@@ -145,6 +171,9 @@ pub struct AttestationSubmittedEvent {
 ///
 /// Emitted once per successful `revoke_attestation` call.  The
 /// `reason` field is a free-form string supplied by the revoker.
+///
+/// This struct is an indexer-facing wire contract; field order and types are
+/// part of compatibility guarantees.
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct AttestationRevokedEvent {
@@ -162,6 +191,9 @@ pub struct AttestationRevokedEvent {
 ///
 /// Contains both old and new values so indexers can reconstruct the
 /// full audit trail without additional storage reads.
+///
+/// This struct is an indexer-facing wire contract; field order and types are
+/// part of compatibility guarantees.
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct AttestationMigratedEvent {

--- a/contracts/attestation/src/events_test.rs
+++ b/contracts/attestation/src/events_test.rs
@@ -688,27 +688,46 @@ fn test_revoke_nonexistent_attestation_panics() {
 }
 
 #[test]
-#[should_panic(expected = "attestation already exists")]
 fn test_duplicate_attestation_panics_no_double_event() {
     let (env, client, _admin) = setup();
     let business = Address::generate(&env);
     let period = String::from_str(&env, "2026-02");
-    // First submit
+
     submit_default(&client, &env, &business, &period, 0);
-    // Second submit for same period must panic — no event should be emitted
-    submit_default(&client, &env, &business, &period, 1);
+    let events_after_first = env.events().all().len();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        submit_default(&client, &env, &business, &period, 1);
+    }));
+
+    assert!(result.is_err(), "expected duplicate submission to panic");
+    assert_eq!(
+        env.events().all().len(),
+        events_after_first,
+        "failed duplicate submission must not emit an additional event"
+    );
 }
 
 #[test]
-#[should_panic(expected = "new version must be greater than old version")]
 fn test_migrate_same_version_panics_no_event() {
     let (env, client, admin) = setup();
     let business = Address::generate(&env);
     let period = String::from_str(&env, "2026-02");
     submit_default(&client, &env, &business, &period, 0);
     let new_root = BytesN::from_array(&env, &[2u8; 32]);
-    // Same version — must panic before event is emitted
-    client.migrate_attestation(&admin, &business, &period, &new_root, &1u32, &1u64);
+
+    let events_before_migration = env.events().all().len();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.migrate_attestation(&admin, &business, &period, &new_root, &1u32, &1u64);
+    }));
+
+    assert!(result.is_err(), "expected same-version migration to panic");
+    assert_eq!(
+        env.events().all().len(),
+        events_before_migration,
+        "failed migration must not emit an additional event"
+    );
 }
 
 #[test]

--- a/docs/attestation-events-indexer.md
+++ b/docs/attestation-events-indexer.md
@@ -1,0 +1,133 @@
+# Attestation Event Payload Specification for Indexers
+
+This document formalizes the attestation lifecycle event payloads emitted by the `attestation` contract for off-chain indexers.
+
+## Scope
+
+This specification covers the following events only:
+
+- `AttestationSubmittedEvent` with topic `(att_sub, business)`
+- `AttestationRevokedEvent` with topic `(att_rev, business)`
+- `AttestationMigratedEvent` with topic `(att_mig, business)`
+
+Source of truth for payload structs and topic symbols:
+- `contracts/attestation/src/events.rs`
+
+## Event Topics and Payloads
+
+### 1. AttestationSubmittedEvent
+
+Topic:
+- Primary: `att_sub`
+- Secondary: `business` (`Address`)
+
+Payload fields:
+- `business: Address`
+  - Business that submitted the attestation.
+- `period: String`
+  - Period identifier used as part of the attestation key.
+- `merkle_root: BytesN<32>`
+  - Merkle root commitment for the attested dataset.
+- `timestamp: u64`
+  - Submission timestamp carried in attestation data.
+- `version: u32`
+  - Attestation payload version provided at submission.
+- `fee_paid: i128`
+  - Total fee charged for the submission.
+- `proof_hash: Option<BytesN<32>>`
+  - Optional off-chain proof commitment hash.
+- `expiry_timestamp: Option<u64>`
+  - Optional attestation expiry timestamp.
+
+Emission conditions:
+- Emitted once after a successful `submit_attestation` state write.
+- Not emitted if submission fails (for example duplicate key, failed auth, failed nonce, validation failure).
+
+### 2. AttestationRevokedEvent
+
+Topic:
+- Primary: `att_rev`
+- Secondary: `business` (`Address`)
+
+Payload fields:
+- `business: Address`
+  - Business whose attestation was revoked.
+- `period: String`
+  - Period identifier of revoked attestation.
+- `revoked_by: Address`
+  - Address that executed revocation.
+- `reason: String`
+  - Free-form revocation reason persisted on-chain.
+
+Emission conditions:
+- Emitted once after revocation metadata is stored.
+- Not emitted if revocation fails (for example missing attestation, already revoked, failed auth).
+
+### 3. AttestationMigratedEvent
+
+Topic:
+- Primary: `att_mig`
+- Secondary: `business` (`Address`)
+
+Payload fields:
+- `business: Address`
+  - Business whose attestation was migrated.
+- `period: String`
+  - Period identifier of migrated attestation.
+- `old_merkle_root: BytesN<32>`
+  - Previous root.
+- `new_merkle_root: BytesN<32>`
+  - New root after migration.
+- `old_version: u32`
+  - Previous attestation version.
+- `new_version: u32`
+  - New attestation version.
+- `migrated_by: Address`
+  - Address that executed migration.
+
+Emission conditions:
+- Emitted once after migrated attestation data is written.
+- Not emitted if migration fails (for example version monotonicity failure, missing attestation, failed auth).
+
+## Schema Versioning Rules
+
+- Current schema version constant: `EVENT_SCHEMA_VERSION` in `contracts/attestation/src/events.rs`.
+- Topic symbol and field order/type define the wire contract for indexers.
+- A schema change is considered breaking when it does any of the following:
+  - Removes a field
+  - Renames a field
+  - Reorders fields
+  - Changes a field type
+  - Repurposes an existing topic symbol
+- Breaking changes MUST increment `EVENT_SCHEMA_VERSION` and update this document.
+
+Non-breaking changes:
+- Appending a new optional field to the end of an event struct.
+- Clarifying documentation without changing wire shape.
+
+## Breaking-Change Policy
+
+For any breaking event schema change:
+
+1. Increment `EVENT_SCHEMA_VERSION`.
+2. Keep historical ledger events unchanged.
+3. Update indexer documentation before release.
+4. Communicate migration impact to downstream indexers.
+
+## Duplicate Event Handling Guidance
+
+Indexers should treat `(contract_id, ledger, tx_hash, event_index)` as the unique event identity.
+
+Operational guidance:
+- Do not deduplicate solely by `(business, period)` because valid lifecycle progression can include:
+  - one `att_sub`
+  - followed later by `att_mig`
+  - and potentially `att_rev`
+- Failed duplicate submissions and invalid migrations do not emit additional lifecycle events.
+- Nonce enforcement prevents successful replay of identical business-authenticated submissions.
+
+## Security and Reliability Notes
+
+- Event emission is contract-internal and follows successful authorization and state transition checks.
+- Event payloads intentionally avoid private key or raw signature material.
+- For strong consistency, indexers should pair event ingestion with occasional state reconciliation reads for mission-critical workflows.


### PR DESCRIPTION

Closes #218

---

### Issue Summary

Formalizes the attestation lifecycle event contract for off-chain indexers, covering submitted, revoked, and migrated event payloads, field semantics, and schema compatibility rules.

---

### Root Cause

- Event structs and topics already existed but no dedicated indexer specification document was present
- No explicit negative assertion confirmed that failed duplicate/migration attempts do not emit extra lifecycle events

---

### Fix Implemented

- Added indexer-compatibility and breaking-change policy Rustdoc in `events.rs`
- Added/updated negative tests in `events_test.rs` to assert event-log count is unchanged on duplicate submission and invalid same-version migration failures
- Added formal indexer documentation in `attestation-events-indexer.md` including field definitions, emission conditions, schema evolution rules, and duplicate handling guidance

---

### Testing Performed

- Added negative test assertions for duplicate submission and invalid same-version migration failure paths
- Verified event-log count remains unchanged on all negative paths

---

### References

- Closes #218
- Updated: `events.rs`, `events_test.rs`, `attestation-events-indexer.md`