### PR TITLE
fix: validate integration connector metadata bounds

### DIFF
--- a/contracts/integration-registry/src/lib.rs
+++ b/contracts/integration-registry/src/lib.rs
@@ -109,6 +109,13 @@ pub struct Provider {
     pub registered_by: Address,
 }
 
+/// Maximum allowed bytes for provider metadata fields.
+pub const MAX_PROVIDER_METADATA_NAME_BYTES: u32 = 64;
+pub const MAX_PROVIDER_METADATA_DESCRIPTION_BYTES: u32 = 512;
+pub const MAX_PROVIDER_METADATA_API_VERSION_BYTES: u32 = 32;
+pub const MAX_PROVIDER_METADATA_DOCS_URL_BYTES: u32 = 256;
+pub const MAX_PROVIDER_METADATA_CATEGORY_BYTES: u32 = 32;
+
 // ════════════════════════════════════════════════════════════════════
 //  Event Topics
 // ════════════════════════════════════════════════════════════════════
@@ -264,7 +271,7 @@ impl IntegrationRegistryContract {
             .instance()
             .get(&DataKey::NamespaceList)
             .unwrap_or_else(|| Vec::new(&env));
-        
+
         // Ensure uniqueness in list (optional, but good practice)
         let mut exists = false;
         for i in 0..namespaces.len() {
@@ -275,7 +282,9 @@ impl IntegrationRegistryContract {
         }
         if !exists {
             namespaces.push_back(namespace.clone());
-            env.storage().instance().set(&DataKey::NamespaceList, &namespaces);
+            env.storage()
+                .instance()
+                .set(&DataKey::NamespaceList, &namespaces);
         }
 
         // Emit event
@@ -284,7 +293,8 @@ impl IntegrationRegistryContract {
             account: initial_owner,
             changed_by: caller,
         };
-        env.events().publish((symbol_short!("ns_reg"), namespace), event);
+        env.events()
+            .publish((symbol_short!("ns_reg"), namespace), event);
     }
 
     /// Grant ownership of a namespace to an address.
@@ -307,9 +317,10 @@ impl IntegrationRegistryContract {
             nonce,
         );
 
-        env.storage()
-            .instance()
-            .set(&DataKey::NamespaceGovernance(namespace.clone(), account.clone()), &true);
+        env.storage().instance().set(
+            &DataKey::NamespaceGovernance(namespace.clone(), account.clone()),
+            &true,
+        );
 
         // Emit event
         let event = NamespaceEvent {
@@ -317,7 +328,8 @@ impl IntegrationRegistryContract {
             account,
             changed_by: caller,
         };
-        env.events().publish((symbol_short!("ns_grnt"), namespace), event);
+        env.events()
+            .publish((symbol_short!("ns_grnt"), namespace), event);
     }
 
     /// Revoke ownership of a namespace from an address.
@@ -340,9 +352,10 @@ impl IntegrationRegistryContract {
             nonce,
         );
 
-        env.storage()
-            .instance()
-            .set(&DataKey::NamespaceGovernance(namespace.clone(), account.clone()), &false);
+        env.storage().instance().set(
+            &DataKey::NamespaceGovernance(namespace.clone(), account.clone()),
+            &false,
+        );
 
         // Emit event
         let event = NamespaceEvent {
@@ -350,7 +363,8 @@ impl IntegrationRegistryContract {
             account,
             changed_by: caller,
         };
-        env.events().publish((symbol_short!("ns_rvk"), namespace), event);
+        env.events()
+            .publish((symbol_short!("ns_rvk"), namespace), event);
     }
 
     // ── Provider Registration ───────────────────────────────────────
@@ -363,6 +377,10 @@ impl IntegrationRegistryContract {
     /// * `caller` - Must have governance role
     /// * `id` - Unique provider identifier (e.g., "stripe")
     /// * `metadata` - Provider metadata
+    ///
+    /// Metadata is validated for bounded storage and unambiguous formatting:
+    /// all fields must be non-empty, within max byte limits, and must not
+    /// have leading or trailing ASCII whitespace.
     ///
     /// Replay protection: uses the caller address and `NONCE_CHANNEL_GOVERNANCE`.
     pub fn register_provider(
@@ -380,6 +398,7 @@ impl IntegrationRegistryContract {
             Self::NONCE_CHANNEL_GOVERNANCE,
             nonce,
         );
+        Self::validate_provider_metadata(&metadata);
 
         let key = DataKey::Provider(namespace.clone(), id.clone());
         if env.storage().instance().has(&key) {
@@ -405,9 +424,10 @@ impl IntegrationRegistryContract {
             .get(&DataKey::NamespaceProviderList(namespace.clone()))
             .unwrap_or_else(|| Vec::new(&env));
         providers.push_back(id.clone());
-        env.storage()
-            .instance()
-            .set(&DataKey::NamespaceProviderList(namespace.clone()), &providers);
+        env.storage().instance().set(
+            &DataKey::NamespaceProviderList(namespace.clone()),
+            &providers,
+        );
 
         // Emit event
         let event = ProviderEvent {
@@ -468,7 +488,13 @@ impl IntegrationRegistryContract {
     /// Deprecated providers are still valid but discouraged for new attestations.
     ///
     /// Replay protection: uses the caller address and `NONCE_CHANNEL_GOVERNANCE`.
-    pub fn deprecate_provider(env: Env, caller: Address, namespace: String, id: String, nonce: u64) {
+    pub fn deprecate_provider(
+        env: Env,
+        caller: Address,
+        namespace: String,
+        id: String,
+        nonce: u64,
+    ) {
         Self::require_namespace_governance(&env, &namespace, &caller);
         replay_protection::verify_and_increment_nonce(
             &env,
@@ -549,6 +575,9 @@ impl IntegrationRegistryContract {
     ///
     /// Can be called on any provider regardless of status.
     ///
+    /// Metadata validation uses the same bounded and ambiguity-resistant
+    /// rules as [`register_provider`].
+    ///
     /// Replay protection: uses the caller address and `NONCE_CHANNEL_GOVERNANCE`.
     pub fn update_metadata(
         env: Env,
@@ -565,6 +594,7 @@ impl IntegrationRegistryContract {
             Self::NONCE_CHANNEL_GOVERNANCE,
             nonce,
         );
+        Self::validate_provider_metadata(&metadata);
 
         let key = DataKey::Provider(namespace.clone(), id.clone());
         let mut provider: Provider = env
@@ -591,7 +621,9 @@ impl IntegrationRegistryContract {
 
     /// Get a provider by ID and namespace.
     pub fn get_provider(env: Env, namespace: String, id: String) -> Option<Provider> {
-        env.storage().instance().get(&DataKey::Provider(namespace, id))
+        env.storage()
+            .instance()
+            .get(&DataKey::Provider(namespace, id))
     }
 
     /// Check if a provider is enabled.
@@ -703,7 +735,11 @@ impl IntegrationRegistryContract {
     /// Returns true if the address is a namespace owner, global governance, or admin.
     pub fn has_namespace_governance(env: Env, namespace: String, account: Address) -> bool {
         // Admin has global access
-        if let Some(admin) = env.storage().instance().get::<DataKey, Address>(&DataKey::Admin) {
+        if let Some(admin) = env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::Admin)
+        {
             if account == admin {
                 return true;
             }
@@ -753,11 +789,74 @@ impl IntegrationRegistryContract {
     }
 
     fn is_admin(env: &Env, account: &Address) -> bool {
-        if let Some(admin) = env.storage().instance().get::<DataKey, Address>(&DataKey::Admin) {
+        if let Some(admin) = env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::Admin)
+        {
             account == &admin
         } else {
             false
         }
+    }
+
+    fn validate_provider_metadata(metadata: &ProviderMetadata) {
+        Self::validate_metadata_field(
+            &metadata.name,
+            MAX_PROVIDER_METADATA_NAME_BYTES,
+            "provider name cannot be empty",
+            "provider name exceeds max bytes",
+            "provider name has leading or trailing whitespace",
+        );
+        Self::validate_metadata_field(
+            &metadata.description,
+            MAX_PROVIDER_METADATA_DESCRIPTION_BYTES,
+            "provider description cannot be empty",
+            "provider description exceeds max bytes",
+            "provider description has leading or trailing whitespace",
+        );
+        Self::validate_metadata_field(
+            &metadata.api_version,
+            MAX_PROVIDER_METADATA_API_VERSION_BYTES,
+            "provider api version cannot be empty",
+            "provider api version exceeds max bytes",
+            "provider api version has leading or trailing whitespace",
+        );
+        Self::validate_metadata_field(
+            &metadata.docs_url,
+            MAX_PROVIDER_METADATA_DOCS_URL_BYTES,
+            "provider docs url cannot be empty",
+            "provider docs url exceeds max bytes",
+            "provider docs url has leading or trailing whitespace",
+        );
+        Self::validate_metadata_field(
+            &metadata.category,
+            MAX_PROVIDER_METADATA_CATEGORY_BYTES,
+            "provider category cannot be empty",
+            "provider category exceeds max bytes",
+            "provider category has leading or trailing whitespace",
+        );
+    }
+
+    fn validate_metadata_field(
+        field: &String,
+        max_len: u32,
+        empty_msg: &str,
+        max_msg: &str,
+        whitespace_msg: &str,
+    ) {
+        let len = field.len();
+        assert!(len > 0, "{}", empty_msg);
+        assert!(len <= max_len, "{}", max_msg);
+
+        let bytes = field.as_bytes();
+        let first = bytes.get(0).unwrap();
+        let last = bytes.get(len - 1).unwrap();
+        assert!(
+            !first.is_ascii_whitespace() && !last.is_ascii_whitespace(),
+            "{}",
+            whitespace_msg
+        );
     }
 
     /// Get the current nonce for a given `(actor, channel)` pair.

--- a/contracts/integration-registry/src/test.rs
+++ b/contracts/integration-registry/src/test.rs
@@ -8,18 +8,23 @@ use soroban_sdk::testutils::Address as _;
 use soroban_sdk::{Address, Env, String};
 
 /// Helper: register the contract and return a client.
-fn setup() -> (Env, IntegrationRegistryContractClient<'static>, Address, String) {
+fn setup() -> (
+    Env,
+    IntegrationRegistryContractClient<'static>,
+    Address,
+    String,
+) {
     let env = Env::default();
     env.mock_all_auths();
     let contract_id = env.register(IntegrationRegistryContract, ());
     let client = IntegrationRegistryContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
     client.initialize(&admin, &0u64);
-    
+
     // Register a default 'global' namespace
     let namespace = String::from_str(&env, "global");
     client.register_namespace(&admin, &namespace, &admin, &0u64);
-    
+
     (env, client, admin, namespace)
 }
 
@@ -32,6 +37,37 @@ fn sample_metadata(env: &Env) -> ProviderMetadata {
         docs_url: String::from_str(env, "https://stripe.com/docs"),
         category: String::from_str(env, "payment"),
     }
+}
+
+/// Helper: create metadata with explicit byte lengths for each field.
+fn metadata_with_lengths(
+    env: &Env,
+    name_len: u32,
+    description_len: u32,
+    api_version_len: u32,
+    docs_url_len: u32,
+    category_len: u32,
+) -> ProviderMetadata {
+    ProviderMetadata {
+        name: String::from_str(env, &"n".repeat(name_len as usize)),
+        description: String::from_str(env, &"d".repeat(description_len as usize)),
+        api_version: String::from_str(env, &"v".repeat(api_version_len as usize)),
+        docs_url: String::from_str(env, &"u".repeat(docs_url_len as usize)),
+        category: String::from_str(env, &"c".repeat(category_len as usize)),
+    }
+}
+
+/// Helper: provision a namespace owned by a dedicated non-admin account.
+fn setup_namespace_owner(
+    env: &Env,
+    client: &IntegrationRegistryContractClient<'static>,
+    admin: &Address,
+    namespace: &str,
+) -> (Address, String) {
+    let owner = Address::generate(env);
+    let ns = String::from_str(env, namespace);
+    client.register_namespace(admin, &ns, &owner, &1u64);
+    (owner, ns)
 }
 
 // ════════════════════════════════════════════════════════════════════
@@ -210,7 +246,7 @@ fn test_update_metadata() {
     let id = String::from_str(&env, "stripe");
     let metadata = sample_metadata(&env);
 
-    client.register_provider(&admin, &ns, &id, &metadata, &0u64);
+    client.register_provider(&admin, &ns, &id, &metadata, &1u64);
 
     let new_metadata = ProviderMetadata {
         name: String::from_str(&env, "Stripe v2"),
@@ -220,7 +256,7 @@ fn test_update_metadata() {
         category: String::from_str(&env, "payment"),
     };
 
-    client.update_metadata(&admin, &ns, &id, &new_metadata, &1u64);
+    client.update_metadata(&admin, &ns, &id, &new_metadata, &2u64);
 
     let provider = client.get_provider(&ns, &id).unwrap();
     assert_eq!(provider.metadata.name, new_metadata.name);
@@ -230,11 +266,107 @@ fn test_update_metadata() {
 #[test]
 #[should_panic(expected = "provider not found")]
 fn test_update_nonexistent_provider_panics() {
-    let (env, client, admin) = setup();
+    let (env, client, admin, ns) = setup();
     let id = String::from_str(&env, "nonexistent");
     let metadata = sample_metadata(&env);
 
-    client.update_metadata(&admin, &id, &metadata, &0u64);
+    client.update_metadata(&admin, &ns, &id, &metadata, &1u64);
+}
+
+#[test]
+fn test_register_provider_accepts_metadata_at_max_bounds() {
+    let (env, client, admin, _ns) = setup();
+    let (owner, ns) = setup_namespace_owner(&env, &client, &admin, "metadata_bounds_ok");
+    let id = String::from_str(&env, "stripe");
+    let metadata = metadata_with_lengths(
+        &env,
+        MAX_PROVIDER_METADATA_NAME_BYTES,
+        MAX_PROVIDER_METADATA_DESCRIPTION_BYTES,
+        MAX_PROVIDER_METADATA_API_VERSION_BYTES,
+        MAX_PROVIDER_METADATA_DOCS_URL_BYTES,
+        MAX_PROVIDER_METADATA_CATEGORY_BYTES,
+    );
+
+    client.register_provider(&owner, &ns, &id, &metadata, &0u64);
+
+    let provider = client.get_provider(&ns, &id).unwrap();
+    assert_eq!(
+        provider.metadata.name.len(),
+        MAX_PROVIDER_METADATA_NAME_BYTES
+    );
+    assert_eq!(
+        provider.metadata.description.len(),
+        MAX_PROVIDER_METADATA_DESCRIPTION_BYTES
+    );
+    assert_eq!(
+        provider.metadata.api_version.len(),
+        MAX_PROVIDER_METADATA_API_VERSION_BYTES
+    );
+    assert_eq!(
+        provider.metadata.docs_url.len(),
+        MAX_PROVIDER_METADATA_DOCS_URL_BYTES
+    );
+    assert_eq!(
+        provider.metadata.category.len(),
+        MAX_PROVIDER_METADATA_CATEGORY_BYTES
+    );
+}
+
+#[test]
+#[should_panic(expected = "provider description exceeds max bytes")]
+fn test_register_provider_rejects_oversized_description() {
+    let (env, client, admin, _ns) = setup();
+    let (owner, ns) = setup_namespace_owner(&env, &client, &admin, "metadata_desc_oversize");
+    let id = String::from_str(&env, "stripe");
+    let metadata = metadata_with_lengths(
+        &env,
+        6,
+        MAX_PROVIDER_METADATA_DESCRIPTION_BYTES + 1,
+        2,
+        18,
+        7,
+    );
+
+    client.register_provider(&owner, &ns, &id, &metadata, &0u64);
+}
+
+#[test]
+#[should_panic(expected = "provider name cannot be empty")]
+fn test_register_provider_rejects_empty_name() {
+    let (env, client, admin, _ns) = setup();
+    let (owner, ns) = setup_namespace_owner(&env, &client, &admin, "metadata_name_empty");
+    let id = String::from_str(&env, "stripe");
+    let mut metadata = sample_metadata(&env);
+    metadata.name = String::from_str(&env, "");
+
+    client.register_provider(&owner, &ns, &id, &metadata, &0u64);
+}
+
+#[test]
+#[should_panic(expected = "provider category has leading or trailing whitespace")]
+fn test_register_provider_rejects_category_with_edge_whitespace() {
+    let (env, client, admin, _ns) = setup();
+    let (owner, ns) = setup_namespace_owner(&env, &client, &admin, "metadata_category_ws");
+    let id = String::from_str(&env, "stripe");
+    let mut metadata = sample_metadata(&env);
+    metadata.category = String::from_str(&env, " payment");
+
+    client.register_provider(&owner, &ns, &id, &metadata, &0u64);
+}
+
+#[test]
+#[should_panic(expected = "provider docs url exceeds max bytes")]
+fn test_update_metadata_rejects_oversized_docs_url() {
+    let (env, client, admin, _ns) = setup();
+    let (owner, ns) = setup_namespace_owner(&env, &client, &admin, "metadata_docs_oversize");
+    let id = String::from_str(&env, "stripe");
+    let metadata = sample_metadata(&env);
+
+    client.register_provider(&owner, &ns, &id, &metadata, &0u64);
+
+    let updated =
+        metadata_with_lengths(&env, 6, 24, 2, MAX_PROVIDER_METADATA_DOCS_URL_BYTES + 1, 7);
+    client.update_metadata(&owner, &ns, &id, &updated, &1u64);
 }
 
 // ════════════════════════════════════════════════════════════════════
@@ -311,13 +443,19 @@ fn test_get_status() {
     assert!(client.get_status(&ns, &id).is_none());
 
     client.register_provider(&admin, &ns, &id, &metadata, &0u64);
-    assert_eq!(client.get_status(&ns, &id), Some(ProviderStatus::Registered));
+    assert_eq!(
+        client.get_status(&ns, &id),
+        Some(ProviderStatus::Registered)
+    );
 
     client.enable_provider(&admin, &ns, &id, &1u64);
     assert_eq!(client.get_status(&ns, &id), Some(ProviderStatus::Enabled));
 
     client.deprecate_provider(&admin, &ns, &id, &2u64);
-    assert_eq!(client.get_status(&ns, &id), Some(ProviderStatus::Deprecated));
+    assert_eq!(
+        client.get_status(&ns, &id),
+        Some(ProviderStatus::Deprecated)
+    );
 
     client.disable_provider(&admin, &ns, &id, &3u64);
     assert_eq!(client.get_status(&ns, &id), Some(ProviderStatus::Disabled));
@@ -398,22 +536,22 @@ fn test_grant_governance_non_admin_panics() {
 #[test]
 fn test_namespace_isolation() {
     let (env, client, admin, _ns) = setup();
-    
+
     let ns_a = String::from_str(&env, "ns_a");
     let ns_b = String::from_str(&env, "ns_b");
     let owner_a = Address::generate(&env);
     let owner_b = Address::generate(&env);
-    
+
     client.register_namespace(&admin, &ns_a, &owner_a, &1u64);
     client.register_namespace(&admin, &ns_b, &owner_b, &2u64);
-    
+
     let id = String::from_str(&env, "provider");
     let metadata = sample_metadata(&env);
-    
+
     // owner_a can register in ns_a
     client.register_provider(&owner_a, &ns_a, &id, &metadata, &0u64);
     assert!(client.get_provider(&ns_a, &id).is_some());
-    
+
     // owner_a CANNOT register in ns_b
     let res = env.try_invoke_contract::<()>(
         &client.contract_id,
@@ -421,15 +559,15 @@ fn test_namespace_isolation() {
         (&owner_a, &ns_b, &id, &metadata, &1u64).into_val(&env),
     );
     assert!(res.is_err());
-    
+
     // owner_b can register same ID in ns_b
     client.register_provider(&owner_b, &ns_b, &id, &metadata, &0u64);
     assert!(client.get_provider(&ns_b, &id).is_some());
-    
+
     // owner_a can update ns_a
     client.enable_provider(&owner_a, &ns_a, &id, &2u64);
     assert!(client.is_enabled(&ns_a, &id));
-    
+
     // owner_a CANNOT update ns_b
     let res = env.try_invoke_contract::<()>(
         &client.contract_id,
@@ -445,10 +583,10 @@ fn test_admin_override() {
     let ns = String::from_str(&env, "private");
     let owner = Address::generate(&env);
     client.register_namespace(&admin, &ns, &owner, &1u64);
-    
+
     let id = String::from_str(&env, "provider");
     let metadata = sample_metadata(&env);
-    
+
     // Admin can register in any namespace without being explicit owner
     client.register_provider(&admin, &ns, &id, &metadata, &2u64);
     assert!(client.get_provider(&ns, &id).is_some());

--- a/docs/integration-registry-metadata.md
+++ b/docs/integration-registry-metadata.md
@@ -1,0 +1,69 @@
+# Integration Registry Metadata Validation
+
+This document defines the metadata validation rules for integration providers in the integration-registry contract.
+
+## Scope
+
+Validation applies to:
+
+- `register_provider(caller, namespace, id, metadata, nonce)`
+- `update_metadata(caller, namespace, id, metadata, nonce)`
+
+Both methods enforce the same metadata rules.
+
+## Metadata Bounds
+
+`ProviderMetadata` fields are bounded in bytes:
+
+- `name`: 1..=64
+- `description`: 1..=512
+- `api_version`: 1..=32
+- `docs_url`: 1..=256
+- `category`: 1..=32
+
+Additional ambiguity guard:
+
+- Each field must not begin or end with ASCII whitespace.
+
+## Security Invariants
+
+- Bounded storage growth: oversized metadata is rejected before storage writes.
+- Deterministic validation: metadata accepted at registration can be updated only with equally valid metadata.
+- Namespace isolation preserved: provider identity remains `(namespace, id)`.
+- Duplicate connector IDs in the same namespace remain rejected.
+- Revocation/status transitions are unchanged: metadata validation does not alter `Enabled`, `Deprecated`, `Disabled` semantics.
+
+## Failure Modes
+
+The contract panics with explicit messages when validation fails, including:
+
+- `provider name cannot be empty`
+- `provider name exceeds max bytes`
+- `provider name has leading or trailing whitespace`
+- `provider description cannot be empty`
+- `provider description exceeds max bytes`
+- `provider description has leading or trailing whitespace`
+- `provider api version cannot be empty`
+- `provider api version exceeds max bytes`
+- `provider api version has leading or trailing whitespace`
+- `provider docs url cannot be empty`
+- `provider docs url exceeds max bytes`
+- `provider docs url has leading or trailing whitespace`
+- `provider category cannot be empty`
+- `provider category exceeds max bytes`
+- `provider category has leading or trailing whitespace`
+
+## Authorization Responsibilities
+
+Writers must still satisfy existing governance checks:
+
+- Only namespace governance (or admin/global governance through existing checks) can register providers.
+- Only namespace governance can update metadata.
+
+Validation is additive to auth checks and replay-protection nonces.
+
+## Operational Guidance
+
+- Off-chain clients should pre-validate metadata lengths before submitting transactions.
+- Keep metadata canonical (no edge whitespace) to avoid duplicate-looking entries in indexers and dashboards.
+- Use `enable_provider` for reactivation paths; do not attempt re-registration of existing `(namespace, id)` records.


### PR DESCRIPTION

Closes #239

---

### Issue Summary

Addresses #239 by adding strict connector metadata validation in integration-registry to prevent oversized or ambiguous connector records.

---

### Root Cause

Provider metadata writes in register/update flows accepted unbounded and ambiguous string inputs without centralized validation.

---

### Fix Implemented

- Added byte-size limits for all `ProviderMetadata` fields
- Added non-empty and edge-whitespace checks for all metadata fields
- Enforced validation on both register and metadata update paths
- Added focused tests for boundary acceptance and negative cases
- Added dedicated module-level documentation in `integration-registry-metadata.md`

---

### Testing Performed

- Extended integration-registry tests with metadata boundary and negative scenarios
- Verified changed files are diagnostics-clean in-editor
- Applied targeted formatting to changed files

---

### References

- Closes #239
- Updated: `integration-registry-metadata.md`