### PR TITLE
Expand dynamic fee computation tests across fee schedule boundaries (#213)

### DIFF
--- a/contracts/attestation/src/dynamic_fees.rs
+++ b/contracts/attestation/src/dynamic_fees.rs
@@ -29,6 +29,21 @@
 //!
 //! If no `FeeConfig` has been stored, or if `FeeConfig.enabled == false`,
 //! attestations are free — identical to pre-fee behavior.
+//!
+//! ### Rounding and Precision
+//!
+//! Fee calculations use integer arithmetic and **round towards zero** (truncation).
+//! This ensures that fees are never overcharged beyond the calculated basis,
+//! though it may result in a fee of 0 for extremely small `base_fee` values
+//! combined with high discounts.
+//!
+//! ### Security Invariants
+//!
+//! 1. **Authorization**: All configuration changes (`FeeConfig`, `TierDiscount`, `VolumeBrackets`)
+//!    require administrative authority.
+//! 2. **Integrity**: Discounts are capped at 10,000 bps (100%).
+//! 3. **Consistency**: Volume thresholds must be strictly ascending to ensure
+//!    deterministic bracket selection.
 
 use soroban_sdk::{contracttype, token, Address, Env, Symbol, Val, Vec};
 
@@ -318,9 +333,17 @@ fn get_effective_fee_config(env: &Env) -> Option<FeeConfig> {
 
 /// Pure-arithmetic fee computation (no storage access).
 ///
+/// The formula applies two independent discount factors to the base fee:
+///
 /// ```text
 /// effective = base_fee × (10 000 − tier_bps) × (10 000 − vol_bps) / 100 000 000
 /// ```
+///
+/// ### Mathematical Properties
+///
+/// - **Commutativity**: The order of tier and volume discounts does not affect the result.
+/// - **Bounds**: The result is always in the range `[0, base_fee]`.
+/// - **Rounding**: Truncates toward zero.
 pub fn compute_fee(base_fee: i128, tier_discount_bps: u32, volume_discount_bps: u32) -> i128 {
     let tier_factor = 10_000i128 - tier_discount_bps as i128;
     let vol_factor = 10_000i128 - volume_discount_bps as i128;

--- a/contracts/attestation/src/dynamic_fees_test.rs
+++ b/contracts/attestation/src/dynamic_fees_test.rs
@@ -408,3 +408,112 @@ fn test_economic_simulation() {
     assert_eq!(t.client.get_fee_quote(&biz_p), 74_800);
     assert_eq!(t.client.get_fee_quote(&biz_e), 61_600);
 }
+
+#[test]
+fn test_compute_fee_rounding_and_precision() {
+    // 1 unit base fee, 1 bps discount (0.01%)
+    // factor = (10000-0) * (10000-1) = 100,000,000 * 0.9999 = 99,990,000
+    // 1 * 99,990,000 / 100,000,000 = 0 (truncation)
+    assert_eq!(compute_fee(1, 0, 1), 0);
+
+    // 100 units, 1 bps discount -> 100 * 0.9999 = 99.99 -> 99
+    assert_eq!(compute_fee(100, 0, 1), 99);
+
+    // 10,000 units, 1 bps discount -> 10,000 * 10,000 * 9,999 / 100,000,000 = 9,999
+    assert_eq!(compute_fee(10_000, 0, 1), 9_999);
+}
+
+#[test]
+fn test_compute_fee_magnitudes() {
+    // Extremely large base_fee (e.g. for high-precision tokens)
+    let large_fee = 1_000_000_000_000_000_000_000_000i128; // 10^24
+    // 10% discount across both (1000 bps)
+    // factor = 9000 * 9000 = 81,000,000
+    // result = 10^24 * 0.81 = 8.1 * 10^23
+    assert_eq!(compute_fee(large_fee, 1_000, 1_000), 810_000_000_000_000_000_000_000i128);
+
+    // Zero base fee
+    assert_eq!(compute_fee(0, 1_000, 1_000), 0);
+}
+
+#[test]
+fn test_bracket_boundary_transitions() {
+    let t = setup_with_fees(1_000_000);
+    // Bracket at 10 attestations, 50% discount
+    let thresholds = vec![&t.env, 10u64];
+    let discounts = vec![&t.env, 5_000u32];
+    t.client.set_volume_brackets(&thresholds, &discounts);
+
+    let business = Address::generate(&t.env);
+    mint(&t.env, &t.token_addr, &business, 100_000_000);
+
+    // 9th submission: still full price
+    for i in 1..=9 {
+        assert_eq!(t.client.get_fee_quote(&business), 1_000_000);
+        submit(&t.client, &t.env, &business, i);
+    }
+
+    // 10th submission: boundary hit, 50% discount applies to NEXT
+    assert_eq!(t.client.get_fee_quote(&business), 1_000_000);
+    submit(&t.client, &t.env, &business, 10);
+
+    // 11th submission: should have discount
+    assert_eq!(t.client.get_fee_quote(&business), 500_000);
+}
+
+#[test]
+fn test_config_change_mid_period_consistency() {
+    let t = setup_with_fees(1_000_000);
+    let business = Address::generate(&t.env);
+    mint(&t.env, &t.token_addr, &business, 10_000_000);
+
+    // First submission at 1M
+    submit(&t.client, &t.env, &business, 1);
+    assert_eq!(balance(&t.env, &t.token_addr, &t.collector), 1_000_000);
+
+    // Admin changes base fee mid-period
+    t.client.configure_fees(&t.token_addr, &t.collector, &500_000, &true);
+    
+    // Second submission should be at 500k
+    submit(&t.client, &t.env, &business, 2);
+    assert_eq!(balance(&t.env, &t.token_addr, &t.collector), 1_500_000);
+
+    // Admin changes discount mid-period
+    t.client.set_tier_discount(&0, &2_000); // 20% off for Tier 0
+    submit(&t.client, &t.env, &business, 3);
+    // 500k * 0.8 = 400k
+    assert_eq!(balance(&t.env, &t.token_addr, &t.collector), 1_900_000);
+}
+
+#[test]
+fn test_max_discount_combinations() {
+    let t = setup_with_fees(1_000_000);
+    t.client.set_tier_discount(&1, &10_000); // 100% discount
+    t.client.set_tier_discount(&2, &5_000);  // 50% discount
+    
+    let thresholds = vec![&t.env, 5u64];
+    let discounts = vec![&t.env, 10_000u32]; // 100% discount
+    t.client.set_volume_brackets(&thresholds, &discounts);
+
+    let biz_tier_100 = Address::generate(&t.env);
+    let biz_vol_100 = Address::generate(&t.env);
+    t.client.set_business_tier(&biz_tier_100, &1);
+
+    // Tier 100% discount -> free regardless of volume
+    assert_eq!(t.client.get_fee_quote(&biz_tier_100), 0);
+
+    // Volume 100% discount -> free after 5 submissions
+    for i in 1..=5 {
+        submit(&t.client, &t.env, &biz_vol_100, i);
+    }
+    assert_eq!(t.client.get_fee_quote(&biz_vol_100), 0);
+
+    // Combined 50% tier + 100% volume -> free
+    let biz_combined = Address::generate(&t.env);
+    t.client.set_business_tier(&biz_combined, &2);
+    for i in 1..=5 {
+        submit(&t.client, &t.env, &biz_combined, i);
+    }
+    assert_eq!(t.client.get_fee_quote(&biz_combined), 0);
+}
+


### PR DESCRIPTION
closes #213 
Summary of Changes:

Expanded Test Coverage: Implemented a comprehensive suite of new tests in dynamic_fees_test.rs targeting edge cases such as zero base fees, extremely large revenue magnitudes ($10^{24}$), and independent axis 100% discount combinations.
Boundary Verification: Added specific tests for bracket transitions (exactly at, below, and above thresholds) to ensure deterministic fee changes.
Configuration Consistency: Verified that administrative updates to the fee schedule (base fee or discount bps) are applied atomically to subsequent attestations, even within the same period.
Documentation: Updated dynamic_fees.rs with production-grade Rustdoc clarifying rounding behavior (integer truncation) and core security invariants.
Reason for Changes: To ensure the mathematical robustness of the Veritasor protocol's fee engine and to guarantee that configuration changes do not leave the system in an inconsistent state during high-volume periods.