### PR TITLE
test: cover initialize idempotency and uninitialized access

### DIFF
--- a/contracts/attestation/src/test.rs
+++ b/contracts/attestation/src/test.rs
@@ -12,4 +12,41 @@ fn test_initialize() {
 
     client.initialize(&admin, &0u64);
     assert_eq!(client.get_admin(), admin);
+    assert!(client.has_role(&admin, &ROLE_ADMIN));
+}
+
+#[test]
+#[should_panic(expected = "already initialized")]
+fn test_initialize_twice_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(AttestationContract, ());
+    let client = AttestationContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &0u64);
+    client.initialize(&admin, &1u64);
+}
+
+#[test]
+#[should_panic(expected = "contract not initialized")]
+fn test_get_admin_before_initialize_panics() {
+    let env = Env::default();
+    let contract_id = env.register(AttestationContract, ());
+    let client = AttestationContractClient::new(&env, &contract_id);
+
+    client.get_admin();
+}
+
+#[test]
+#[should_panic(expected = "contract not initialized")]
+fn test_require_admin_backed_call_before_initialize_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+    let contract_id = env.register(AttestationContract, ());
+    let client = AttestationContractClient::new(&env, &contract_id);
+
+    client.configure_fees(&token, &collector, &100i128, &true);
 }


### PR DESCRIPTION
Closes #334

---

Issue #334: Add double-initialize and uninitialized-call tests for initialize

Completed and pushed branch test-initialize-guards.

What was done:

Added a test confirming initialize grants ROLE_ADMIN to the admin.
Added a test confirming calling initialize twice panics with "already initialized".
Added a test confirming get_admin before setup panics with "contract not initialized".
Added a test confirming a require_admin-backed method, configure_fees, panics before initialization.