### PR TITLE
test: cover duplicate attestation rejection paths

### DIFF
--- a/contracts/attestation/src/batch_submission_test.rs
+++ b/contracts/attestation/src/batch_submission_test.rs
@@ -1053,7 +1053,7 @@ fn test_duplicate_identical_items_in_batch() {
 
     let item = create_batch_item(&env, &business, "2026-01", &[1u8; 32], 1_700_000_000, 1);
 
-    let mut items = Vec::new(&env);
+    let mut items = soroban_sdk::Vec::new(&env);
     items.push_back(item.clone());
     items.push_back(item); // Identical clone
 

--- a/contracts/attestation/src/batch_submission_test.rs
+++ b/contracts/attestation/src/batch_submission_test.rs
@@ -1060,7 +1060,7 @@ fn test_duplicate_identical_items_in_batch() {
         1,
     );
 
-    let mut items = Vec::new(&env);
+    let mut items: Vec<BatchAttestationItem> = Vec::new(&env);
     items.push_back(item.clone());
     items.push_back(item); // Identical clone
 
@@ -1076,7 +1076,7 @@ fn test_duplicate_across_batch_calls() {
     let business = Address::generate(&env);
 
     // First batch submission
-    let mut items1 = Vec::new(&env);
+    let mut items1: Vec<BatchAttestationItem> = Vec::new(&env);
     items1.push_back(create_batch_item(
         &env,
         &business,
@@ -1088,7 +1088,7 @@ fn test_duplicate_across_batch_calls() {
     client.submit_attestations_batch(&items1);
 
     // Second batch submission with same (business, period)
-    let mut items2 = Vec::new(&env);
+    let mut items2: Vec<BatchAttestationItem> = Vec::new(&env);
     items2.push_back(create_batch_item(
         &env,
         &business,
@@ -1107,7 +1107,7 @@ fn test_distinct_periods_for_business_in_batch_succeed() {
     let (env, client) = setup();
     let business = Address::generate(&env);
 
-    let mut items = Vec::new(&env);
+    let mut items: Vec<BatchAttestationItem> = Vec::new(&env);
     items.push_back(create_batch_item(
         &env,
         &business,

--- a/contracts/attestation/src/batch_submission_test.rs
+++ b/contracts/attestation/src/batch_submission_test.rs
@@ -1060,7 +1060,7 @@ fn test_duplicate_identical_items_in_batch() {
         1,
     );
 
-    let mut items: Vec<BatchAttestationItem> = Vec::new(&env);
+    let mut items = Vec::new(&env);
     items.push_back(item.clone());
     items.push_back(item); // Identical clone
 
@@ -1076,7 +1076,7 @@ fn test_duplicate_across_batch_calls() {
     let business = Address::generate(&env);
 
     // First batch submission
-    let mut items1: Vec<BatchAttestationItem> = Vec::new(&env);
+    let mut items1 = Vec::new(&env);
     items1.push_back(create_batch_item(
         &env,
         &business,
@@ -1088,7 +1088,7 @@ fn test_duplicate_across_batch_calls() {
     client.submit_attestations_batch(&items1);
 
     // Second batch submission with same (business, period)
-    let mut items2: Vec<BatchAttestationItem> = Vec::new(&env);
+    let mut items2 = Vec::new(&env);
     items2.push_back(create_batch_item(
         &env,
         &business,
@@ -1107,7 +1107,7 @@ fn test_distinct_periods_for_business_in_batch_succeed() {
     let (env, client) = setup();
     let business = Address::generate(&env);
 
-    let mut items: Vec<BatchAttestationItem> = Vec::new(&env);
+    let mut items = Vec::new(&env);
     items.push_back(create_batch_item(
         &env,
         &business,

--- a/contracts/attestation/src/batch_submission_test.rs
+++ b/contracts/attestation/src/batch_submission_test.rs
@@ -10,6 +10,7 @@ use super::*;
 use soroban_sdk::testutils::Address as _;
 use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
 use soroban_sdk::{Address, BytesN, Env, String, Vec};
+use soroban_sdk::Vec as SorobanVec;
 
 // ════════════════════════════════════════════════════════════════════
 //  Helpers

--- a/contracts/attestation/src/batch_submission_test.rs
+++ b/contracts/attestation/src/batch_submission_test.rs
@@ -97,7 +97,7 @@ fn test_batch_submit_single_item() {
     let (env, client) = setup();
     let business = Address::generate(&env);
 
-    let mut items = Vec::new(&env);
+    let mut items = soroban_sdk::Vec::new(&env);
     items.push_back(create_batch_item(
         &env,
         &business,

--- a/contracts/attestation/src/batch_submission_test.rs
+++ b/contracts/attestation/src/batch_submission_test.rs
@@ -97,7 +97,7 @@ fn test_batch_submit_single_item() {
     let (env, client) = setup();
     let business = Address::generate(&env);
 
-    let mut items = Vec::new(&env);
+    let mut items = soroban_sdk::Vec::new(&env);
     items.push_back(create_batch_item(
         &env,
         &business,
@@ -1053,7 +1053,7 @@ fn test_duplicate_identical_items_in_batch() {
 
     let item = create_batch_item(&env, &business, "2026-01", &[1u8; 32], 1_700_000_000, 1);
 
-    let mut items = soroban_sdk::Vec::new(&env);
+    let mut items = Vec::new(&env);
     items.push_back(item.clone());
     items.push_back(item); // Identical clone
 

--- a/contracts/attestation/src/batch_submission_test.rs
+++ b/contracts/attestation/src/batch_submission_test.rs
@@ -1038,3 +1038,112 @@ fn test_atomicity_clean_batch_succeeds_after_failed_batch() {
         .is_some());
     assert_eq!(client.get_business_count(&business), 3);
 }
+
+// ════════════════════════════════════════════════════════════════════
+//  Duplicate Detection Tests — Joint Coverage
+// ════════════════════════════════════════════════════════════════════
+
+/// Test with two truly identical BatchAttestationItems in same batch.
+/// Expects panic message: "duplicate attestation in batch"
+#[test]
+#[should_panic(expected = "duplicate attestation in batch")]
+fn test_duplicate_identical_items_in_batch() {
+    let (env, client) = setup();
+    let business = Address::generate(&env);
+
+    let item = create_batch_item(
+        &env,
+        &business,
+        "2026-01",
+        &[1u8; 32],
+        1_700_000_000,
+        1,
+    );
+
+    let mut items = Vec::new(&env);
+    items.push_back(item.clone());
+    items.push_back(item); // Identical clone
+
+    client.submit_attestations_batch(&items);
+}
+
+/// Test submitting a period via batch, then re-submitting it in a later batch.
+/// Expects panic message: "attestation already exists for this business and period"
+#[test]
+#[should_panic(expected = "attestation already exists for this business and period")]
+fn test_duplicate_across_batch_calls() {
+    let (env, client) = setup();
+    let business = Address::generate(&env);
+
+    // First batch submission
+    let mut items1 = Vec::new(&env);
+    items1.push_back(create_batch_item(
+        &env,
+        &business,
+        "2026-01",
+        &[1u8; 32],
+        1_700_000_000,
+        1,
+    ));
+    client.submit_attestations_batch(&items1);
+
+    // Second batch submission with same (business, period)
+    let mut items2 = Vec::new(&env);
+    items2.push_back(create_batch_item(
+        &env,
+        &business,
+        "2026-01",
+        &[2u8; 32], // Different merkle_root, but same business+period
+        1_700_000_001,
+        1,
+    ));
+    client.submit_attestations_batch(&items2);
+}
+
+/// Test confirming distinct periods for one business in a batch all succeed.
+/// This validates the positive case: no duplicates should be accepted.
+#[test]
+fn test_distinct_periods_for_business_in_batch_succeed() {
+    let (env, client) = setup();
+    let business = Address::generate(&env);
+
+    let mut items = Vec::new(&env);
+    items.push_back(create_batch_item(
+        &env,
+        &business,
+        "2026-01",
+        &[1u8; 32],
+        1_700_000_000,
+        1,
+    ));
+    items.push_back(create_batch_item(
+        &env,
+        &business,
+        "2026-02",
+        &[2u8; 32],
+        1_700_008_640,
+        1,
+    ));
+    items.push_back(create_batch_item(
+        &env,
+        &business,
+        "2026-03",
+        &[3u8; 32],
+        1_700_017_280,
+        1,
+    ));
+
+    client.submit_attestations_batch(&items);
+
+    // Verify all three distinct periods were stored
+    assert!(client
+        .get_attestation(&business, &String::from_str(&env, "2026-01"))
+        .is_some());
+    assert!(client
+        .get_attestation(&business, &String::from_str(&env, "2026-02"))
+        .is_some());
+    assert!(client
+        .get_attestation(&business, &String::from_str(&env, "2026-03"))
+        .is_some());
+    assert_eq!(client.get_business_count(&business), 3);
+}

--- a/contracts/attestation/src/batch_submission_test.rs
+++ b/contracts/attestation/src/batch_submission_test.rs
@@ -10,7 +10,6 @@ use super::*;
 use soroban_sdk::testutils::Address as _;
 use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
 use soroban_sdk::{Address, BytesN, Env, String, Vec};
-use soroban_sdk::Vec as SorobanVec;
 
 // ════════════════════════════════════════════════════════════════════
 //  Helpers
@@ -98,7 +97,7 @@ fn test_batch_submit_single_item() {
     let (env, client) = setup();
     let business = Address::generate(&env);
 
-    let mut items = soroban_sdk::Vec::new(&env);
+    let mut items = Vec::new(&env);
     items.push_back(create_batch_item(
         &env,
         &business,

--- a/contracts/attestation/src/batch_submission_test.rs
+++ b/contracts/attestation/src/batch_submission_test.rs
@@ -1051,14 +1051,7 @@ fn test_duplicate_identical_items_in_batch() {
     let (env, client) = setup();
     let business = Address::generate(&env);
 
-    let item = create_batch_item(
-        &env,
-        &business,
-        "2026-01",
-        &[1u8; 32],
-        1_700_000_000,
-        1,
-    );
+    let item = create_batch_item(&env, &business, "2026-01", &[1u8; 32], 1_700_000_000, 1);
 
     let mut items = Vec::new(&env);
     items.push_back(item.clone());
@@ -1077,26 +1070,12 @@ fn test_duplicate_across_batch_calls() {
 
     // First batch submission
     let mut items1 = Vec::new(&env);
-    items1.push_back(create_batch_item(
-        &env,
-        &business,
-        "2026-01",
-        &[1u8; 32],
-        1_700_000_000,
-        1,
-    ));
+    items1.push_back(create_batch_item(&env, &business, "2026-01", &[1u8; 32], 1_700_000_000, 1));
     client.submit_attestations_batch(&items1);
 
     // Second batch submission with same (business, period)
     let mut items2 = Vec::new(&env);
-    items2.push_back(create_batch_item(
-        &env,
-        &business,
-        "2026-01",
-        &[2u8; 32], // Different merkle_root, but same business+period
-        1_700_000_001,
-        1,
-    ));
+    items2.push_back(create_batch_item(&env, &business, "2026-01", &[2u8; 32], 1_700_000_001, 1)); // Different merkle_root, but same business+period
     client.submit_attestations_batch(&items2);
 }
 
@@ -1108,30 +1087,9 @@ fn test_distinct_periods_for_business_in_batch_succeed() {
     let business = Address::generate(&env);
 
     let mut items = Vec::new(&env);
-    items.push_back(create_batch_item(
-        &env,
-        &business,
-        "2026-01",
-        &[1u8; 32],
-        1_700_000_000,
-        1,
-    ));
-    items.push_back(create_batch_item(
-        &env,
-        &business,
-        "2026-02",
-        &[2u8; 32],
-        1_700_008_640,
-        1,
-    ));
-    items.push_back(create_batch_item(
-        &env,
-        &business,
-        "2026-03",
-        &[3u8; 32],
-        1_700_017_280,
-        1,
-    ));
+    items.push_back(create_batch_item(&env, &business, "2026-01", &[1u8; 32], 1_700_000_000, 1));
+    items.push_back(create_batch_item(&env, &business, "2026-02", &[2u8; 32], 1_700_008_640, 1));
+    items.push_back(create_batch_item(&env, &business, "2026-03", &[3u8; 32], 1_700_017_280, 1));
 
     client.submit_attestations_batch(&items);
 

--- a/contracts/attestation/src/batch_submission_test.rs
+++ b/contracts/attestation/src/batch_submission_test.rs
@@ -1070,12 +1070,26 @@ fn test_duplicate_across_batch_calls() {
 
     // First batch submission
     let mut items1 = Vec::new(&env);
-    items1.push_back(create_batch_item(&env, &business, "2026-01", &[1u8; 32], 1_700_000_000, 1));
+    items1.push_back(create_batch_item(
+        &env,
+        &business,
+        "2026-01",
+        &[1u8; 32],
+        1_700_000_000,
+        1,
+    ));
     client.submit_attestations_batch(&items1);
 
     // Second batch submission with same (business, period)
     let mut items2 = Vec::new(&env);
-    items2.push_back(create_batch_item(&env, &business, "2026-01", &[2u8; 32], 1_700_000_001, 1)); // Different merkle_root, but same business+period
+    items2.push_back(create_batch_item(
+        &env,
+        &business,
+        "2026-01",
+        &[2u8; 32],
+        1_700_000_001,
+        1,
+    )); // Different merkle_root, but same business+period
     client.submit_attestations_batch(&items2);
 }
 
@@ -1087,9 +1101,30 @@ fn test_distinct_periods_for_business_in_batch_succeed() {
     let business = Address::generate(&env);
 
     let mut items = Vec::new(&env);
-    items.push_back(create_batch_item(&env, &business, "2026-01", &[1u8; 32], 1_700_000_000, 1));
-    items.push_back(create_batch_item(&env, &business, "2026-02", &[2u8; 32], 1_700_008_640, 1));
-    items.push_back(create_batch_item(&env, &business, "2026-03", &[3u8; 32], 1_700_017_280, 1));
+    items.push_back(create_batch_item(
+        &env,
+        &business,
+        "2026-01",
+        &[1u8; 32],
+        1_700_000_000,
+        1,
+    ));
+    items.push_back(create_batch_item(
+        &env,
+        &business,
+        "2026-02",
+        &[2u8; 32],
+        1_700_008_640,
+        1,
+    ));
+    items.push_back(create_batch_item(
+        &env,
+        &business,
+        "2026-03",
+        &[3u8; 32],
+        1_700_017_280,
+        1,
+    ));
 
     client.submit_attestations_batch(&items);
 


### PR DESCRIPTION
Closes #326

---

running 25 tests
test batch_submission_test::test_atomicity_in_batch_self_duplicate_rejects_all ... ok
test batch_submission_test::test_atomicity_cross_business_failure_rejects_all ... ok
test batch_submission_test::test_atomicity_failure_at_first_item_rejects_all ... ok
test batch_submission_test::test_atomicity_failure_at_last_item_rejects_all ... ok
test batch_submission_test::test_atomicity_failure_at_middle_item_rejects_all ... ok
test batch_submission_test::test_batch_emits_events ... ok
test batch_submission_test::test_batch_submit_duplicate_in_batch - should panic ... ok
test batch_submission_test::test_atomicity_business_count_unchanged_on_failure ... ok
test batch_submission_test::test_batch_submit_empty_panics - should panic ... ok
test batch_submission_test::test_atomicity_clean_batch_succeeds_after_failed_batch ... ok
test batch_submission_test::test_batch_submit_existing_period - should panic ... ok
test batch_submission_test::test_batch_submit_when_paused - should panic ... ok
test batch_submission_test::test_batch_submit_single_item ... ok
test batch_submission_test::test_batch_fees_calculated_correctly ... ok
test batch_submission_test::test_batch_submit_multiple_periods_same_business ... ok
test batch_submission_test::test_batch_submit_multiple_businesses ... ok
test batch_submission_test::test_batch_fees_multiple_businesses ... ok
test batch_submission_test::test_duplicate_identical_items_in_batch - should panic ... ok
test batch_submission_test::test_duplicate_across_batch_calls - should panic ... ok
test test::test_initialize ... ok
test batch_submission_test::test_batch_mixed_businesses_and_periods ... ok
test batch_submission_test::test_distinct_periods_for_business_in_batch_succeed ... ok
test batch_submission_test::test_batch_fees_with_volume_discounts ... ok
test batch_submission_test::test_batch_vs_single_cost_comparison ... ok
test batch_submission_test::test_batch_large_size ... ok

test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.47s
