### PR TITLE
feat: cap batch attestation size

### DIFF
--- a/contracts/attestation/src/batch_submission_test.rs
+++ b/contracts/attestation/src/batch_submission_test.rs
@@ -1038,3 +1038,47 @@ fn test_atomicity_clean_batch_succeeds_after_failed_batch() {
         .is_some());
     assert_eq!(client.get_business_count(&business), 3);
 }
+
+// ════════════════════════════════════════════════════════════════════
+//  Batch size cap tests
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_batch_at_max_size_accepted() {
+    let (env, client) = setup();
+    let business = Address::generate(&env);
+
+    let mut items = Vec::new(&env);
+    for i in 0..MAX_BATCH_SIZE {
+        let period = String::from_str(&env, &std::format!("2026-{:02}", i + 1));
+        let mut root = [0u8; 32];
+        root[0] = i as u8;
+        items.push_back(create_batch_item(&env, &business, &std::format!("2026-{:02}", i + 1), &root, 1_700_000_000, 1));
+    }
+
+    client.submit_attestations_batch(&items);
+    assert_eq!(client.get_business_count(&business), MAX_BATCH_SIZE as u64);
+}
+
+#[test]
+#[should_panic(expected = "batch exceeds maximum size")]
+fn test_batch_one_over_max_size_rejected() {
+    let (env, client) = setup();
+    let business = Address::generate(&env);
+
+    let mut items = Vec::new(&env);
+    for i in 0..=MAX_BATCH_SIZE {
+        let mut root = [0u8; 32];
+        root[0] = i as u8;
+        items.push_back(create_batch_item(&env, &business, &std::format!("2026-{:02}", i + 1), &root, 1_700_000_000, 1));
+    }
+
+    client.submit_attestations_batch(&items);
+}
+
+#[test]
+#[should_panic(expected = "batch cannot be empty")]
+fn test_batch_empty_still_rejected() {
+    let (env, client) = setup();
+    client.submit_attestations_batch(&Vec::new(&env));
+}

--- a/contracts/attestation/src/lib.rs
+++ b/contracts/attestation/src/lib.rs
@@ -92,6 +92,14 @@ pub struct BatchAttestationItem {
     pub expiry_timestamp: Option<u64>,
 }
 
+/// Maximum number of items allowed in a single batch submission.
+///
+/// The O(n²) duplicate scan and per-item auth checks mean cost grows
+/// quadratically. At 25 items the validation loop executes at most
+/// 25 × 25 = 625 comparisons — well within Soroban's CPU budget while
+/// still covering all practical bulk-submission use cases.
+pub const MAX_BATCH_SIZE: u32 = 25;
+
 #[contract]
 pub struct AttestationContract;
 
@@ -256,6 +264,9 @@ impl AttestationContract {
         access_control::require_not_paused(&env);
         if items.is_empty() {
             panic!("batch cannot be empty");
+        }
+        if items.len() > MAX_BATCH_SIZE {
+            panic!("batch exceeds maximum size");
         }
 
         // 1. Validation Phase

--- a/docs/batch-attestation-submission.md
+++ b/docs/batch-attestation-submission.md
@@ -79,10 +79,15 @@ The function will panic (rejecting the entire batch) if:
 
 - The contract is paused
 - The batch is empty
+- The batch exceeds `MAX_BATCH_SIZE` (25 items)
 - Any business address fails to authorize
 - Any (business, period) pair already exists in storage
 - Any (business, period) pair appears multiple times within the batch
 - Any fee collection fails (e.g., insufficient token balance)
+
+#### Batch Size Limit
+
+`MAX_BATCH_SIZE = 25`. The duplicate scan is O(n²) and each item triggers an auth check, so an unbounded batch is a resource-exhaustion vector. At 25 items the validation loop runs at most 625 comparisons, keeping CPU cost predictable. Callers needing more than 25 attestations should split them across multiple transactions.
 
 #### Events
 


### PR DESCRIPTION
- Add MAX_BATCH_SIZE = 25 constant next to BatchAttestationItem in lib.rs
- Panic with batch exceeds maximum size before the validation loop
- Add test_batch_at_max_size_accepted: 25 items succeeds
- Add test_batch_one_over_max_size_rejected: 26 items panics
- Add test_batch_empty_still_rejected: empty check still fires first
- Document the limit and rationale in docs/batch-attestation-submission.md


closes #321 