### PR TITLE
feat(attestation): add update_proof_hash function

### DIFF
--- a/contracts/attestation/src/events.rs
+++ b/contracts/attestation/src/events.rs
@@ -124,6 +124,8 @@ pub const TOPIC_BIZ_APPROVED: Symbol = symbol_short!("biz_apr");
 pub const TOPIC_BIZ_SUSPENDED: Symbol = symbol_short!("biz_sus");
 /// Topic: business reactivated
 pub const TOPIC_BIZ_REACTIVATE: Symbol = symbol_short!("biz_rea");
+/// Topic: proof hash updated
+pub const TOPIC_PROOF_HASH_UPDATED: Symbol = symbol_short!("ph_upd");
 
 // ════════════════════════════════════════════════════════════════════
 //  Normalized Event Data Structures
@@ -397,6 +399,24 @@ pub struct BusinessReactivatedEvent {
     pub business: Address,
     /// Admin address that performed the reactivation.
     pub reactivated_by: Address,
+}
+
+/// Normalized payload for `ProofHashUpdated` events.
+///
+/// Emitted when an attestation's proof hash is updated by an admin.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ProofHashUpdatedEvent {
+    /// Business address whose attestation was updated.
+    pub business: Address,
+    /// Period identifier of the attestation.
+    pub period: String,
+    /// Old proof hash value.
+    pub old_proof_hash: Option<BytesN<32>>,
+    /// New proof hash value.
+    pub new_proof_hash: Option<BytesN<32>>,
+    /// Address that performed the update.
+    pub updated_by: Address,
 }
 
 // ════════════════════════════════════════════════════════════════════
@@ -919,4 +939,37 @@ pub fn emit_business_reactivated(env: &Env, business: &Address, reactivated_by: 
     };
     env.events()
         .publish((TOPIC_BIZ_REACTIVATE, business.clone()), event);
+}
+
+/// Emit a `ProofHashUpdated` event.
+///
+/// # Arguments
+///
+/// * `env`            – Soroban execution environment.
+/// * `business`       – Business address whose attestation was updated.
+/// * `period`         – Period identifier of the attestation.
+/// * `old_proof_hash` – Old proof hash value.
+/// * `new_proof_hash` – New proof hash value.
+/// * `updated_by`     – Address that performed the update.
+///
+/// # Events
+///
+/// Publishes `(ph_upd, business)` → `ProofHashUpdatedEvent`.
+pub fn emit_proof_hash_updated(
+    env: &Env,
+    business: &Address,
+    period: &String,
+    old_proof_hash: &Option<BytesN<32>>,
+    new_proof_hash: &Option<BytesN<32>>,
+    updated_by: &Address,
+) {
+    let event = ProofHashUpdatedEvent {
+        business: business.clone(),
+        period: period.clone(),
+        old_proof_hash: old_proof_hash.clone(),
+        new_proof_hash: new_proof_hash.clone(),
+        updated_by: updated_by.clone(),
+    };
+    env.events()
+        .publish((TOPIC_PROOF_HASH_UPDATED, business.clone()), event);
 }

--- a/contracts/attestation/src/lib.rs
+++ b/contracts/attestation/src/lib.rs
@@ -54,7 +54,7 @@ pub use dispute::{
     Dispute, DisputeOutcome, DisputeResolution, DisputeStatus, DisputeType, OptionalResolution,
 };
 pub use dynamic_fees::{compute_fee, DataKey, FeeConfig};
-pub use events::{AttestationMigratedEvent, AttestationRevokedEvent, AttestationSubmittedEvent};
+pub use events::{AttestationMigratedEvent, AttestationRevokedEvent, AttestationSubmittedEvent, ProofHashUpdatedEvent};
 pub use fees::{collect_flat_fee, FlatFeeConfig};
 pub use multisig::{Proposal, ProposalAction, ProposalStatus};
 pub use rate_limit::RateLimitConfig;
@@ -504,6 +504,42 @@ impl AttestationContract {
         );
     }
 
+    pub fn update_proof_hash(
+        env: Env,
+        caller: Address,
+        business: Address,
+        period: String,
+        proof_hash: Option<BytesN<32>>,
+    ) {
+        access_control::require_admin(&env, &caller);
+
+        let key = DataKey::Attestation(business.clone(), period.clone());
+        let (merkle_root, timestamp, version, fee, old_proof_hash, expiry): AttestationData = env
+            .storage()
+            .instance()
+            .get(&key)
+            .expect("attestation not found");
+
+        let data: AttestationData = (
+            merkle_root,
+            timestamp,
+            version,
+            fee,
+            proof_hash.clone(),
+            expiry,
+        );
+        env.storage().instance().set(&key, &data);
+
+        events::emit_proof_hash_updated(
+            &env,
+            &business,
+            &period,
+            &old_proof_hash,
+            &proof_hash,
+            &caller,
+        );
+    }
+
     pub fn get_attestation(env: Env, business: Address, period: String) -> Option<AttestationData> {
         let key = DataKey::Attestation(business, period);
         env.storage().instance().get(&key)
@@ -851,5 +887,7 @@ impl AttestationContract {
 // ── Test Modules ──
 #[cfg(test)]
 mod batch_submission_test;
+#[cfg(test)]
+mod proof_hash_update_test;
 #[cfg(test)]
 mod test;

--- a/contracts/attestation/src/proof_hash_update_test.rs
+++ b/contracts/attestation/src/proof_hash_update_test.rs
@@ -1,0 +1,190 @@
+//! Tests for `update_proof_hash` function.
+//!
+//! Covers:
+//! - Non-admin caller is rejected
+//! - Missing attestation panics
+//! - `get_proof_hash` reflects the new value after update
+//! - merkle_root, timestamp, version are unchanged after update
+
+use super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, BytesN, Env, String};
+
+/// Helper: register the contract and return a client with admin address.
+fn setup_with_admin() -> (Env, AttestationContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AttestationContract, ());
+    let client = AttestationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    client.initialize(&admin, &0u64);
+    (env, client, admin, non_admin)
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Admin authorization tests
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+#[should_panic(expected = "does not have ADMIN role")]
+fn non_admin_caller_is_rejected() {
+    let (env, client, _admin, non_admin) = setup_with_admin();
+
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "202601");
+    let merkle_root = BytesN::from_array(&env, &[1u8; 32]);
+    let proof_hash = BytesN::from_array(&env, &[2u8; 32]);
+    let new_proof_hash = BytesN::from_array(&env, &[3u8; 32]);
+
+    client.submit_attestation(
+        &business,
+        &period,
+        &merkle_root,
+        &1000u64,
+        &1u32,
+        &Some(proof_hash),
+        &None,
+    );
+
+    // Non-admin tries to update proof_hash - should fail
+    client.update_proof_hash(&non_admin, &business, &period, &Some(new_proof_hash));
+}
+
+#[test]
+#[should_panic(expected = "attestation not found")]
+fn missing_attestation_panics() {
+    let (_env, client, admin, _non_admin) = setup_with_admin();
+
+    let business = Address::generate(&_env);
+    let period = String::from_str(&_env, "202601");
+    let new_proof_hash = BytesN::from_array(&_env, &[3u8; 32]);
+
+    // No attestation submitted - should panic
+    client.update_proof_hash(&admin, &business, &period, &Some(new_proof_hash));
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Proof hash update and retrieval tests
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn get_proof_hash_reflects_new_value_after_update() {
+    let (env, client, admin, _non_admin) = setup_with_admin();
+
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "202601");
+    let merkle_root = BytesN::from_array(&env, &[1u8; 32]);
+    let proof_hash = BytesN::from_array(&env, &[2u8; 32]);
+    let new_proof_hash = BytesN::from_array(&env, &[3u8; 32]);
+
+    client.submit_attestation(
+        &business,
+        &period,
+        &merkle_root,
+        &1000u64,
+        &1u32,
+        &Some(proof_hash.clone()),
+        &None,
+    );
+
+    // Verify initial proof hash
+    let initial = client.get_proof_hash(&business, &period);
+    assert_eq!(initial, Some(proof_hash));
+
+    // Update proof hash
+    client.update_proof_hash(&admin, &business, &period, &Some(new_proof_hash.clone()));
+
+    // Verify new proof hash
+    let updated = client.get_proof_hash(&business, &period);
+    assert_eq!(updated, Some(new_proof_hash));
+}
+
+#[test]
+fn other_fields_unchanged_after_update() {
+    let (env, client, admin, _non_admin) = setup_with_admin();
+
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "202601");
+    let merkle_root = BytesN::from_array(&env, &[1u8; 32]);
+    let proof_hash = BytesN::from_array(&env, &[2u8; 32]);
+    let new_proof_hash = BytesN::from_array(&env, &[3u8; 32]);
+    let timestamp = 1000u64;
+    let version = 1u32;
+
+    client.submit_attestation(
+        &business,
+        &period,
+        &merkle_root,
+        &timestamp,
+        &version,
+        &Some(proof_hash),
+        &None,
+    );
+
+    // Update proof hash
+    client.update_proof_hash(&admin, &business, &period, &Some(new_proof_hash));
+
+    // Verify other fields unchanged
+    let (stored_root, stored_ts, stored_ver, _fee, stored_proof, _expiry) =
+        client.get_attestation(&business, &period).unwrap();
+
+    assert_eq!(stored_root, merkle_root, "merkle_root should be unchanged");
+    assert_eq!(stored_ts, timestamp, "timestamp should be unchanged");
+    assert_eq!(stored_ver, version, "version should be unchanged");
+    assert_eq!(stored_proof, Some(new_proof_hash), "proof_hash should be updated");
+}
+
+#[test]
+fn can_update_to_none_proof_hash() {
+    let (env, client, admin, _non_admin) = setup_with_admin();
+
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "202601");
+    let merkle_root = BytesN::from_array(&env, &[1u8; 32]);
+    let proof_hash = BytesN::from_array(&env, &[2u8; 32]);
+
+    client.submit_attestation(
+        &business,
+        &period,
+        &merkle_root,
+        &1000u64,
+        &1u32,
+        &Some(proof_hash),
+        &None,
+    );
+
+    // Update to None
+    client.update_proof_hash(&admin, &business, &period, &None);
+
+    // Verify proof hash is None
+    let updated = client.get_proof_hash(&business, &period);
+    assert!(updated.is_none(), "proof_hash should be None after update");
+}
+
+#[test]
+fn can_update_from_none_to_some_proof_hash() {
+    let (env, client, admin, _non_admin) = setup_with_admin();
+
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "202601");
+    let merkle_root = BytesN::from_array(&env, &[1u8; 32]);
+    let new_proof_hash = BytesN::from_array(&env, &[3u8; 32]);
+
+    client.submit_attestation(
+        &business,
+        &period,
+        &merkle_root,
+        &1000u64,
+        &1u32,
+        &None,
+        &None,
+    );
+
+    // Update from None to Some
+    client.update_proof_hash(&admin, &business, &period, &Some(new_proof_hash.clone()));
+
+    // Verify proof hash updated
+    let updated = client.get_proof_hash(&business, &period);
+    assert_eq!(updated, Some(new_proof_hash));
+}


### PR DESCRIPTION
- Add update_proof_hash(env, caller, business, period, proof_hash) function
- Gate with access_control::require_admin
- Panic if attestation not found
- Replace only proof_hash field, preserve merkle_root, timestamp, version
- Add ProofHashUpdatedEvent and emit_proof_hash_updated
- Add tests for admin check, missing attestation, and field preservation

Closes #312