### PR TITLE
Add extend_expiry function for monotonic expiry extension

### DIFF
--- a/contracts/attestation/src/events.rs
+++ b/contracts/attestation/src/events.rs
@@ -532,6 +532,22 @@ pub fn emit_attestation_migrated(
         .publish((TOPIC_ATTESTATION_MIGRATED, business.clone()), event);
 }
 
+/// Normalized payload for `AttestationExpiryExtended` events.
+///
+/// Emitted when a business extends the expiry timestamp of an attestation.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct AttestationExpiryExtendedEvent {
+    /// Business address that owns the attestation.
+    pub business: Address,
+    /// Period identifier of the attestation.
+    pub period: String,
+    /// Previous expiry timestamp (may be `None` if previously unset).
+    pub old_expiry: Option<u64>,
+    /// New expiry timestamp.
+    pub new_expiry: u64,
+}
+
 /// Normalized payload for `MultiPeriodIssued` events.
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -546,8 +562,42 @@ pub struct MultiPeriodIssuedEvent {
     pub merkle_root: BytesN<32>,
 }
 
+/// Topic: attestation expiry extended
+pub const TOPIC_ATTESTATION_EXPIRY_EXTENDED: Symbol = symbol_short!("att_exp");
 /// Topic: multi-period attestation issued
 pub const TOPIC_MULTI_PERIOD_ISSUED: Symbol = symbol_short!("mul_iss");
+
+/// Emit an `AttestationExpiryExtended` event.
+///
+/// Call this after the attestation expiry has been updated.
+///
+/// # Arguments
+///
+/// * `env`        – Soroban execution environment.
+/// * `business`   – Business address that owns the attestation.
+/// * `period`     – Period identifier of the attestation.
+/// * `old_expiry` – Previous expiry timestamp (may be `None` if previously unset).
+/// * `new_expiry` – New expiry timestamp.
+///
+/// # Events
+///
+/// Publishes `(att_exp, business)` → `AttestationExpiryExtendedEvent`.
+pub fn emit_attestation_expiry_extended(
+    env: &Env,
+    business: &Address,
+    period: &String,
+    old_expiry: Option<u64>,
+    new_expiry: u64,
+) {
+    let event = AttestationExpiryExtendedEvent {
+        business: business.clone(),
+        period: period.clone(),
+        old_expiry,
+        new_expiry,
+    };
+    env.events()
+        .publish((TOPIC_ATTESTATION_EXPIRY_EXTENDED, business.clone()), event);
+}
 
 /// Emit a `MultiPeriodIssued` event.
 pub fn emit_multi_period_issued(

--- a/contracts/attestation/src/extend_expiry_test.rs
+++ b/contracts/attestation/src/extend_expiry_test.rs
@@ -1,0 +1,288 @@
+use crate::{AttestationContract, AttestationContractClient};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, BytesN, Env, String,
+};
+
+fn setup() -> (Env, AttestationContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AttestationContract, ());
+    let client = AttestationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &0u64);
+    (env, client, admin)
+}
+
+#[test]
+fn extend_expiry_updates_correctly() {
+    let (env, client, _admin) = setup();
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "2026-Q1");
+    let merkle_root = BytesN::from_array(&env, &[1u8; 32]);
+
+    env.ledger().set_timestamp(1000);
+    client.submit_attestation(
+        &business,
+        &period,
+        &merkle_root,
+        &1000u64,
+        &1u32,
+        &0i128,
+        &None,
+        &Some(2000u64),
+    );
+
+    // Verify initial expiry
+    let (_, _, _, _, _, initial_expiry) = client.get_attestation(&business, &period).unwrap();
+    assert_eq!(initial_expiry, Some(2000u64));
+
+    // Extend expiry
+    client.extend_expiry(&business, &period, &3000u64);
+
+    // Verify new expiry
+    let (root, ts, ver, fee, proof_hash, new_expiry) = client.get_attestation(&business, &period).unwrap();
+    assert_eq!(root, merkle_root);
+    assert_eq!(ts, 1000);
+    assert_eq!(ver, 1);
+    assert_eq!(new_expiry, Some(3000u64));
+    // Verify other fields are unchanged
+    assert_eq!(fee, 0);
+    assert!(proof_hash.is_none());
+}
+
+#[test]
+fn extend_expiry_all_fields_preserved() {
+    let (env, client, _admin) = setup();
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "2026-Q2");
+    let merkle_root = BytesN::from_array(&env, &[2u8; 32]);
+    let proof_hash = BytesN::from_array(&env, &[3u8; 32]);
+
+    env.ledger().set_timestamp(1000);
+    client.submit_attestation(
+        &business,
+        &period,
+        &merkle_root,
+        &1000u64,
+        &2u32,
+        &0i128,
+        &Some(proof_hash.clone()),
+        &Some(2000u64),
+    );
+
+    // Extend expiry
+    client.extend_expiry(&business, &period, &5000u64);
+
+    // Verify all fields except expiry are unchanged
+    let (root, ts, ver, _fee, ph, new_expiry) = client.get_attestation(&business, &period).unwrap();
+    assert_eq!(root, merkle_root);
+    assert_eq!(ts, 1000);
+    assert_eq!(ver, 2);
+    assert_eq!(ph, Some(proof_hash));
+    assert_eq!(new_expiry, Some(5000u64));
+}
+
+#[test]
+fn extend_expiry_from_none() {
+    let (env, client, _admin) = setup();
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "2026-Q3");
+    let merkle_root = BytesN::from_array(&env, &[4u8; 32]);
+
+    env.ledger().set_timestamp(1000);
+    // Submit without expiry
+    client.submit_attestation(
+        &business,
+        &period,
+        &merkle_root,
+        &1000u64,
+        &1u32,
+        &0i128,
+        &None,
+        &None,
+    );
+
+    // Verify no initial expiry
+    let (_, _, _, _, _, initial_expiry) = client.get_attestation(&business, &period).unwrap();
+    assert_eq!(initial_expiry, None);
+
+    // Extend from None to Some
+    client.extend_expiry(&business, &period, &3000u64);
+
+    // Verify expiry is now set
+    let (_, _, _, _, _, new_expiry) = client.get_attestation(&business, &period).unwrap();
+    assert_eq!(new_expiry, Some(3000u64));
+}
+
+#[test]
+#[should_panic(expected = "new_expiry must be greater than current expiry")]
+fn extend_expiry_rejected_if_not_greater_than_current() {
+    let (env, client, _admin) = setup();
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "2026-Q4");
+    let merkle_root = BytesN::from_array(&env, &[5u8; 32]);
+
+    env.ledger().set_timestamp(1000);
+    client.submit_attestation(
+        &business,
+        &period,
+        &merkle_root,
+        &1000u64,
+        &1u32,
+        &0i128,
+        &None,
+        &Some(2000u64),
+    );
+
+    // Try to extend with same expiry - should fail
+    client.extend_expiry(&business, &period, &2000u64);
+}
+
+#[test]
+#[should_panic(expected = "new_expiry must be greater than current expiry")]
+fn extend_expiry_rejected_if_less_than_current() {
+    let (env, client, _admin) = setup();
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "2027-Q1");
+    let merkle_root = BytesN::from_array(&env, &[6u8; 32]);
+
+    env.ledger().set_timestamp(1000);
+    client.submit_attestation(
+        &business,
+        &period,
+        &merkle_root,
+        &1000u64,
+        &1u32,
+        &0i128,
+        &None,
+        &Some(3000u64),
+    );
+
+    // Try to extend with smaller expiry - should fail
+    client.extend_expiry(&business, &period, &2500u64);
+}
+
+#[test]
+#[should_panic(expected = "new_expiry must be greater than attestation timestamp")]
+fn extend_expiry_rejected_if_less_than_timestamp() {
+    let (env, client, _admin) = setup();
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "2027-Q2");
+    let merkle_root = BytesN::from_array(&env, &[7u8; 32]);
+
+    env.ledger().set_timestamp(1000);
+    client.submit_attestation(
+        &business,
+        &period,
+        &merkle_root,
+        &2000u64,  // attestation timestamp is 2000
+        &1u32,
+        &0i128,
+        &None,
+        &Some(3000u64),
+    );
+
+    // Try to extend with expiry less than timestamp - should fail
+    client.extend_expiry(&business, &period, &1500u64);
+}
+
+/// Test that extend_expiry requires the business address to authenticate.
+/// Note: With mock_all_auths(), all addresses are authorized, so this test
+/// verifies the function accepts the business caller when properly authenticated.
+#[test]
+fn extend_expiry_accepts_auth_business() {
+    let (env, client, _admin) = setup();
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "2027-Q3");
+    let merkle_root = BytesN::from_array(&env, &[8u8; 32]);
+
+    env.ledger().set_timestamp(1000);
+    client.submit_attestation(
+        &business,
+        &period,
+        &merkle_root,
+        &1000u64,
+        &1u32,
+        &0i128,
+        &None,
+        &Some(2000u64),
+    );
+
+    // Business can extend their own attestation when authenticated
+    client.extend_expiry(&business, &period, &3000u64);
+    
+    let (_, _, _, _, _, new_expiry) = client.get_attestation(&business, &period).unwrap();
+    assert_eq!(new_expiry, Some(3000u64));
+}
+
+#[test]
+#[should_panic(expected = "attestation not found")]
+fn extend_expiry_panics_for_missing_attestation() {
+    let (env, client, _admin) = setup();
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "2027-Q4");
+
+    // Try to extend non-existent attestation
+    client.extend_expiry(&business, &period, &3000u64);
+}
+
+#[test]
+fn extend_expiry_multiple_times() {
+    let (env, client, _admin) = setup();
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "2028-Q1");
+    let merkle_root = BytesN::from_array(&env, &[9u8; 32]);
+
+    env.ledger().set_timestamp(1000);
+    client.submit_attestation(
+        &business,
+        &period,
+        &merkle_root,
+        &1000u64,
+        &1u32,
+        &0i128,
+        &None,
+        &Some(2000u64),
+    );
+
+    // Extend multiple times
+    client.extend_expiry(&business, &period, &3000u64);
+    let (_, _, _, _, _, expiry1) = client.get_attestation(&business, &period).unwrap();
+    assert_eq!(expiry1, Some(3000u64));
+
+    client.extend_expiry(&business, &period, &4000u64);
+    let (_, _, _, _, _, expiry2) = client.get_attestation(&business, &period).unwrap();
+    assert_eq!(expiry2, Some(4000u64));
+
+    client.extend_expiry(&business, &period, &5000u64);
+    let (_, _, _, _, _, expiry3) = client.get_attestation(&business, &period).unwrap();
+    assert_eq!(expiry3, Some(5000u64));
+}
+
+#[test]
+fn extend_expiry_with_large_timestamp() {
+    let (env, client, _admin) = setup();
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "2028-Q2");
+    let merkle_root = BytesN::from_array(&env, &[10u8; 32]);
+
+    env.ledger().set_timestamp(1000);
+    client.submit_attestation(
+        &business,
+        &period,
+        &merkle_root,
+        &1000u64,
+        &1u32,
+        &0i128,
+        &None,
+        &Some(2000u64),
+    );
+
+    // Extend to a very large expiry
+    let large_expiry = u64::MAX - 100;
+    client.extend_expiry(&business, &period, &large_expiry);
+
+    let (_, _, _, _, _, new_expiry) = client.get_attestation(&business, &period).unwrap();
+    assert_eq!(new_expiry, Some(large_expiry));
+}

--- a/contracts/attestation/src/lib.rs
+++ b/contracts/attestation/src/lib.rs
@@ -504,6 +504,42 @@ impl AttestationContract {
         );
     }
 
+    pub fn extend_expiry(
+        env: Env,
+        business: Address,
+        period: String,
+        new_expiry: u64,
+    ) {
+        business.require_auth();
+
+        let key = DataKey::Attestation(business.clone(), period.clone());
+        let (merkle_root, timestamp, version, fee, proof_hash, old_expiry): AttestationData = env
+            .storage()
+            .instance()
+            .get(&key)
+            .expect("attestation not found");
+
+        let current_expiry = old_expiry.unwrap_or(0);
+        if new_expiry <= current_expiry {
+            panic!("new_expiry must be greater than current expiry");
+        }
+        if new_expiry <= timestamp {
+            panic!("new_expiry must be greater than attestation timestamp");
+        }
+
+        let data: AttestationData = (
+            merkle_root,
+            timestamp,
+            version,
+            fee,
+            proof_hash,
+            Some(new_expiry),
+        );
+        env.storage().instance().set(&key, &data);
+
+        events::emit_attestation_expiry_extended(&env, &business, &period, old_expiry, new_expiry);
+    }
+
     pub fn get_attestation(env: Env, business: Address, period: String) -> Option<AttestationData> {
         let key = DataKey::Attestation(business, period);
         env.storage().instance().get(&key)
@@ -851,5 +887,7 @@ impl AttestationContract {
 // ── Test Modules ──
 #[cfg(test)]
 mod batch_submission_test;
+#[cfg(test)]
+mod extend_expiry_test;
 #[cfg(test)]
 mod test;

--- a/docs/attestation-expiry.md
+++ b/docs/attestation-expiry.md
@@ -278,10 +278,46 @@ To change expiry, the business must:
 | Data Preservation | Expired attestations remain queryable |
 | Migration | Expiry preserved during attestation migration |
 
+## Monotonic Expiry Invariant
+
+The contract enforces a **monotonic expiry** invariant through the `extend_expiry` function:
+
+- Expiry timestamps can only be **extended** (increased), never reduced.
+- This ensures that once an attestation is valid until a certain time, its validity period cannot be shortened without revocation.
+
+### Extending Expiry
+
+Businesses can extend the expiry of their attestations using `extend_expiry`:
+
+```rust
+pub fn extend_expiry(
+    env: Env,
+    business: Address,
+    period: String,
+    new_expiry: u64,
+)
+```
+
+**Requirements:**
+1. The caller must be the business address (authenticated via `require_auth`).
+2. The attestation must exist (panics if not found).
+3. The `new_expiry` must be **strictly greater** than the current expiry.
+4. The `new_expiry` must be **strictly greater** than the attestation timestamp.
+
+**Behavior:**
+- Updates only the expiry field, preserving all other attestation data.
+- Emits an `AttestationExpiryExtended` event.
+- Allows extending from `None` (no expiry) to `Some(expiry)` or extending an existing expiry.
+
+### Use Cases
+
+1. **Renewal**: Extend an attestation's validity period without resubmitting.
+2. **Continuity**: Maintain the same attestation data while extending the deadline.
+3. **Compliance**: Meet regulatory requirements for attestation freshness.
+
 ## Future Enhancements
 
 Potential extensions (not currently implemented):
 - Automatic expiry extension mechanisms
 - Expiry-based fee discounts
 - Batch expiry queries
-- Expiry events


### PR DESCRIPTION
Implements 
- Add extend_expiry(env, business, period, new_expiry) to lib.rs
- Add AttestationExpiryExtendedEvent and emit function to events.rs
- Update docs/attestation-expiry.md with monotonic-expiry invariant
- Add comprehensive tests in extend_expiry_test.rs

The function allows businesses to extend attestation expiry while:
- Requiring business authentication
- Enforcing new_expiry > current_expiry
- Enforcing new_expiry > attestation timestamp
- Preserving all other attestation fields
- Emitting an event for indexers

closes #313 