### PR TITLE
feat: bound tier index in business tier configuration (#318)

### DIFF
--- a/contracts/attestation/src/dynamic_fees.rs
+++ b/contracts/attestation/src/dynamic_fees.rs
@@ -48,6 +48,18 @@
 use soroban_sdk::{contracttype, token, Address, Env, Symbol, Val, Vec};
 
 // ════════════════════════════════════════════════════════════════════
+//  Tier bounds
+// ════════════════════════════════════════════════════════════════════
+
+/// Maximum supported business tier index (inclusive).
+///
+/// Tiers are 0-indexed: 0 = Standard, 1 = Pro, 2 = Enterprise, …, MAX_TIER = top tier.
+/// Both `set_business_tier` and `set_tier_discount` reject any value above this limit,
+/// preventing silent misconfiguration where a business is placed in an unconfigured tier
+/// that silently yields a 0-discount (full fee).
+pub const MAX_TIER: u32 = 9;
+
+// ════════════════════════════════════════════════════════════════════
 //  Storage types
 // ════════════════════════════════════════════════════════════════════
 
@@ -189,6 +201,7 @@ pub fn get_tier_discount(env: &Env, tier: u32) -> u32 {
 }
 
 pub fn set_tier_discount(env: &Env, tier: u32, discount_bps: u32) {
+    assert!(tier <= MAX_TIER, "tier exceeds MAX_TIER");
     assert!(discount_bps <= 10_000, "discount cannot exceed 10 000 bps");
     env.storage()
         .instance()
@@ -204,6 +217,7 @@ pub fn get_business_tier(env: &Env, business: &Address) -> u32 {
 }
 
 pub fn set_business_tier(env: &Env, business: &Address, tier: u32) {
+    assert!(tier <= MAX_TIER, "tier exceeds MAX_TIER");
     env.storage()
         .instance()
         .set(&DataKey::BusinessTier(business.clone()), &tier);

--- a/contracts/attestation/src/lib.rs
+++ b/contracts/attestation/src/lib.rs
@@ -852,4 +852,6 @@ impl AttestationContract {
 #[cfg(test)]
 mod batch_submission_test;
 #[cfg(test)]
+mod tier_bounds_test;
+#[cfg(test)]
 mod test;

--- a/contracts/attestation/src/tier_bounds_test.rs
+++ b/contracts/attestation/src/tier_bounds_test.rs
@@ -1,0 +1,102 @@
+//! Tests for MAX_TIER enforcement in set_business_tier and set_tier_discount.
+//! Issue #318: validate tier and discount bounds at write time.
+
+extern crate std;
+
+use super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
+use soroban_sdk::{Address, Env};
+
+struct TierTestSetup<'a> {
+    env: Env,
+    client: AttestationContractClient<'a>,
+}
+
+fn setup() -> TierTestSetup<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let collector = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_addr = token_contract.address().clone();
+
+    let contract_id = env.register(AttestationContract, ());
+    let client = AttestationContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &0u64);
+    client.configure_fees(&token_addr, &collector, &1_000_000i128, &true);
+
+    TierTestSetup { env, client }
+}
+
+// ── set_business_tier bounds ────────────────────────────────────────
+
+#[test]
+fn test_set_business_tier_zero_accepted() {
+    let t = setup();
+    let biz = Address::generate(&t.env);
+    t.client.set_business_tier(&biz, &0);
+}
+
+#[test]
+fn test_set_business_tier_at_max_accepted() {
+    let t = setup();
+    let biz = Address::generate(&t.env);
+    t.client.set_business_tier(&biz, &dynamic_fees::MAX_TIER);
+}
+
+#[test]
+#[should_panic(expected = "tier exceeds MAX_TIER")]
+fn test_set_business_tier_above_max_panics() {
+    let t = setup();
+    let biz = Address::generate(&t.env);
+    t.client.set_business_tier(&biz, &(dynamic_fees::MAX_TIER + 1));
+}
+
+#[test]
+#[should_panic(expected = "tier exceeds MAX_TIER")]
+fn test_set_business_tier_u32_max_panics() {
+    let t = setup();
+    let biz = Address::generate(&t.env);
+    t.client.set_business_tier(&biz, &u32::MAX);
+}
+
+// ── set_tier_discount bounds ────────────────────────────────────────
+
+#[test]
+fn test_set_tier_discount_at_max_tier_accepted() {
+    let t = setup();
+    t.client.set_tier_discount(&dynamic_fees::MAX_TIER, &5_000);
+}
+
+#[test]
+#[should_panic(expected = "tier exceeds MAX_TIER")]
+fn test_set_tier_discount_above_max_panics() {
+    let t = setup();
+    t.client.set_tier_discount(&(dynamic_fees::MAX_TIER + 1), &5_000);
+}
+
+#[test]
+#[should_panic(expected = "tier exceeds MAX_TIER")]
+fn test_set_tier_discount_u32_max_panics() {
+    let t = setup();
+    t.client.set_tier_discount(&u32::MAX, &0);
+}
+
+/// Tier check fires before discount-bps check.
+#[test]
+#[should_panic(expected = "tier exceeds MAX_TIER")]
+fn test_tier_checked_before_discount_bps() {
+    let t = setup();
+    t.client.set_tier_discount(&(dynamic_fees::MAX_TIER + 1), &10_001);
+}
+
+/// discount_bps > 10 000 is still rejected when tier is valid.
+#[test]
+#[should_panic(expected = "discount cannot exceed 10 000 bps")]
+fn test_discount_over_100_pct_rejected_for_valid_tier() {
+    let t = setup();
+    t.client.set_tier_discount(&0, &10_001);
+}

--- a/docs/attestation-dynamic-fees.md
+++ b/docs/attestation-dynamic-fees.md
@@ -57,9 +57,12 @@ Businesses are assigned to tiers by the contract admin. Tiers are identified by 
 | 0    | Standard     | 0% (default for all businesses) |
 | 1    | Professional | 10–20%                          |
 | 2    | Enterprise   | 30–50%                          |
-| 3+   | Custom       | Admin-defined                   |
+| 3–9  | Custom       | Admin-defined                   |
 
-The scheme is open-ended — any `u32` tier level can be configured with a discount.
+**Tier bounds:** valid tier indices are `0` through `MAX_TIER` (currently **9**, inclusive). Both
+`set_business_tier` and `set_tier_discount` reject any value above `MAX_TIER` with a runtime
+panic, ensuring that misconfiguration is caught at write time rather than silently yielding a
+zero-discount (full-fee) result for an unconfigured tier slot.
 
 Unassigned businesses default to tier 0.
 


### PR DESCRIPTION
## Summary

- Introduces `MAX_TIER = 9` constant in `dynamic_fees.rs`
- Adds bounds assertions in `set_business_tier` and `set_tier_discount` so an out-of-range tier panics at write time rather than silently landing a business in an unconfigured slot (which yields 0 discount = full fee)
- Documents the supported tier range in `docs/attestation-dynamic-fees.md`
- 9 new tests in `tier_bounds_test.rs` covering all edge cases

## Security notes

Without this fix, an admin typo (e.g. `tier = 10` when only `0–2` are configured) silently assigns a business to an unconfigured tier slot, causing `get_tier_discount` to return 0 and charge the full base fee — a silent misconfiguration that is hard to detect from on-chain state. The write-time assertion makes the error immediately visible.

## Test plan

| Test | Expected |
|------|----------|
| `test_set_business_tier_zero_accepted` | pass |
| `test_set_business_tier_at_max_accepted` (tier = 9) | pass |
| `test_set_business_tier_above_max_panics` (tier = 10) | panic: `tier exceeds MAX_TIER` |
| `test_set_business_tier_u32_max_panics` | panic |
| `test_set_tier_discount_at_max_tier_accepted` (tier = 9) | pass |
| `test_set_tier_discount_above_max_panics` (tier = 10) | panic |
| `test_set_tier_discount_u32_max_panics` | panic |
| `test_tier_checked_before_discount_bps` | tier check fires first |
| `test_discount_over_100_pct_rejected_for_valid_tier` | discount check still works |

All 31 tests pass (`cargo test -p veritasor-attestation`).

Closes #318