### PR TITLE
fix: resolve CI workflow compilation errors

### DIFF
--- a/contracts/attestation/src/dynamic_fees_test.rs
+++ b/contracts/attestation/src/dynamic_fees_test.rs
@@ -517,3 +517,30 @@ fn test_max_discount_combinations() {
     assert_eq!(t.client.get_fee_quote(&biz_combined), 0);
 }
 
+
+#[test]
+fn test_get_volume_brackets_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AttestationContract, ());
+    let client = AttestationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &0u64);
+
+    let (thresholds, discounts) = client.get_volume_brackets();
+    assert_eq!(thresholds.len(), 0);
+    assert_eq!(discounts.len(), 0);
+}
+
+#[test]
+fn test_get_volume_brackets_round_trip() {
+    let t = setup_with_fees(1_000_000);
+
+    let thresholds = vec![&t.env, 5u64, 10u64, 50u64];
+    let discounts = vec![&t.env, 500u32, 1_500u32, 3_000u32];
+    t.client.set_volume_brackets(&thresholds, &discounts);
+
+    let (got_thresholds, got_discounts) = t.client.get_volume_brackets();
+    assert_eq!(got_thresholds, thresholds);
+    assert_eq!(got_discounts, discounts);
+}

--- a/contracts/attestation/src/lib.rs
+++ b/contracts/attestation/src/lib.rs
@@ -153,6 +153,18 @@ impl AttestationContract {
         dynamic_fees::set_volume_brackets(&env, &thresholds, &discounts);
     }
 
+    /// Returns the configured volume brackets as two parallel vectors: `(thresholds, discounts)`.
+    ///
+    /// `thresholds[i]` is the minimum cumulative attestation count to enter bracket `i`;
+    /// `discounts[i]` is the corresponding discount in basis points (0–10 000).
+    /// Both vectors are empty when no brackets have been configured.
+    pub fn get_volume_brackets(env: Env) -> (Vec<u64>, Vec<u32>) {
+        (
+            dynamic_fees::get_volume_thresholds(&env),
+            dynamic_fees::get_volume_discounts_vec(&env),
+        )
+    }
+
     pub fn set_fee_enabled(env: Env, enabled: bool) {
         dynamic_fees::require_admin(&env);
         dynamic_fees::set_fee_enabled(&env, enabled);
@@ -567,19 +579,12 @@ impl AttestationContract {
             timestamp,
             version,
             fee,
-            proof_hash.clone(),
-            expiry,
+            proof_hash,
+            Some(new_expiry),
         );
         env.storage().instance().set(&key, &data);
 
-        events::emit_proof_hash_updated(
-            &env,
-            &business,
-            &period,
-            &old_proof_hash,
-            &proof_hash,
-            &caller,
-        );
+        events::emit_attestation_expiry_extended(&env, &business, &period, old_expiry, new_expiry);
     }
 
     pub fn get_attestation(env: Env, business: Address, period: String) -> Option<AttestationData> {
@@ -589,6 +594,42 @@ impl AttestationContract {
 
     pub fn get_proof_hash(env: Env, business: Address, period: String) -> Option<BytesN<32>> {
         Self::get_attestation(env, business, period).and_then(|data| data.4)
+    }
+
+    pub fn update_proof_hash(
+        env: Env,
+        caller: Address,
+        business: Address,
+        period: String,
+        new_proof_hash: Option<BytesN<32>>,
+    ) {
+        access_control::require_admin(&env, &caller);
+
+        let key = DataKey::Attestation(business.clone(), period.clone());
+        let (merkle_root, timestamp, version, fee, old_proof_hash, expiry): AttestationData = env
+            .storage()
+            .instance()
+            .get(&key)
+            .expect("attestation not found");
+
+        let data: AttestationData = (
+            merkle_root,
+            timestamp,
+            version,
+            fee,
+            new_proof_hash.clone(),
+            expiry,
+        );
+        env.storage().instance().set(&key, &data);
+
+        events::emit_proof_hash_updated(
+            &env,
+            &business,
+            &period,
+            &old_proof_hash,
+            &new_proof_hash,
+            &caller,
+        );
     }
 
     pub fn get_attestation_for_period(
@@ -1037,10 +1078,58 @@ impl AttestationContract {
 
 // ── Test Modules ──
 #[cfg(test)]
+mod access_control_test;
+#[cfg(test)]
+mod anomaly_test;
+#[cfg(test)]
+mod attestor_staking_integration_test;
+#[cfg(test)]
 mod batch_submission_test;
 #[cfg(test)]
-mod tier_bounds_test;
+mod dao_override_test;
+#[cfg(test)]
+mod dispute_test;
+#[cfg(test)]
+mod dynamic_fees_test;
+#[cfg(test)]
+mod events_test;
+#[cfg(test)]
+mod expiry_test;
+#[cfg(test)]
+mod extend_expiry_test;
+#[cfg(test)]
+mod extended_metadata_test;
+#[cfg(test)]
+mod fee_admin_auth_test;
+#[cfg(test)]
+mod fees_test;
+#[cfg(test)]
+mod gas_benchmark_test;
+#[cfg(test)]
+mod key_rotation_test;
+#[cfg(test)]
+mod multi_period_test;
+#[cfg(test)]
+mod multisig_test;
+#[cfg(test)]
+mod pause_test;
+#[cfg(test)]
+mod proof_hash_test;
+#[cfg(test)]
+mod proof_hash_update_test;
+#[cfg(test)]
+mod property_test;
+#[cfg(test)]
+mod query_pagination_test;
+#[cfg(test)]
+mod rate_limit_test;
+#[cfg(test)]
+mod registry_test;
+#[cfg(test)]
+mod revocation_test;
 #[cfg(test)]
 mod test;
+#[cfg(test)]
+mod tier_bounds_test;
 #[cfg(test)]
 mod verify_attestation_test;

--- a/contracts/attestation/src/proof_hash_update_test.rs
+++ b/contracts/attestation/src/proof_hash_update_test.rs
@@ -43,6 +43,7 @@ fn non_admin_caller_is_rejected() {
         &merkle_root,
         &1000u64,
         &1u32,
+        &0i128,
         &Some(proof_hash),
         &None,
     );
@@ -84,6 +85,7 @@ fn get_proof_hash_reflects_new_value_after_update() {
         &merkle_root,
         &1000u64,
         &1u32,
+        &0i128,
         &Some(proof_hash.clone()),
         &None,
     );
@@ -118,6 +120,7 @@ fn other_fields_unchanged_after_update() {
         &merkle_root,
         &timestamp,
         &version,
+        &0i128,
         &Some(proof_hash),
         &None,
     );
@@ -150,6 +153,7 @@ fn can_update_to_none_proof_hash() {
         &merkle_root,
         &1000u64,
         &1u32,
+        &0i128,
         &Some(proof_hash),
         &None,
     );
@@ -177,6 +181,7 @@ fn can_update_from_none_to_some_proof_hash() {
         &merkle_root,
         &1000u64,
         &1u32,
+        &0i128,
         &None,
         &None,
     );


### PR DESCRIPTION
- extend_expiry: fix undefined variables (expiry, old_proof_hash, caller) and wrong event call; now correctly stores Some(new_expiry) and emits emit_attestation_expiry_extended
- add missing update_proof_hash public method (referenced in tests but absent from contract impl)
- declare all 27 test modules in lib.rs (only 4 were registered, causing 23 test files to be silently excluded from cargo test)
- fix proof_hash_update_test: insert missing _fee_paid arg in all 5 submit_attestation calls
- feat: expose get_volume_brackets read accessor delegating to get_volume_thresholds and get_volume_discounts_vec
- add get_volume_brackets tests: empty brackets and round-trip

closes #316