### PR TITLE
"Add property tests for compute_fee bounds and discount commutativity Emit fee config change events from configure_fees and set_fee_enabled Add tests for get_proof_hash returning None vs Some across submission paths

### DIFF
--- a/contracts/attestation/src/events_test.rs
+++ b/contracts/attestation/src/events_test.rs
@@ -27,17 +27,19 @@ use crate::access_control::ROLE_ADMIN;
 use crate::events::{
     AttestationMigratedEvent, AttestationRevokedEvent, AttestationSubmittedEvent,
     BusinessApprovedEvent, BusinessReactivatedEvent, BusinessRegisteredEvent,
-    BusinessSuspendedEvent, FeeConfigChangedEvent, KeyRotationCancelledEvent,
-    KeyRotationConfirmedEvent, KeyRotationEmergencyEvent, KeyRotationProposedEvent,
-    PauseChangedEvent, RateLimitConfigChangedEvent, RoleChangedEvent,
+    BusinessSuspendedEvent, FeeConfigChangedEvent, FlatFeeConfigChangedEvent,
+    KeyRotationCancelledEvent, KeyRotationConfirmedEvent, KeyRotationEmergencyEvent,
+    KeyRotationProposedEvent, PauseChangedEvent, ProofHashUpdatedEvent,
+    RateLimitConfigChangedEvent, RoleChangedEvent,
     TOPIC_ATTESTATION_MIGRATED, TOPIC_ATTESTATION_REVOKED, TOPIC_ATTESTATION_SUBMITTED,
     TOPIC_BIZ_APPROVED, TOPIC_BIZ_REACTIVATE, TOPIC_BIZ_REGISTERED, TOPIC_BIZ_SUSPENDED,
-    TOPIC_FEE_CONFIG, TOPIC_KEY_ROTATION_CANCELLED, TOPIC_KEY_ROTATION_CONFIRMED,
-    TOPIC_KEY_ROTATION_EMERGENCY, TOPIC_KEY_ROTATION_PROPOSED, TOPIC_PAUSED, TOPIC_RATE_LIMIT,
-    TOPIC_ROLE_GRANTED, TOPIC_ROLE_REVOKED, TOPIC_UNPAUSED, EVENT_SCHEMA_VERSION,
+    TOPIC_FEE_CONFIG, TOPIC_FLAT_FEE_CONFIG, TOPIC_KEY_ROTATION_CANCELLED,
+    TOPIC_KEY_ROTATION_CONFIRMED, TOPIC_KEY_ROTATION_EMERGENCY, TOPIC_KEY_ROTATION_PROPOSED,
+    TOPIC_PAUSED, TOPIC_PROOF_HASH_UPDATED, TOPIC_RATE_LIMIT, TOPIC_ROLE_GRANTED,
+    TOPIC_ROLE_REVOKED, TOPIC_UNPAUSED, EVENT_SCHEMA_VERSION,
 };
 use soroban_sdk::testutils::{Address as _, Events as _};
-use soroban_sdk::{symbol_short, Address, BytesN, Env, IntoVal, String, TryFromVal};
+use soroban_sdk::{symbol_short, Address, BytesN, Env, String, Symbol, TryFromVal};
 
 // ════════════════════════════════════════════════════════════════════
 //  Test helpers
@@ -60,7 +62,6 @@ fn submit_default(
     env: &Env,
     business: &Address,
     period: &String,
-    nonce: u64,
 ) {
     let root = BytesN::from_array(env, &[1u8; 32]);
     client.submit_attestation(
@@ -69,9 +70,9 @@ fn submit_default(
         &root,
         &1_700_000_000u64,
         &1u32,
+        &0i128,
         &None,
         &None,
-        &nonce,
     );
 }
 
@@ -119,16 +120,15 @@ fn test_multiple_attestations_emit_multiple_events() {
     for i in 1u64..=5 {
         let period = String::from_str(&env, &alloc::format!("2026-0{}", i));
         let root = BytesN::from_array(&env, &[i as u8; 32]);
-        let nonce = client.get_replay_nonce(&business, &crate::NONCE_CHANNEL_BUSINESS);
         client.submit_attestation(
             &business,
             &period,
             &root,
             &(1_700_000_000u64 + i),
             &1u32,
+            &0i128,
             &None,
             &None,
-            &nonce,
         );
     }
 
@@ -389,6 +389,53 @@ fn test_fee_config_changed_disabled_state() {
 }
 
 // ════════════════════════════════════════════════════════════════════
+//  8b. Schema Snapshot — FlatFeeConfigChangedEvent
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_flat_fee_config_changed_schema_snapshot() {
+    let (env, _client, _admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+    let changed_by = Address::generate(&env);
+
+    crate::events::emit_flat_fee_config_changed(
+        &env, &token, &collector, 500i128, true, &changed_by,
+    );
+
+    let (_cid, topics, data) = env.events().all().last().unwrap();
+    assert_eq!(topics.len(), 1);
+    assert_eq!(
+        Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap(),
+        TOPIC_FLAT_FEE_CONFIG,
+    );
+
+    let ev = FlatFeeConfigChangedEvent::try_from_val(&env, &data).unwrap();
+    assert_eq!(ev.token, token);
+    assert_eq!(ev.collector, collector);
+    assert_eq!(ev.amount, 500i128);
+    assert!(ev.enabled);
+    assert_eq!(ev.changed_by, changed_by);
+}
+
+#[test]
+fn test_flat_fee_config_changed_disabled_zero_amount() {
+    let (env, _client, _admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+    let changed_by = Address::generate(&env);
+
+    crate::events::emit_flat_fee_config_changed(
+        &env, &token, &collector, 0i128, false, &changed_by,
+    );
+
+    let (_cid, _topics, data) = env.events().all().last().unwrap();
+    let ev = FlatFeeConfigChangedEvent::try_from_val(&env, &data).unwrap();
+    assert_eq!(ev.amount, 0);
+    assert!(!ev.enabled);
+}
+
+// ════════════════════════════════════════════════════════════════════
 //  9. Schema Snapshot — RateLimitConfigChangedEvent (all fields)
 // ════════════════════════════════════════════════════════════════════
 
@@ -616,7 +663,7 @@ fn test_revoke_attestation_emits_event() {
     let (env, client, admin) = setup();
     let business = Address::generate(&env);
     let period = String::from_str(&env, "2026-02");
-    submit_default(&client, &env, &business, &period, 0);
+    submit_default(&client, &env, &business, &period);
 
     let reason = String::from_str(&env, "fraudulent data detected");
     client.revoke_attestation(&admin, &business, &period, &reason, &1u64);
@@ -629,10 +676,10 @@ fn test_migrate_attestation_emits_event() {
     let (env, client, admin) = setup();
     let business = Address::generate(&env);
     let period = String::from_str(&env, "2026-02");
-    submit_default(&client, &env, &business, &period, 0);
+    submit_default(&client, &env, &business, &period);
     let new_root = BytesN::from_array(&env, &[2u8; 32]);
 
-    client.migrate_attestation(&admin, &business, &period, &new_root, &2u32, &1u64);
+    client.migrate_attestation(&admin, &business, &period, &new_root, &2u32);
 
     assert!(!env.events().all().is_empty());
 }
@@ -642,7 +689,7 @@ fn test_grant_role_emits_event() {
     let (env, client, admin) = setup();
     let user = Address::generate(&env);
 
-    client.grant_role(&admin, &user, &ROLE_ADMIN, &1u64);
+    client.grant_role(&admin, &user, &ROLE_ADMIN);
 
     assert!(!env.events().all().is_empty());
 }
@@ -652,8 +699,8 @@ fn test_revoke_role_emits_event() {
     let (env, client, admin) = setup();
     let user = Address::generate(&env);
 
-    client.grant_role(&admin, &user, &ROLE_ADMIN, &1u64);
-    client.revoke_role(&admin, &user, &ROLE_ADMIN, &2u64);
+    client.grant_role(&admin, &user, &ROLE_ADMIN);
+    client.revoke_role(&admin, &user, &ROLE_ADMIN);
 
     assert!(!env.events().all().is_empty());
 }
@@ -661,15 +708,15 @@ fn test_revoke_role_emits_event() {
 #[test]
 fn test_pause_emits_event() {
     let (env, client, admin) = setup();
-    client.pause(&admin, &1u64);
+    client.pause(&admin);
     assert!(!env.events().all().is_empty());
 }
 
 #[test]
 fn test_unpause_emits_event() {
     let (env, client, admin) = setup();
-    client.pause(&admin, &1u64);
-    client.unpause(&admin, &2u64);
+    client.pause(&admin);
+    client.unpause(&admin);
     assert!(!env.events().all().is_empty());
 }
 
@@ -693,11 +740,11 @@ fn test_duplicate_attestation_panics_no_double_event() {
     let business = Address::generate(&env);
     let period = String::from_str(&env, "2026-02");
 
-    submit_default(&client, &env, &business, &period, 0);
+    submit_default(&client, &env, &business, &period);
     let events_after_first = env.events().all().len();
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        submit_default(&client, &env, &business, &period, 1);
+        submit_default(&client, &env, &business, &period);
     }));
 
     assert!(result.is_err(), "expected duplicate submission to panic");
@@ -713,13 +760,13 @@ fn test_migrate_same_version_panics_no_event() {
     let (env, client, admin) = setup();
     let business = Address::generate(&env);
     let period = String::from_str(&env, "2026-02");
-    submit_default(&client, &env, &business, &period, 0);
+    submit_default(&client, &env, &business, &period);
     let new_root = BytesN::from_array(&env, &[2u8; 32]);
 
     let events_before_migration = env.events().all().len();
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        client.migrate_attestation(&admin, &business, &period, &new_root, &1u32, &1u64);
+        client.migrate_attestation(&admin, &business, &period, &new_root, &1u32);
     }));
 
     assert!(result.is_err(), "expected same-version migration to panic");
@@ -738,11 +785,11 @@ fn test_migrate_lower_version_panics() {
     let period = String::from_str(&env, "2026-02");
     let root = BytesN::from_array(&env, &[1u8; 32]);
     client.submit_attestation(
-        &business, &period, &root, &1_700_000_000u64, &5u32, &None, &None, &0u64,
+        &business, &period, &root, &1_700_000_000u64, &5u32, &0i128, &None, &None,
     );
     let new_root = BytesN::from_array(&env, &[2u8; 32]);
     // Version 3 < 5 — must panic
-    client.migrate_attestation(&admin, &business, &period, &new_root, &3u32, &1u64);
+    client.migrate_attestation(&admin, &business, &period, &new_root, &3u32);
 }
 
 // ════════════════════════════════════════════════════════════════════
@@ -762,7 +809,7 @@ fn test_is_revoked_true_after_revocation() {
     let (env, client, admin) = setup();
     let business = Address::generate(&env);
     let period = String::from_str(&env, "2026-02");
-    submit_default(&client, &env, &business, &period, 0);
+    submit_default(&client, &env, &business, &period);
 
     let reason = String::from_str(&env, "policy violation");
     client.revoke_attestation(&admin, &business, &period, &reason, &1u64);
@@ -777,7 +824,7 @@ fn test_revoked_attestation_fails_verify() {
     let root = BytesN::from_array(&env, &[1u8; 32]);
 
     client.submit_attestation(
-        &business, &period, &root, &1_700_000_000u64, &1u32, &None, &None, &0u64,
+        &business, &period, &root, &1_700_000_000u64, &1u32, &0i128, &None, &None,
     );
 
     assert!(client.verify_attestation(&business, &period, &root));
@@ -891,9 +938,9 @@ fn test_events_are_ordered_chronologically() {
     let period2 = String::from_str(&env, "2026-02");
     let period3 = String::from_str(&env, "2026-03");
 
-    submit_default(&client, &env, &business, &period1, 0);
-    submit_default(&client, &env, &business, &period2, 1);
-    submit_default(&client, &env, &business, &period3, 2);
+    submit_default(&client, &env, &business, &period1);
+    submit_default(&client, &env, &business, &period2);
+    submit_default(&client, &env, &business, &period3);
 
     let events = env.events().all();
 
@@ -922,15 +969,15 @@ fn test_multiple_migrations_emit_incremental_events() {
     let root_v3 = BytesN::from_array(&env, &[3u8; 32]);
 
     client.submit_attestation(
-        &business, &period, &root_v1, &1_700_000_000u64, &1u32, &None, &None, &0u64,
+        &business, &period, &root_v1, &1_700_000_000u64, &1u32, &0i128, &None, &None,
     );
     let count_after_submit = env.events().all().len();
 
-    client.migrate_attestation(&admin, &business, &period, &root_v2, &2u32, &1u64);
+    client.migrate_attestation(&admin, &business, &period, &root_v2, &2u32);
     let count_after_v2 = env.events().all().len();
     assert!(count_after_v2 > count_after_submit, "migration v2 must emit an event");
 
-    client.migrate_attestation(&admin, &business, &period, &root_v3, &3u32, &2u64);
+    client.migrate_attestation(&admin, &business, &period, &root_v3, &3u32);
     let count_after_v3 = env.events().all().len();
     assert!(count_after_v3 > count_after_v2, "migration v3 must emit an event");
 
@@ -942,29 +989,26 @@ fn test_multiple_migrations_emit_incremental_events() {
 }
 
 #[test]
-fn test_replay_nonce_prevents_duplicate_submission_event() {
+fn test_duplicate_period_rejected_no_extra_event() {
+    // Verifies that a second submission for the same business+period panics (duplicate rule)
+    // and does not emit an additional att_sub event.
     let (env, client, _admin) = setup();
     let business = Address::generate(&env);
     let period = String::from_str(&env, "2026-02");
-    let root = BytesN::from_array(&env, &[1u8; 32]);
-    let nonce = client.get_replay_nonce(&business, &crate::NONCE_CHANNEL_BUSINESS);
 
-    client.submit_attestation(
-        &business, &period, &root, &1_700_000_000u64, &1u32, &None, &None, &nonce,
-    );
+    submit_default(&client, &env, &business, &period);
     let events_after_first = env.events().all().len();
 
-    // Attempting to use the same nonce again should panic — ensuring one event per submission.
-    let result = std::panic::catch_unwind(|| {
-        // We can't call the client in this context so we just verify the nonce advanced.
-    });
-    let _ = result;
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        submit_default(&client, &env, &business, &period);
+    }));
 
-    // Nonce must have incremented — the next valid nonce is different.
-    let next_nonce = client.get_replay_nonce(&business, &crate::NONCE_CHANNEL_BUSINESS);
-    assert_ne!(nonce, next_nonce, "nonce should advance after a valid submission");
-    // No new events were emitted by the nonce check itself.
-    assert_eq!(env.events().all().len(), events_after_first);
+    assert!(result.is_err(), "duplicate period submission must panic");
+    assert_eq!(
+        env.events().all().len(),
+        events_after_first,
+        "duplicate rejection must not emit an extra event",
+    );
 }
 
 // ════════════════════════════════════════════════════════════════════
@@ -984,6 +1028,7 @@ fn test_all_topic_symbols_are_distinct() {
         TOPIC_PAUSED,
         TOPIC_UNPAUSED,
         TOPIC_FEE_CONFIG,
+        TOPIC_FLAT_FEE_CONFIG,
         TOPIC_RATE_LIMIT,
         TOPIC_KEY_ROTATION_PROPOSED,
         TOPIC_KEY_ROTATION_CONFIRMED,
@@ -993,6 +1038,7 @@ fn test_all_topic_symbols_are_distinct() {
         TOPIC_BIZ_APPROVED,
         TOPIC_BIZ_SUSPENDED,
         TOPIC_BIZ_REACTIVATE,
+        TOPIC_PROOF_HASH_UPDATED,
     ];
 
     for i in 0..topics.len() {
@@ -1006,6 +1052,6 @@ fn test_all_topic_symbols_are_distinct() {
     }
 
     // Explicitly verify count to catch any future additions.
-    assert_eq!(topics.len(), 17, "expected 17 distinct topic symbols");
+    assert_eq!(topics.len(), 19, "expected 19 distinct topic symbols");
     let _ = env; // env required for Address::generate in other tests
 }

--- a/contracts/attestation/src/lib.rs
+++ b/contracts/attestation/src/lib.rs
@@ -127,7 +127,7 @@ impl AttestationContract {
         base_fee: i128,
         enabled: bool,
     ) {
-        dynamic_fees::require_admin(&env);
+        let admin = dynamic_fees::require_admin(&env);
         assert!(base_fee >= 0, "base_fee must be non-negative");
         let config = FeeConfig {
             token,
@@ -136,6 +136,14 @@ impl AttestationContract {
             enabled,
         };
         dynamic_fees::set_fee_config(&env, &config);
+        events::emit_fee_config_changed(
+            &env,
+            &config.token,
+            &config.collector,
+            config.base_fee,
+            config.enabled,
+            &admin,
+        );
     }
 
     pub fn set_tier_discount(env: Env, tier: u32, discount_bps: u32) {
@@ -154,8 +162,18 @@ impl AttestationContract {
     }
 
     pub fn set_fee_enabled(env: Env, enabled: bool) {
-        dynamic_fees::require_admin(&env);
+        let admin = dynamic_fees::require_admin(&env);
         dynamic_fees::set_fee_enabled(&env, enabled);
+        if let Some(config) = dynamic_fees::get_fee_config(&env) {
+            events::emit_fee_config_changed(
+                &env,
+                &config.token,
+                &config.collector,
+                config.base_fee,
+                config.enabled,
+                &admin,
+            );
+        }
     }
 
     pub fn configure_flat_fee(
@@ -165,7 +183,7 @@ impl AttestationContract {
         amount: i128,
         enabled: bool,
     ) {
-        dynamic_fees::require_admin(&env);
+        let admin = dynamic_fees::require_admin(&env);
         let config = FlatFeeConfig {
             token,
             collector,
@@ -173,6 +191,14 @@ impl AttestationContract {
             enabled,
         };
         fees::set_flat_fee_config(&env, &config);
+        events::emit_flat_fee_config_changed(
+            &env,
+            &config.token,
+            &config.collector,
+            config.amount,
+            config.enabled,
+            &admin,
+        );
     }
 
     pub fn set_attestor_staking_contract(env: Env, caller: Address, staking_contract: Address) {
@@ -1033,6 +1059,10 @@ impl AttestationContract {
 mod batch_submission_test;
 #[cfg(test)]
 mod dao_override_test;
+#[cfg(test)]
+mod events_test;
+#[cfg(test)]
+mod property_test;
 #[cfg(test)]
 mod test;
 #[cfg(test)]

--- a/contracts/attestation/src/property_test.rs
+++ b/contracts/attestation/src/property_test.rs
@@ -309,10 +309,10 @@ fn prop_data_integrity_and_counter_monotonicity() {
             "case {idx} [{period_str}]: initial count must be 0"
         );
 
-        client.submit_attestation(&business, &period, &root, &timestamp, &version, &None, &None, &0u64);
+        client.submit_attestation(&business, &period, &root, &timestamp, &version, &0i128, &None, &None);
 
         // P4: Every field must round-trip exactly.
-        let (got_root, got_ts, got_ver, got_fee, _, _, _) = client
+        let (got_root, got_ts, got_ver, got_fee, _, _) = client
             .get_attestation(&business, &period)
             .unwrap_or_else(|| {
                 panic!("case {idx} [{period_str}]: attestation must exist after submit")
@@ -341,7 +341,7 @@ fn prop_data_integrity_and_counter_monotonicity() {
 
         // P5 continued: second submit (different period) increments to 2.
         let period2 = String::from_str(&env, &std::format!("{period_str}-v2"));
-        client.submit_attestation(&business, &period2, &root, &timestamp, &version, &None, &None, &0u64);
+        client.submit_attestation(&business, &period2, &root, &timestamp, &version, &0i128, &None, &None);
         assert_eq!(
             client.get_business_count(&business),
             2,
@@ -392,9 +392,9 @@ fn prop_verify_consistency() {
             &submitted_root,
             &1_700_000_000,
             &1,
+            &0i128,
             &None,
             &None,
-            &0u64,
         );
 
         // After submit: correct root → true, wrong roots → false.
@@ -439,7 +439,7 @@ fn prop_revocation_permanence() {
         let period = String::from_str(&env, "2026-01");
         let submitted_root = BytesN::from_array(&env, &sub_bytes);
 
-        client.submit_attestation(&business, &period, &submitted_root, &1_000_000, &1, &None, &None, &0u64);
+        client.submit_attestation(&business, &period, &submitted_root, &1_000_000, &1, &0i128, &None, &None);
 
         // Sanity: verifies before revocation.
         assert!(
@@ -502,9 +502,9 @@ fn prop_duplicate_attestation_panics() {
             let business = Address::generate(&env);
             let period = String::from_str(&env, &period_owned);
             let root = BytesN::from_array(&env, &[1u8; 32]);
-            client.submit_attestation(&business, &period, &root, &1_000_000, &1, &None, &None, &0u64);
+            client.submit_attestation(&business, &period, &root, &1_000_000, &1, &0i128, &None, &None);
             // Second call for the same (business, period) must panic.
-            client.submit_attestation(&business, &period, &root, &2_000_000, &2, &None, &None, &0u64);
+            client.submit_attestation(&business, &period, &root, &2_000_000, &2, &0i128, &None, &None);
         });
 
         let err = result.expect_err(&std::format!(
@@ -546,8 +546,8 @@ fn prop_migration_succeeds_for_increasing_version() {
         let old_root = BytesN::from_array(&env, &[1u8; 32]);
         let new_root = BytesN::from_array(&env, &[2u8; 32]);
 
-        client.submit_attestation(&business, &period, &old_root, &1_000_000, &old_ver, &None, &None);
-        client.migrate_attestation(&admin, &business, &period, &new_root, &new_ver, &0u64);
+        client.submit_attestation(&business, &period, &old_root, &1_000_000, &old_ver, &0i128, &None, &None);
+        client.migrate_attestation(&admin, &business, &period, &new_root, &new_ver);
 
         let (got_root, _, got_ver, _, _, _) = client.get_attestation(&business, &period).unwrap();
         assert_eq!(
@@ -585,8 +585,8 @@ fn prop_migration_panics_for_non_increasing_version() {
             let period = String::from_str(&env, "2026-01");
             let old_root = BytesN::from_array(&env, &[1u8; 32]);
             let new_root = BytesN::from_array(&env, &[2u8; 32]);
-            client.submit_attestation(&business, &period, &old_root, &1_000_000, &old_ver, &None, &None, &0u64);
-            client.migrate_attestation(&admin_addr, &business, &period, &new_root, &bad_new_ver, &0u64);
+            client.submit_attestation(&business, &period, &old_root, &1_000_000, &old_ver, &0i128, &None, &None);
+            client.migrate_attestation(&admin_addr, &business, &period, &new_root, &bad_new_ver);
         });
 
         let err = result.expect_err(&std::format!(
@@ -789,8 +789,8 @@ fn prop_business_isolation() {
     let root_a = BytesN::from_array(&env, &[1u8; 32]);
     let root_b = BytesN::from_array(&env, &[2u8; 32]);
 
-    client.submit_attestation(&biz_a, &period, &root_a, &1_000, &1, &None, &None, &0u64);
-    client.submit_attestation(&biz_b, &period, &root_b, &2_000, &2, &None, &None, &0u64);
+    client.submit_attestation(&biz_a, &period, &root_a, &1_000, &1, &0i128, &None, &None);
+    client.submit_attestation(&biz_b, &period, &root_b, &2_000, &2, &0i128, &None, &None);
 
     // biz_c has no attestation.
     assert!(
@@ -808,8 +808,8 @@ fn prop_business_isolation() {
     );
 
     // biz_a and biz_b have independent data.
-    let (a_root, _, a_ver, _, _, _, _) = client.get_attestation(&biz_a, &period).unwrap();
-    let (b_root, _, b_ver, _, _, _, _) = client.get_attestation(&biz_b, &period).unwrap();
+    let (a_root, _, a_ver, _, _, _) = client.get_attestation(&biz_a, &period).unwrap();
+    let (b_root, _, b_ver, _, _, _) = client.get_attestation(&biz_b, &period).unwrap();
     assert_eq!(a_root, root_a, "biz_a root must match what was submitted");
     assert_eq!(b_root, root_b, "biz_b root must match what was submitted");
     assert_ne!(a_ver, b_ver, "versions were different and must differ");
@@ -867,11 +867,11 @@ fn prop_pause_blocks_all_submissions() {
             let client = AttestationContractClient::new(&env, &contract_id);
             let admin = Address::generate(&env);
             client.initialize(&admin, &0u64);
-            client.pause(&client.get_admin(), &0u64);
+            client.pause(&client.get_admin());
             let business = Address::generate(&env);
             let period = String::from_str(&env, &period_owned);
             let root = BytesN::from_array(&env, &[1u8; 32]);
-            client.submit_attestation(&business, &period, &root, &1_000, &1, &None, &None, &0u64);
+            client.submit_attestation(&business, &period, &root, &1_000, &1, &0i128, &None, &None);
         });
 
         let err = result.expect_err(&std::format!(
@@ -894,11 +894,11 @@ fn prop_unpause_restores_submission() {
     let period = String::from_str(&env, "2026-01");
     let root = BytesN::from_array(&env, &[1u8; 32]);
 
-    client.pause(&client.get_admin(), &0u64);
-    client.unpause(&client.get_admin(), &0u64);
+    client.pause(&client.get_admin());
+    client.unpause(&client.get_admin());
 
     // Must succeed after unpause.
-    client.submit_attestation(&business, &period, &root, &1_000, &1, &None, &None, &0u64);
+    client.submit_attestation(&business, &period, &root, &1_000, &1, &0i128, &None, &None);
     assert!(
         client.get_attestation(&business, &period).is_some(),
         "attestation must exist after unpause + submit"
@@ -957,7 +957,7 @@ fn prop_fee_quote_matches_actual_charge() {
         for i in 0..vol_threshold {
             let warm_period = String::from_str(&env, &std::format!("WARM-{i:05}"));
             let warm_root = BytesN::from_array(&env, &[i as u8; 32]);
-            client.submit_attestation(&business, &warm_period, &warm_root, &1, &1, &None, &None);
+            client.submit_attestation(&business, &warm_period, &warm_root, &1, &1, &0i128, &None, &None);
         }
 
         // Capture quote and balance immediately before the test submission.
@@ -966,7 +966,7 @@ fn prop_fee_quote_matches_actual_charge() {
 
         let test_period = String::from_str(&env, "TEST-FINAL");
         let test_root = BytesN::from_array(&env, &[99u8; 32]);
-        client.submit_attestation(&business, &test_period, &test_root, &1_000_000, &1, &None, &None);
+        client.submit_attestation(&business, &test_period, &test_root, &1_000_000, &1, &0i128, &None, &None);
 
         let after = token_balance(&env, &token_addr, &business);
         let charged = before - after;
@@ -978,7 +978,7 @@ fn prop_fee_quote_matches_actual_charge() {
         );
 
         // P14-b: fee_paid field in the stored attestation record also matches.
-        let (_, _, _, fee_in_record, _, _, _) = client.get_attestation(&business, &test_period).unwrap();
+        let (_, _, _, fee_in_record, _, _) = client.get_attestation(&business, &test_period).unwrap();
         assert_eq!(
             fee_in_record, quote,
             "stored fee_paid must equal the pre-submit quote"
@@ -1176,7 +1176,7 @@ fn prop_tier_upgrade_fee_monotonicity() {
     let (env, client, _admin, token_addr, _collector) = setup_with_fees(base_fee);
 
     for &(tier_level, discount_bps) in TIER_MONOTONICITY_DISCOUNTS {
-        client.set_tier_discount(&client.get_admin(), &tier_level, &discount_bps);
+        client.set_tier_discount(&tier_level, &discount_bps);
     }
 
     let business = Address::generate(&env);
@@ -1185,7 +1185,7 @@ fn prop_tier_upgrade_fee_monotonicity() {
     let mut prev_quote = i128::MAX;
 
     for &(tier_level, discount_bps) in TIER_MONOTONICITY_DISCOUNTS {
-        client.set_business_tier(&client.get_admin(), &business, &tier_level);
+        client.set_business_tier(&business, &tier_level);
         let quote = client.get_fee_quote(&business);
 
         // P21: Quote must be ≤ previous quote.
@@ -1240,7 +1240,7 @@ fn prop_volume_bracket_crossing_fee_monotonicity() {
         for &d in VOLUME_BRACKET_DISCOUNTS { v.push_back(d); }
         v
     };
-    client.set_volume_brackets(&client.get_admin(), &soroban_thresholds, &soroban_discounts);
+    client.set_volume_brackets(&soroban_thresholds, &soroban_discounts);
 
     let business = Address::generate(&env);
     let total_submissions = VOLUME_BRACKET_THRESHOLDS.last().copied().unwrap_or(0) + 5;
@@ -1261,7 +1261,7 @@ fn prop_volume_bracket_crossing_fee_monotonicity() {
         while submission_idx < target_count {
             let period = String::from_str(&env, &std::format!("VOL-MONO-{submission_idx:05}"));
             let root = BytesN::from_array(&env, &[(submission_idx % 256) as u8; 32]);
-            client.submit_attestation(&business, &period, &root, &1_000_000, &1, &None, &None);
+            client.submit_attestation(&business, &period, &root, &1_000_000, &1, &0i128, &None, &None);
             submission_idx += 1;
         }
 
@@ -1293,7 +1293,7 @@ fn prop_sequential_stored_fees_non_increasing() {
     // Brackets: ≥3 → 10%, ≥8 → 25%, ≥15 → 40%.
     let soroban_thresholds = vec![&env, 3u64, 8u64, 15u64];
     let soroban_discounts  = vec![&env, 1_000u32, 2_500u32, 4_000u32];
-    client.set_volume_brackets(&client.get_admin(), &soroban_thresholds, &soroban_discounts);
+    client.set_volume_brackets(&soroban_thresholds, &soroban_discounts);
 
     let business = Address::generate(&env);
     mint(&env, &token_addr, &business, base_fee * 30);
@@ -1303,9 +1303,9 @@ fn prop_sequential_stored_fees_non_increasing() {
     for i in 0u64..20 {
         let period = String::from_str(&env, &std::format!("SEQ-{i:04}"));
         let root = BytesN::from_array(&env, &[(i % 256) as u8; 32]);
-        client.submit_attestation(&business, &period, &root, &1_000_000, &1, &None, &None);
+        client.submit_attestation(&business, &period, &root, &1_000_000, &1, &0i128, &None, &None);
 
-        let (_, _, _, fee_paid, _, _, _) = client.get_attestation(&business, &period).unwrap();
+        let (_, _, _, fee_paid, _, _) = client.get_attestation(&business, &period).unwrap();
 
         // P23: Each record's fee_paid ≤ previous record's fee_paid.
         assert!(
@@ -1354,13 +1354,13 @@ fn prop_combined_tier_volume_fee_monotonicity() {
         let (env, client, _admin, _token_addr, _collector) = setup_with_fees(base_fee);
         let business = Address::generate(&env);
 
-        client.set_tier_discount(&client.get_admin(), &1u32, &tier_bps);
-        client.set_business_tier(&client.get_admin(), &business, &1u32);
+        client.set_tier_discount(&1u32, &tier_bps);
+        client.set_business_tier(&business, &1u32);
 
         if vol_bps > 0 {
             let soroban_thresholds = vec![&env, 0u64];
             let soroban_discounts  = vec![&env, vol_bps];
-            client.set_volume_brackets(&client.get_admin(), &soroban_thresholds, &soroban_discounts);
+            client.set_volume_brackets(&soroban_thresholds, &soroban_discounts);
         }
 
         let quote   = client.get_fee_quote(&business);
@@ -1502,8 +1502,8 @@ fn prop_tier_assignment_cannot_inflate_fee() {
     mint(&env, &token_addr, &business, base_fee * 10);
 
     for discount_bps in (0u32..=10_000).step_by(500) {
-        client.set_tier_discount(&client.get_admin(), &99u32, &discount_bps);
-        client.set_business_tier(&client.get_admin(), &business, &99u32);
+        client.set_tier_discount(&99u32, &discount_bps);
+        client.set_business_tier(&business, &99u32);
         let quote = client.get_fee_quote(&business);
         assert!(
             quote <= base_fee,
@@ -1527,25 +1527,25 @@ fn prop_fee_toggle_determinism() {
     let (env, client, _admin, _token_addr, _collector) = setup_with_fees(base_fee);
     let business = Address::generate(&env);
 
-    client.set_tier_discount(&client.get_admin(), &1u32, &2_000u32);
-    client.set_business_tier(&client.get_admin(), &business, &1u32);
+    client.set_tier_discount(&1u32, &2_000u32);
+    client.set_business_tier(&business, &1u32);
 
     let soroban_thresholds = vec![&env, 0u64];
     let soroban_discounts  = vec![&env, 1_000u32];
-    client.set_volume_brackets(&client.get_admin(), &soroban_thresholds, &soroban_discounts);
+    client.set_volume_brackets(&soroban_thresholds, &soroban_discounts);
 
     // Expected fee: 1_000_000 × 0.80 × 0.90 = 720_000
     let expected_fee = compute_fee(base_fee, 2_000, 1_000);
 
     for cycle in 0..5u32 {
-        client.set_fee_enabled(&client.get_admin(), &true);
+        client.set_fee_enabled(&true);
         let enabled_quote = client.get_fee_quote(&business);
         assert_eq!(
             enabled_quote, expected_fee,
             "cycle={cycle}: enabled quote={enabled_quote} != expected={expected_fee}"
         );
 
-        client.set_fee_enabled(&client.get_admin(), &false);
+        client.set_fee_enabled(&false);
         let disabled_quote = client.get_fee_quote(&business);
         assert_eq!(
             disabled_quote, 0,
@@ -1566,7 +1566,7 @@ fn prop_zero_threshold_volume_bracket_applies_immediately() {
 
     let soroban_thresholds = vec![&env, 0u64];
     let soroban_discounts  = vec![&env, 3_000u32]; // 30% off
-    client.set_volume_brackets(&client.get_admin(), &soroban_thresholds, &soroban_discounts);
+    client.set_volume_brackets(&soroban_thresholds, &soroban_discounts);
 
     let business = Address::generate(&env);
     let expected = compute_fee(base_fee, 0, 3_000); // 700_000
@@ -1582,7 +1582,7 @@ fn prop_zero_threshold_volume_bracket_applies_immediately() {
     let before = token_balance(&env, &token_addr, &business);
     let period = String::from_str(&env, "ZERO-THRESH");
     let root   = BytesN::from_array(&env, &[77u8; 32]);
-    client.submit_attestation(&business, &period, &root, &1_000_000, &1, &None, &None);
+    client.submit_attestation(&business, &period, &root, &1_000_000, &1, &0i128, &None, &None);
     let after = token_balance(&env, &token_addr, &business);
     assert_eq!(
         before - after, expected,
@@ -1601,12 +1601,12 @@ fn prop_tier_reassignment_no_state_leakage() {
 
     let tiers: &[(u32, u32)] = &[(0, 0), (1, 1_000), (2, 5_000), (3, 10_000)];
     for &(tier, disc) in tiers {
-        client.set_tier_discount(&client.get_admin(), &tier, &disc);
+        client.set_tier_discount(&tier, &disc);
     }
 
     // Cycle through tiers in arbitrary order; settle on tier 2.
     for &t in &[3u32, 1, 0, 2, 3, 0, 1, 2] {
-        client.set_business_tier(&client.get_admin(), &business, &t);
+        client.set_business_tier(&business, &t);
     }
 
     let final_quote = client.get_fee_quote(&business);
@@ -1649,21 +1649,21 @@ fn prop_regression_docs_worked_example() {
     // Contract layer: reproduce the docs scenario end-to-end.
     let (env, client, _admin, token_addr, _collector) = setup_with_fees(1_000_000);
 
-    client.set_tier_discount(&client.get_admin(), &1u32, &2_000u32); // 20%
+    client.set_tier_discount(&1u32, &2_000u32); // 20%
 
     let soroban_thresholds = vec![&env, 10u64];
     let soroban_discounts  = vec![&env, 1_000u32]; // 10%
-    client.set_volume_brackets(&client.get_admin(), &soroban_thresholds, &soroban_discounts);
+    client.set_volume_brackets(&soroban_thresholds, &soroban_discounts);
 
     let business = Address::generate(&env);
-    client.set_business_tier(&client.get_admin(), &business, &1u32);
+    client.set_business_tier(&business, &1u32);
     mint(&env, &token_addr, &business, 1_000_000 * 25);
 
     // Submit 12 attestations → count = 12 (≥10 bracket active).
     for i in 0u64..12 {
         let period = String::from_str(&env, &std::format!("DOC-EX-{i:03}"));
         let root   = BytesN::from_array(&env, &[(i % 256) as u8; 32]);
-        client.submit_attestation(&business, &period, &root, &1_700_000_000, &1, &None, &None);
+        client.submit_attestation(&business, &period, &root, &1_700_000_000, &1, &0i128, &None, &None);
     }
 
     let quote = client.get_fee_quote(&business);
@@ -1680,13 +1680,13 @@ fn prop_get_fee_quote_is_idempotent() {
     let base_fee: i128 = 750_000;
     let (env, client, _admin, _token_addr, _collector) = setup_with_fees(base_fee);
 
-    client.set_tier_discount(&client.get_admin(), &1u32, &1_500u32);
+    client.set_tier_discount(&1u32, &1_500u32);
     let business = Address::generate(&env);
-    client.set_business_tier(&client.get_admin(), &business, &1u32);
+    client.set_business_tier(&business, &1u32);
 
     let soroban_thresholds = vec![&env, 0u64];
     let soroban_discounts  = vec![&env, 1_000u32];
-    client.set_volume_brackets(&client.get_admin(), &soroban_thresholds, &soroban_discounts);
+    client.set_volume_brackets(&soroban_thresholds, &soroban_discounts);
 
     let first_quote = client.get_fee_quote(&business);
 
@@ -1738,21 +1738,21 @@ fn prop_regression_protocol_revenue_determinism() {
     let base_fee: i128 = 1_000_000;
     let (env, client, _admin, token_addr, collector) = setup_with_fees(base_fee);
 
-    client.set_tier_discount(&client.get_admin(), &0u32, &0u32);
-    client.set_tier_discount(&client.get_admin(), &1u32, &1_500u32); // 15%
-    client.set_tier_discount(&client.get_admin(), &2u32, &3_000u32); // 30%
+    client.set_tier_discount(&0u32, &0u32);
+    client.set_tier_discount(&1u32, &1_500u32); // 15%
+    client.set_tier_discount(&2u32, &3_000u32); // 30%
 
     let soroban_thresholds = vec![&env, 5u64, 10u64];
     let soroban_discounts  = vec![&env, 500u32, 1_000u32];
-    client.set_volume_brackets(&client.get_admin(), &soroban_thresholds, &soroban_discounts);
+    client.set_volume_brackets(&soroban_thresholds, &soroban_discounts);
 
     let biz_standard     = Address::generate(&env);
     let biz_professional = Address::generate(&env);
     let biz_enterprise   = Address::generate(&env);
 
-    client.set_business_tier(&client.get_admin(), &biz_standard,     &0u32);
-    client.set_business_tier(&client.get_admin(), &biz_professional, &1u32);
-    client.set_business_tier(&client.get_admin(), &biz_enterprise,   &2u32);
+    client.set_business_tier(&biz_standard,     &0u32);
+    client.set_business_tier(&biz_professional, &1u32);
+    client.set_business_tier(&biz_enterprise,   &2u32);
 
     let mint_amount = base_fee * 20;
     for biz in [&biz_standard, &biz_professional, &biz_enterprise] {
@@ -1767,7 +1767,7 @@ fn prop_regression_protocol_revenue_determinism() {
         ] {
             let period = String::from_str(&env, &std::format!("{prefix}-{i:03}"));
             let root   = BytesN::from_array(&env, &[(i % 256) as u8; 32]);
-            client.submit_attestation(biz, &period, &root, &1_700_000_000, &1, &None, &None);
+            client.submit_attestation(biz, &period, &root, &1_700_000_000, &1, &0i128, &None, &None);
         }
     }
 

--- a/contracts/attestation/src/test.rs
+++ b/contracts/attestation/src/test.rs
@@ -298,3 +298,170 @@ fn test_migrate_attestation_preserves_fee_and_optional_fields() {
     assert_eq!(stored_proof, proof_hash);
     assert_eq!(stored_expiry, expiry);
 }
+
+// ── Fee configuration events ───────────────────────────────────────
+
+#[test]
+fn test_configure_fees_emits_fee_config_changed_event() {
+    let (env, client, admin, _) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.configure_fees(&token, &collector, &1_000i128, &true);
+
+    let events = env.events().all();
+    let last = events.last().unwrap();
+    let topics = last.1.clone();
+
+    assert_eq!(topics.len(), 1);
+    assert_eq!(
+        soroban_sdk::Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap(),
+        symbol_short!("fee_cfg"),
+        "configure_fees must emit a FeeConfigChanged event"
+    );
+
+    let ev = events::FeeConfigChangedEvent::try_from_val(&env, &last.2).unwrap();
+    assert_eq!(ev.token, token);
+    assert_eq!(ev.collector, collector);
+    assert_eq!(ev.base_fee, 1_000i128);
+    assert!(ev.enabled);
+    assert_eq!(ev.changed_by, admin);
+}
+
+#[test]
+fn test_configure_fees_event_matches_stored_config() {
+    let (env, client, _admin, _) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.configure_fees(&token, &collector, &500i128, &false);
+
+    let stored = client.get_fee_config().unwrap();
+    let ev = events::FeeConfigChangedEvent::try_from_val(
+        &env,
+        &env.events().all().last().unwrap().2,
+    )
+    .unwrap();
+
+    assert_eq!(ev.token, stored.token);
+    assert_eq!(ev.collector, stored.collector);
+    assert_eq!(ev.base_fee, stored.base_fee);
+    assert_eq!(ev.enabled, stored.enabled);
+}
+
+#[test]
+fn test_set_fee_enabled_emits_fee_config_changed_event() {
+    let (env, client, admin, _) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+    client.configure_fees(&token, &collector, &200i128, &true);
+
+    client.set_fee_enabled(&false);
+
+    let events = env.events().all();
+    let last = events.last().unwrap();
+    let topics = last.1.clone();
+
+    assert_eq!(topics.len(), 1);
+    assert_eq!(
+        soroban_sdk::Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap(),
+        symbol_short!("fee_cfg"),
+        "set_fee_enabled must emit a FeeConfigChanged event"
+    );
+
+    let ev = events::FeeConfigChangedEvent::try_from_val(&env, &last.2).unwrap();
+    assert_eq!(ev.token, token);
+    assert_eq!(ev.collector, collector);
+    assert_eq!(ev.base_fee, 200i128);
+    assert!(!ev.enabled);
+    assert_eq!(ev.changed_by, admin);
+}
+
+#[test]
+fn test_set_fee_enabled_event_reflects_persisted_state() {
+    let (env, client, _admin, _) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+    client.configure_fees(&token, &collector, &100i128, &false);
+
+    client.set_fee_enabled(&true);
+
+    let ev = events::FeeConfigChangedEvent::try_from_val(
+        &env,
+        &env.events().all().last().unwrap().2,
+    )
+    .unwrap();
+    let stored = client.get_fee_config().unwrap();
+
+    assert_eq!(ev.enabled, stored.enabled);
+    assert_eq!(ev.base_fee, stored.base_fee);
+}
+
+#[test]
+fn test_set_fee_enabled_no_config_emits_no_extra_event() {
+    // When no FeeConfig exists, set_fee_enabled is a no-op and must not emit.
+    let (env, client, _admin, _) = setup();
+
+    client.set_fee_enabled(&true);
+
+    // The only event present should be from initialize (role_gr), not fee_cfg.
+    for (_cid, topics, _data) in env.events().all().iter() {
+        if topics.len() > 0 {
+            let sym =
+                soroban_sdk::Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
+            assert_ne!(
+                sym,
+                symbol_short!("fee_cfg"),
+                "set_fee_enabled with no config must not emit a fee_cfg event"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_configure_flat_fee_emits_flat_fee_config_changed_event() {
+    let (env, client, admin, _) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.configure_flat_fee(&token, &collector, &250i128, &true);
+
+    let events = env.events().all();
+    let last = events.last().unwrap();
+    let topics = last.1.clone();
+
+    assert_eq!(topics.len(), 1);
+    assert_eq!(
+        soroban_sdk::Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap(),
+        symbol_short!("ff_cfg"),
+        "configure_flat_fee must emit a FlatFeeConfigChanged event"
+    );
+
+    let ev = events::FlatFeeConfigChangedEvent::try_from_val(&env, &last.2).unwrap();
+    assert_eq!(ev.token, token);
+    assert_eq!(ev.collector, collector);
+    assert_eq!(ev.amount, 250i128);
+    assert!(ev.enabled);
+    assert_eq!(ev.changed_by, admin);
+}
+
+#[test]
+fn test_configure_flat_fee_event_matches_stored_config() {
+    let (env, client, _admin, _) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.configure_flat_fee(&token, &collector, &750i128, &false);
+
+    let stored = client.get_flat_fee_config().unwrap();
+    let ev = events::FlatFeeConfigChangedEvent::try_from_val(
+        &env,
+        &env.events().all().last().unwrap().2,
+    )
+    .unwrap();
+
+    assert_eq!(ev.token, stored.token);
+    assert_eq!(ev.collector, stored.collector);
+    assert_eq!(ev.amount, stored.amount);
+    assert_eq!(ev.enabled, stored.enabled);
+}


### PR DESCRIPTION
Fixes #338" "Add tests for get_proof_hash returning None vs Some across submission paths Fixes #331" "Emit fee config change events from configure_fees and set_fee_enabled Fixes #317"