### PR TITLE
fix: harden compute_fee arithmetic against overflow

### DIFF
--- a/contracts/attestation/src/dynamic_fees.rs
+++ b/contracts/attestation/src/dynamic_fees.rs
@@ -44,6 +44,8 @@
 //! 2. **Integrity**: Discounts are capped at 10,000 bps (100%).
 //! 3. **Consistency**: Volume thresholds must be strictly ascending to ensure
 //!    deterministic bracket selection.
+//! 4. **Arithmetic safety**: `compute_fee` panics on negative `base_fee` or
+//!    any intermediate overflow, and enforces the result in `[0, base_fee]`.
 
 use soroban_sdk::{contracttype, token, Address, Env, Symbol, Val, Vec};
 
@@ -359,9 +361,20 @@ fn get_effective_fee_config(env: &Env) -> Option<FeeConfig> {
 /// - **Bounds**: The result is always in the range `[0, base_fee]`.
 /// - **Rounding**: Truncates toward zero.
 pub fn compute_fee(base_fee: i128, tier_discount_bps: u32, volume_discount_bps: u32) -> i128 {
+    assert!(base_fee >= 0, "base_fee must be non-negative");
     let tier_factor = 10_000i128 - tier_discount_bps as i128;
     let vol_factor = 10_000i128 - volume_discount_bps as i128;
-    base_fee * tier_factor * vol_factor / 100_000_000i128
+    let product = base_fee
+        .checked_mul(tier_factor)
+        .expect("fee overflow: base_fee * tier_factor")
+        .checked_mul(vol_factor)
+        .expect("fee overflow: base_fee * tier_factor * vol_factor");
+    let fee = product
+        .checked_div(100_000_000i128)
+        .expect("fee overflow: divide by scale");
+    assert!(fee >= 0, "fee must be non-negative");
+    assert!(fee <= base_fee, "fee exceeds base_fee");
+    fee
 }
 
 /// Collect the fee: transfer tokens from `business` to the fee collector.

--- a/contracts/attestation/src/dynamic_fees_test.rs
+++ b/contracts/attestation/src/dynamic_fees_test.rs
@@ -121,6 +121,24 @@ fn test_compute_fee_zero_base() {
 }
 
 #[test]
+#[should_panic(expected = "base_fee must be non-negative")]
+fn test_compute_fee_negative_base_panics() {
+    compute_fee(-1, 0, 0);
+}
+
+#[test]
+fn test_compute_fee_large_base_full_discount() {
+    let base_fee = i128::MAX;
+    assert_eq!(compute_fee(base_fee, 10_000, 0), 0);
+}
+
+#[test]
+fn test_compute_fee_large_base_combined_full_discounts() {
+    let base_fee = i128::MAX;
+    assert_eq!(compute_fee(base_fee, 10_000, 10_000), 0);
+}
+
+#[test]
 fn test_flat_fee_no_discounts() {
     let t = setup_with_fees(1_000_000);
     let business = Address::generate(&t.env);


### PR DESCRIPTION
## Closes #319

## Summary
Adds explicit overflow-checked arithmetic and bounds enforcement in `compute_fee`, plus tests for negative base fee and large-base full discount scenarios.

## Root Cause
`compute_fee` relied on unchecked multiplication and lacked a direct `base_fee >= 0` guard, allowing a stale negative base fee from DAO overrides to violate the `[0, base_fee]` invariant.

## Changes
- Added checked arithmetic and post-conditions in `compute_fee`
- Added `base_fee >= 0` guard against stale DAO override values
- Documented arithmetic safety behavior
- Extended tests for negative base fee and large-base full discount edge cases