### PR TITLE
ci: guard event schema version against silent breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,22 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  event-schema-guard:
+    name: Event Schema Version Guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify event schema snapshot is up to date
+        run: |
+          chmod +x scripts/check_event_schema.sh
+          ./scripts/check_event_schema.sh
+
+      - name: Run event schema tests
+        run: |
+          chmod +x scripts/tests/test_check_event_schema.sh
+          ./scripts/tests/test_check_event_schema.sh
+
   check:
     name: Check
     runs-on: ubuntu-latest

--- a/contracts/attestation/event_schema_snapshot.txt
+++ b/contracts/attestation/event_schema_snapshot.txt
@@ -1,0 +1,2 @@
+version=1
+struct_hash=5761bd8f9e8de934f73641fa163b6ce561a30c1adde0a9160617cb70bd976700

--- a/scripts/check_event_schema.sh
+++ b/scripts/check_event_schema.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# check_event_schema.sh
+#
+# Guards EVENT_SCHEMA_VERSION against silent breakage by hashing every
+# #[contracttype] struct in contracts/attestation/src/events.rs and
+# comparing the result against a checked-in snapshot.
+#
+# Normal CI run (exits non-zero on divergence):
+#   ./scripts/check_event_schema.sh
+#
+# Regenerate snapshot (run after any struct change AND after bumping
+# EVENT_SCHEMA_VERSION when the change is breaking):
+#   ./scripts/check_event_schema.sh --update
+#
+# Exit codes:
+#   0  schema unchanged, or snapshot successfully updated
+#   1  schema diverged, or usage / environment error
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Allow test harness to override paths via environment variables.
+EVENTS_RS="${EVENTS_RS_OVERRIDE:-$REPO_ROOT/contracts/attestation/src/events.rs}"
+SNAPSHOT="${SNAPSHOT_OVERRIDE:-$REPO_ROOT/contracts/attestation/event_schema_snapshot.txt}"
+
+# ── usage ─────────────────────────────────────────────────────────────
+
+usage() {
+  echo "Usage: $0 [--update]"
+  echo ""
+  echo "  (no flags)  Compare current struct hash against snapshot; fail on divergence."
+  echo "  --update    Regenerate the snapshot from the current events.rs state."
+  echo "  --help      Show this message."
+  exit 1
+}
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+# Read EVENT_SCHEMA_VERSION from events.rs.
+extract_version() {
+  local ver
+  # Extract the numeric literal after '= ' on the EVENT_SCHEMA_VERSION line.
+  ver=$(grep -E '^pub const EVENT_SCHEMA_VERSION: u32 = [0-9]+;' "$EVENTS_RS" \
+        | sed 's/.*= \([0-9]*\);.*/\1/')
+  if [[ -z "$ver" ]]; then
+    echo "ERROR: Could not find EVENT_SCHEMA_VERSION in $EVENTS_RS" >&2
+    exit 1
+  fi
+  echo "$ver"
+}
+
+# Extract every #[contracttype] struct, strip comments and blank lines,
+# sort alphabetically by struct name, then emit a SHA-256 hex digest.
+# Uses Python for reliable multi-line block parsing.
+compute_struct_hash() {
+  python3 - "$EVENTS_RS" <<'PYEOF'
+import sys
+import re
+import hashlib
+
+content = open(sys.argv[1], encoding='utf-8').read()
+lines = content.split('\n')
+
+structs = {}   # name -> normalised body string
+i = 0
+while i < len(lines):
+    stripped = lines[i].strip()
+    # Detect the #[contracttype] attribute line (exact match to avoid
+    # false positives from #[contracttype(...)]).
+    if stripped == '#[contracttype]':
+        # Skip forward over other attributes, derives, doc-comments, blanks
+        # to reach the 'pub struct Name {' line.
+        j = i + 1
+        while j < len(lines):
+            s = lines[j].strip()
+            if (s.startswith('#[') or s.startswith('///') or
+                    s.startswith('//') or s == ''):
+                j += 1
+                continue
+            break
+
+        if j >= len(lines):
+            i += 1
+            continue
+
+        m = re.match(r'pub\s+struct\s+(\w+)', lines[j].strip())
+        if not m:
+            i = j + 1
+            continue
+
+        struct_name = m.group(1)
+        struct_body_lines = []
+        depth = 0
+        k = j
+        while k < len(lines):
+            raw = lines[k]
+            s = raw.strip()
+            # Skip doc/line comments (don't include them in the hash).
+            if s.startswith('///') or s.startswith('//'):
+                k += 1
+                continue
+            # Count braces only on code lines.
+            depth += raw.count('{') - raw.count('}')
+            if s:  # skip blank lines
+                struct_body_lines.append(s)
+            k += 1
+            if depth == 0 and len(struct_body_lines) > 1:
+                break
+
+        structs[struct_name] = '\n'.join(struct_body_lines)
+        i = k
+        continue
+    i += 1
+
+# Stable sort by struct name so ordering changes never create false positives.
+normalized = '\n\n'.join(body for _, body in sorted(structs.items()))
+digest = hashlib.sha256(normalized.encode('utf-8')).hexdigest()
+print(digest)
+PYEOF
+}
+
+# ── argument parsing ──────────────────────────────────────────────────
+
+UPDATE=false
+for arg in "$@"; do
+  case "$arg" in
+    --update) UPDATE=true ;;
+    --help|-h) usage ;;
+    *) echo "Unknown argument: $arg" >&2; usage ;;
+  esac
+done
+
+# ── sanity checks ─────────────────────────────────────────────────────
+
+if [[ ! -f "$EVENTS_RS" ]]; then
+  echo "ERROR: events.rs not found at: $EVENTS_RS" >&2
+  exit 1
+fi
+
+# ── compute current state ─────────────────────────────────────────────
+
+CURRENT_VERSION=$(extract_version)
+CURRENT_HASH=$(compute_struct_hash)
+
+# ── --update mode ─────────────────────────────────────────────────────
+
+if [[ "$UPDATE" == "true" ]]; then
+  printf 'version=%s\nstruct_hash=%s\n' "$CURRENT_VERSION" "$CURRENT_HASH" > "$SNAPSHOT"
+  echo "Snapshot updated."
+  echo "  version     = $CURRENT_VERSION"
+  echo "  struct_hash = $CURRENT_HASH"
+  exit 0
+fi
+
+# ── compare against snapshot ──────────────────────────────────────────
+
+if [[ ! -f "$SNAPSHOT" ]]; then
+  echo "ERROR: Snapshot not found at: $SNAPSHOT" >&2
+  echo "" >&2
+  echo "  Generate it by running:" >&2
+  echo "    scripts/check_event_schema.sh --update" >&2
+  echo "  then commit the resulting file." >&2
+  exit 1
+fi
+
+SNAP_VERSION=$(grep '^version='     "$SNAPSHOT" | cut -d= -f2)
+SNAP_HASH=$(grep    '^struct_hash=' "$SNAPSHOT" | cut -d= -f2)
+
+if [[ "$CURRENT_HASH" == "$SNAP_HASH" ]]; then
+  echo "OK: Event schema unchanged."
+  echo "  version     = $CURRENT_VERSION"
+  echo "  struct_hash = $CURRENT_HASH"
+  exit 0
+fi
+
+# ── struct definitions have changed ──────────────────────────────────
+
+echo "ERROR: Event struct definitions have changed." >&2
+echo "" >&2
+echo "  Snapshot : version=$SNAP_VERSION  hash=$SNAP_HASH" >&2
+echo "  Current  : version=$CURRENT_VERSION  hash=$CURRENT_HASH" >&2
+echo "" >&2
+
+if [[ "$CURRENT_VERSION" == "$SNAP_VERSION" ]]; then
+  echo "  EVENT_SCHEMA_VERSION was NOT bumped." >&2
+  echo "" >&2
+  echo "  Breaking change (field removed / renamed / reordered / type changed)?" >&2
+  echo "    1. Increment EVENT_SCHEMA_VERSION in contracts/attestation/src/events.rs" >&2
+  echo "    2. Update docs/attestation-events-indexer.md" >&2
+  echo "    3. Run: scripts/check_event_schema.sh --update" >&2
+  echo "    4. Commit events.rs, the doc, and event_schema_snapshot.txt together." >&2
+  echo "" >&2
+  echo "  Non-breaking change (new optional field appended at end)?" >&2
+  echo "    No version bump needed — just run: scripts/check_event_schema.sh --update" >&2
+  echo "    and commit event_schema_snapshot.txt." >&2
+else
+  echo "  EVENT_SCHEMA_VERSION was bumped ($SNAP_VERSION -> $CURRENT_VERSION)" >&2
+  echo "  but the snapshot has not been updated." >&2
+  echo "" >&2
+  echo "  Run: scripts/check_event_schema.sh --update" >&2
+  echo "  and commit event_schema_snapshot.txt alongside your struct changes." >&2
+fi
+
+exit 1

--- a/scripts/tests/test_check_event_schema.sh
+++ b/scripts/tests/test_check_event_schema.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+#
+# test_check_event_schema.sh
+#
+# Integration tests for scripts/check_event_schema.sh.
+# Each test runs the script against a temp copy of events.rs and a temp
+# snapshot file, then asserts the expected exit code.
+#
+# Usage:
+#   ./scripts/tests/test_check_event_schema.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/../check_event_schema.sh"
+EVENTS_RS_ORIG="$(cd "$SCRIPT_DIR/../.." && pwd)/contracts/attestation/src/events.rs"
+
+PASS=0
+FAIL=0
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+# run_test <description> <expected_exit_code> <cmd...>
+run_test() {
+  local desc="$1"
+  local expected="$2"
+  shift 2
+  local actual=0
+  "$@" > /dev/null 2>&1 || actual=$?
+  if [[ "$actual" == "$expected" ]]; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc  (expected=$expected actual=$actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Create a fresh temp workspace; caller sets TMPWORK.
+setup_workspace() {
+  TMPWORK=$(mktemp -d)
+  cp "$EVENTS_RS_ORIG" "$TMPWORK/events.rs"
+}
+
+# Run check_event_schema.sh against the temp workspace.
+run_check() {
+  EVENTS_RS_OVERRIDE="$TMPWORK/events.rs" \
+  SNAPSHOT_OVERRIDE="$TMPWORK/snapshot.txt" \
+  bash "$CHECK_SCRIPT" "$@"
+}
+
+# Initialise a valid snapshot from the temp workspace.
+init_snapshot() {
+  run_check --update > /dev/null 2>&1
+}
+
+# ── tests ─────────────────────────────────────────────────────────────
+
+echo "Running check_event_schema tests..."
+echo ""
+
+# 1. No snapshot file → must fail
+setup_workspace
+run_test "fail when snapshot is missing" 1 \
+  bash -c "EVENTS_RS_OVERRIDE='$TMPWORK/events.rs' SNAPSHOT_OVERRIDE='$TMPWORK/snapshot.txt' bash '$CHECK_SCRIPT'"
+rm -rf "$TMPWORK"
+
+# 2. Unchanged events.rs with valid snapshot → must pass
+setup_workspace
+init_snapshot
+run_test "pass when schema is unchanged" 0 \
+  bash -c "EVENTS_RS_OVERRIDE='$TMPWORK/events.rs' SNAPSHOT_OVERRIDE='$TMPWORK/snapshot.txt' bash '$CHECK_SCRIPT'"
+rm -rf "$TMPWORK"
+
+# 3. --update creates/refreshes the snapshot → must pass
+setup_workspace
+run_test "--update creates snapshot and exits 0" 0 \
+  bash -c "EVENTS_RS_OVERRIDE='$TMPWORK/events.rs' SNAPSHOT_OVERRIDE='$TMPWORK/snapshot.txt' bash '$CHECK_SCRIPT' --update"
+rm -rf "$TMPWORK"
+
+# 4. Field renamed (breaking) without version bump → must fail
+setup_workspace
+init_snapshot
+# Rename 'business' to 'biz' in the AttestationSubmittedEvent struct
+sed -i.bak 's/pub business: Address,/pub biz: Address,/' "$TMPWORK/events.rs"
+run_test "fail: field renamed without version bump" 1 \
+  bash -c "EVENTS_RS_OVERRIDE='$TMPWORK/events.rs' SNAPSHOT_OVERRIDE='$TMPWORK/snapshot.txt' bash '$CHECK_SCRIPT'"
+rm -rf "$TMPWORK"
+
+# 5. Field reordered (breaking) without version bump → must fail
+setup_workspace
+init_snapshot
+# Swap 'period' and 'merkle_root' field order in AttestationRevokedEvent
+python3 - "$TMPWORK/events.rs" <<'PYEOF'
+import sys, re
+content = open(sys.argv[1]).read()
+# Swap the two consecutive field lines inside AttestationRevokedEvent
+old = (
+    "    pub period: String,\n"
+    "    /// Address that performed the revocation (must hold ADMIN role).\n"
+    "    pub revoked_by: Address,\n"
+    "    /// Human-readable revocation reason for audit trail.\n"
+    "    pub reason: String,\n"
+)
+new = (
+    "    pub reason: String,\n"
+    "    /// Address that performed the revocation (must hold ADMIN role).\n"
+    "    pub revoked_by: Address,\n"
+    "    /// Human-readable revocation reason for audit trail.\n"
+    "    pub period: String,\n"
+)
+content = content.replace(old, new)
+open(sys.argv[1], 'w').write(content)
+PYEOF
+run_test "fail: fields reordered without version bump" 1 \
+  bash -c "EVENTS_RS_OVERRIDE='$TMPWORK/events.rs' SNAPSHOT_OVERRIDE='$TMPWORK/snapshot.txt' bash '$CHECK_SCRIPT'"
+rm -rf "$TMPWORK"
+
+# 6. Optional field appended (non-breaking) without snapshot update → must fail
+setup_workspace
+init_snapshot
+# Append a new optional field to AttestationRevokedEvent
+python3 - "$TMPWORK/events.rs" <<'PYEOF'
+import sys
+content = open(sys.argv[1]).read()
+old = (
+    "    /// Human-readable revocation reason for audit trail.\n"
+    "    pub reason: String,\n"
+    "}\n"
+    "\n"
+    "/// Normalized payload for `AttestationMigrated`"
+)
+new = (
+    "    /// Human-readable revocation reason for audit trail.\n"
+    "    pub reason: String,\n"
+    "    /// Optional block height at which revocation was confirmed.\n"
+    "    pub block_height: Option<u64>,\n"
+    "}\n"
+    "\n"
+    "/// Normalized payload for `AttestationMigrated`"
+)
+content = content.replace(old, new)
+open(sys.argv[1], 'w').write(content)
+PYEOF
+run_test "fail: optional field appended without snapshot update" 1 \
+  bash -c "EVENTS_RS_OVERRIDE='$TMPWORK/events.rs' SNAPSHOT_OVERRIDE='$TMPWORK/snapshot.txt' bash '$CHECK_SCRIPT'"
+rm -rf "$TMPWORK"
+
+# 7. Version bumped + struct changed but snapshot NOT updated → must fail
+setup_workspace
+init_snapshot
+sed -i.bak 's/^pub const EVENT_SCHEMA_VERSION: u32 = 1;/pub const EVENT_SCHEMA_VERSION: u32 = 2;/' "$TMPWORK/events.rs"
+sed -i.bak 's/pub business: Address,/pub biz: Address,/' "$TMPWORK/events.rs"
+run_test "fail: version bumped + struct changed but snapshot not updated" 1 \
+  bash -c "EVENTS_RS_OVERRIDE='$TMPWORK/events.rs' SNAPSHOT_OVERRIDE='$TMPWORK/snapshot.txt' bash '$CHECK_SCRIPT'"
+rm -rf "$TMPWORK"
+
+# 8. Version bumped + struct changed + snapshot updated → must pass
+setup_workspace
+init_snapshot
+sed -i.bak 's/^pub const EVENT_SCHEMA_VERSION: u32 = 1;/pub const EVENT_SCHEMA_VERSION: u32 = 2;/' "$TMPWORK/events.rs"
+sed -i.bak 's/pub business: Address,/pub biz: Address,/' "$TMPWORK/events.rs"
+run_check --update > /dev/null 2>&1
+run_test "pass: version bumped + struct changed + snapshot updated" 0 \
+  bash -c "EVENTS_RS_OVERRIDE='$TMPWORK/events.rs' SNAPSHOT_OVERRIDE='$TMPWORK/snapshot.txt' bash '$CHECK_SCRIPT'"
+rm -rf "$TMPWORK"
+
+# 9. Unknown flag → must fail with exit 1
+setup_workspace
+run_test "fail: unknown flag" 1 \
+  bash -c "EVENTS_RS_OVERRIDE='$TMPWORK/events.rs' SNAPSHOT_OVERRIDE='$TMPWORK/snapshot.txt' bash '$CHECK_SCRIPT' --bad-flag"
+rm -rf "$TMPWORK"
+
+# 10. Missing events.rs → must fail
+setup_workspace
+init_snapshot
+rm "$TMPWORK/events.rs"
+run_test "fail: events.rs missing" 1 \
+  bash -c "EVENTS_RS_OVERRIDE='$TMPWORK/events.rs' SNAPSHOT_OVERRIDE='$TMPWORK/snapshot.txt' bash '$CHECK_SCRIPT'"
+rm -rf "$TMPWORK"
+
+# ── summary ───────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Adds `scripts/check_event_schema.sh` that extracts every `#[contracttype]` struct from `contracts/attestation/src/events.rs`, computes a SHA-256 fingerprint, and compares it against a checked-in snapshot (`contracts/attestation/event_schema_snapshot.txt`)
- CI fails if structs change without updating the snapshot; the script error message explains whether a version bump is needed (breaking change) or just a snapshot refresh (non-breaking append)
- Wires the check into `.github/workflows/ci.yml` as a new `event-schema-guard` job that runs on every push/PR to `main`
- Includes `scripts/tests/test_check_event_schema.sh` with 10 integration tests covering all edge cases from the issue: field rename, field reorder, optional field append, missing snapshot, version-bumped-but-snapshot-stale, full happy path, and more

## Test output

```
Running check_event_schema tests...

PASS: fail when snapshot is missing
PASS: pass when schema is unchanged
PASS: --update creates snapshot and exits 0
PASS: fail: field renamed without version bump
PASS: fail: fields reordered without version bump
PASS: fail: optional field appended without snapshot update
PASS: fail: version bumped + struct changed but snapshot not updated
PASS: pass: version bumped + struct changed + snapshot updated
PASS: fail: unknown flag
PASS: fail: events.rs missing

Results: 10 passed, 0 failed
```

## Security notes

- No `eval`, no untrusted input, all paths are derived from `$SCRIPT_DIR` or env-var overrides (test harness only)
- Struct extraction uses Python `hashlib.sha256` — no external hashing binary, works identically on macOS and Linux
- The `--update` flag is the only mutating operation; normal CI runs are read-only

## Developer workflow

After any change to a `#[contracttype]` struct in `events.rs`:

```bash
# Breaking change: remove/rename/reorder/retype a field
# 1. Increment EVENT_SCHEMA_VERSION in events.rs
# 2. Update docs/attestation-events-indexer.md
# 3. Refresh snapshot
./scripts/check_event_schema.sh --update
# Commit events.rs, the doc, and event_schema_snapshot.txt together.

# Non-breaking change: append a new optional field
./scripts/check_event_schema.sh --update
# Commit event_schema_snapshot.txt.
```

Closes #379
