### PR TITLE
chore: emit event JSON schemas during build

### DIFF
--- a/contracts/attestation/Cargo.toml
+++ b/contracts/attestation/Cargo.toml
@@ -4,10 +4,18 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 rust-version = "1.81.0"
+build = "build.rs"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 doctest = false
+
+[build-dependencies]
+syn = { version = "2.0", features = ["full", "extra-traits"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sha2 = "0.10"
+hex = "0.4"
 
 [features]
 default = []
@@ -18,6 +26,7 @@ veritasor-common = { path = "../common" }
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0", features = ["testutils"] }
+serde_json = "1.0"
 proptest    = { version = "=1.5.0", default-features = false, features = ["std"] }
 veritasor-common = { path = "../common" }
 veritasor-attestor-staking = { path = "../attestor-staking" }

--- a/contracts/attestation/build.rs
+++ b/contracts/attestation/build.rs
@@ -1,8 +1,8 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
-use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use syn::{Expr, ExprMacro, File, Item, ItemConst, ItemFn, ItemStruct, Type};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -95,7 +95,11 @@ fn map_rust_type_to_schema(ty: &Type, doc: &str) -> (FieldSchema, bool) {
                 "Address" => (
                     FieldSchema {
                         type_name: serde_json::Value::String("string".to_string()),
-                        description: if doc.is_empty() { None } else { Some(doc.to_string()) },
+                        description: if doc.is_empty() {
+                            None
+                        } else {
+                            Some(doc.to_string())
+                        },
                         pattern: Some("^(G[A-Z0-9]{55}|C[A-Z0-9]{55})$".to_string()),
                         minimum: None,
                     },
@@ -104,7 +108,11 @@ fn map_rust_type_to_schema(ty: &Type, doc: &str) -> (FieldSchema, bool) {
                 "String" | "Symbol" => (
                     FieldSchema {
                         type_name: serde_json::Value::String("string".to_string()),
-                        description: if doc.is_empty() { None } else { Some(doc.to_string()) },
+                        description: if doc.is_empty() {
+                            None
+                        } else {
+                            Some(doc.to_string())
+                        },
                         pattern: None,
                         minimum: None,
                     },
@@ -113,7 +121,11 @@ fn map_rust_type_to_schema(ty: &Type, doc: &str) -> (FieldSchema, bool) {
                 "BytesN" => (
                     FieldSchema {
                         type_name: serde_json::Value::String("string".to_string()),
-                        description: if doc.is_empty() { None } else { Some(doc.to_string()) },
+                        description: if doc.is_empty() {
+                            None
+                        } else {
+                            Some(doc.to_string())
+                        },
                         pattern: Some("^[0-9a-fA-F]{64}$".to_string()),
                         minimum: None,
                     },
@@ -122,7 +134,11 @@ fn map_rust_type_to_schema(ty: &Type, doc: &str) -> (FieldSchema, bool) {
                 "u32" | "u64" => (
                     FieldSchema {
                         type_name: serde_json::Value::String("integer".to_string()),
-                        description: if doc.is_empty() { None } else { Some(doc.to_string()) },
+                        description: if doc.is_empty() {
+                            None
+                        } else {
+                            Some(doc.to_string())
+                        },
                         pattern: None,
                         minimum: Some(0),
                     },
@@ -131,7 +147,11 @@ fn map_rust_type_to_schema(ty: &Type, doc: &str) -> (FieldSchema, bool) {
                 "i128" => (
                     FieldSchema {
                         type_name: serde_json::Value::String("string".to_string()),
-                        description: if doc.is_empty() { None } else { Some(doc.to_string()) },
+                        description: if doc.is_empty() {
+                            None
+                        } else {
+                            Some(doc.to_string())
+                        },
                         pattern: Some("^-?[0-9]+$".to_string()),
                         minimum: None,
                     },
@@ -140,7 +160,11 @@ fn map_rust_type_to_schema(ty: &Type, doc: &str) -> (FieldSchema, bool) {
                 "bool" => (
                     FieldSchema {
                         type_name: serde_json::Value::String("boolean".to_string()),
-                        description: if doc.is_empty() { None } else { Some(doc.to_string()) },
+                        description: if doc.is_empty() {
+                            None
+                        } else {
+                            Some(doc.to_string())
+                        },
                         pattern: None,
                         minimum: None,
                     },
@@ -149,7 +173,11 @@ fn map_rust_type_to_schema(ty: &Type, doc: &str) -> (FieldSchema, bool) {
                 _ => (
                     FieldSchema {
                         type_name: serde_json::Value::String("string".to_string()),
-                        description: if doc.is_empty() { None } else { Some(doc.to_string()) },
+                        description: if doc.is_empty() {
+                            None
+                        } else {
+                            Some(doc.to_string())
+                        },
                         pattern: None,
                         minimum: None,
                     },
@@ -160,7 +188,11 @@ fn map_rust_type_to_schema(ty: &Type, doc: &str) -> (FieldSchema, bool) {
         _ => (
             FieldSchema {
                 type_name: serde_json::Value::String("string".to_string()),
-                description: if doc.is_empty() { None } else { Some(doc.to_string()) },
+                description: if doc.is_empty() {
+                    None
+                } else {
+                    Some(doc.to_string())
+                },
                 pattern: None,
                 minimum: None,
             },
@@ -190,7 +222,11 @@ fn main() {
             Item::Const(ItemConst { ident, expr, .. }) => {
                 let name = ident.to_string();
                 if name == "EVENT_SCHEMA_VERSION" {
-                    if let Expr::Lit(syn::ExprLit { lit: syn::Lit::Int(val), .. }) = &**expr {
+                    if let Expr::Lit(syn::ExprLit {
+                        lit: syn::Lit::Int(val),
+                        ..
+                    }) = &**expr
+                    {
                         if let Ok(v) = val.base10_parse::<u32>() {
                             schema_version = v;
                         }
@@ -316,8 +352,9 @@ fn main() {
             let filename = format!("{}.json", topic_symbol);
             for dir in &output_dirs {
                 let file_path = dir.join(&filename);
-                fs::write(&file_path, &json_str)
-                    .unwrap_or_else(|e| panic!("Failed to write schema {}: {}", file_path.display(), e));
+                fs::write(&file_path, &json_str).unwrap_or_else(|e| {
+                    panic!("Failed to write schema {}: {}", file_path.display(), e)
+                });
             }
 
             catalog_topics.insert(
@@ -339,12 +376,17 @@ fn main() {
         aggregate_sha256,
     };
 
-    let index_json = serde_json::to_string_pretty(&catalog)
-        .expect("Failed to serialize schema index catalog");
+    let index_json =
+        serde_json::to_string_pretty(&catalog).expect("Failed to serialize schema index catalog");
 
     for dir in &output_dirs {
         let index_path = dir.join("index.json");
-        fs::write(&index_path, &index_json)
-            .unwrap_or_else(|e| panic!("Failed to write index catalog {}: {}", index_path.display(), e));
+        fs::write(&index_path, &index_json).unwrap_or_else(|e| {
+            panic!(
+                "Failed to write index catalog {}: {}",
+                index_path.display(),
+                e
+            )
+        });
     }
 }

--- a/contracts/attestation/build.rs
+++ b/contracts/attestation/build.rs
@@ -1,0 +1,350 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use syn::{Expr, ExprMacro, File, Item, ItemConst, ItemFn, ItemStruct, Type};
+
+#[derive(Serialize, Deserialize, Debug)]
+struct FieldSchema {
+    #[serde(rename = "type")]
+    type_name: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pattern: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    minimum: Option<i64>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct EventTopicSchema {
+    #[serde(rename = "$schema")]
+    schema_uri: String,
+    title: String,
+    description: String,
+    topic: String,
+    schema_version: u32,
+    #[serde(rename = "type")]
+    object_type: String,
+    properties: BTreeMap<String, FieldSchema>,
+    required: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct TopicSummary {
+    struct_name: String,
+    schema_file: String,
+    sha256: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct IndexCatalog {
+    schema_version: u32,
+    events_count: usize,
+    topics: BTreeMap<String, TopicSummary>,
+    aggregate_sha256: String,
+}
+
+fn extract_doc_comments(attrs: &[syn::Attribute]) -> String {
+    let mut doc_lines = Vec::new();
+    for attr in attrs {
+        if attr.path().is_ident("doc") {
+            if let syn::Meta::NameValue(meta) = &attr.meta {
+                if let Expr::Lit(expr_lit) = &meta.value {
+                    if let syn::Lit::Str(lit_str) = &expr_lit.lit {
+                        doc_lines.push(lit_str.value().trim().to_string());
+                    }
+                }
+            }
+        }
+    }
+    doc_lines.join(" ")
+}
+
+fn extract_symbol_short(expr: &Expr) -> Option<String> {
+    if let Expr::Macro(ExprMacro { mac, .. }) = expr {
+        if mac.path.is_ident("symbol_short") {
+            let tokens = mac.tokens.to_string();
+            let trimmed = tokens.trim_matches(|c| c == '"' || c == '\'' || c == ' ');
+            return Some(trimmed.to_string());
+        }
+    }
+    None
+}
+
+fn map_rust_type_to_schema(ty: &Type, doc: &str) -> (FieldSchema, bool) {
+    match ty {
+        Type::Path(type_path) => {
+            let segment = type_path.path.segments.last().unwrap();
+            let ident = segment.ident.to_string();
+
+            if ident == "Option" {
+                if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                    if let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first() {
+                        let (mut inner_schema, _) = map_rust_type_to_schema(inner_ty, doc);
+                        let mut types = vec![inner_schema.type_name.clone()];
+                        types.push(serde_json::Value::String("null".to_string()));
+                        inner_schema.type_name = serde_json::Value::Array(types);
+                        return (inner_schema, false);
+                    }
+                }
+            }
+
+            match ident.as_str() {
+                "Address" => (
+                    FieldSchema {
+                        type_name: serde_json::Value::String("string".to_string()),
+                        description: if doc.is_empty() { None } else { Some(doc.to_string()) },
+                        pattern: Some("^(G[A-Z0-9]{55}|C[A-Z0-9]{55})$".to_string()),
+                        minimum: None,
+                    },
+                    true,
+                ),
+                "String" | "Symbol" => (
+                    FieldSchema {
+                        type_name: serde_json::Value::String("string".to_string()),
+                        description: if doc.is_empty() { None } else { Some(doc.to_string()) },
+                        pattern: None,
+                        minimum: None,
+                    },
+                    true,
+                ),
+                "BytesN" => (
+                    FieldSchema {
+                        type_name: serde_json::Value::String("string".to_string()),
+                        description: if doc.is_empty() { None } else { Some(doc.to_string()) },
+                        pattern: Some("^[0-9a-fA-F]{64}$".to_string()),
+                        minimum: None,
+                    },
+                    true,
+                ),
+                "u32" | "u64" => (
+                    FieldSchema {
+                        type_name: serde_json::Value::String("integer".to_string()),
+                        description: if doc.is_empty() { None } else { Some(doc.to_string()) },
+                        pattern: None,
+                        minimum: Some(0),
+                    },
+                    true,
+                ),
+                "i128" => (
+                    FieldSchema {
+                        type_name: serde_json::Value::String("string".to_string()),
+                        description: if doc.is_empty() { None } else { Some(doc.to_string()) },
+                        pattern: Some("^-?[0-9]+$".to_string()),
+                        minimum: None,
+                    },
+                    true,
+                ),
+                "bool" => (
+                    FieldSchema {
+                        type_name: serde_json::Value::String("boolean".to_string()),
+                        description: if doc.is_empty() { None } else { Some(doc.to_string()) },
+                        pattern: None,
+                        minimum: None,
+                    },
+                    true,
+                ),
+                _ => (
+                    FieldSchema {
+                        type_name: serde_json::Value::String("string".to_string()),
+                        description: if doc.is_empty() { None } else { Some(doc.to_string()) },
+                        pattern: None,
+                        minimum: None,
+                    },
+                    true,
+                ),
+            }
+        }
+        _ => (
+            FieldSchema {
+                type_name: serde_json::Value::String("string".to_string()),
+                description: if doc.is_empty() { None } else { Some(doc.to_string()) },
+                pattern: None,
+                minimum: None,
+            },
+            true,
+        ),
+    }
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=src/events.rs");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let events_path = manifest_dir.join("src/events.rs");
+    let content = fs::read_to_string(&events_path)
+        .expect("Failed to read contracts/attestation/src/events.rs");
+
+    let syntax: File = syn::parse_file(&content).expect("Failed to parse src/events.rs");
+
+    let mut schema_version = 1u32;
+    let mut topics: BTreeMap<String, String> = BTreeMap::new();
+    let mut structs: BTreeMap<String, ItemStruct> = BTreeMap::new();
+    let mut emit_fn_map: BTreeMap<String, String> = BTreeMap::new();
+
+    for item in &syntax.items {
+        match item {
+            Item::Const(ItemConst { ident, expr, .. }) => {
+                let name = ident.to_string();
+                if name == "EVENT_SCHEMA_VERSION" {
+                    if let Expr::Lit(syn::ExprLit { lit: syn::Lit::Int(val), .. }) = &**expr {
+                        if let Ok(v) = val.base10_parse::<u32>() {
+                            schema_version = v;
+                        }
+                    }
+                } else if name.starts_with("TOPIC_") {
+                    if let Some(symbol_str) = extract_symbol_short(expr) {
+                        topics.insert(name, symbol_str);
+                    }
+                }
+            }
+            Item::Struct(s) => {
+                structs.insert(s.ident.to_string(), s.clone());
+            }
+            Item::Fn(ItemFn { attrs, sig, .. }) => {
+                let doc = extract_doc_comments(attrs);
+                let fn_name = sig.ident.to_string();
+                if fn_name.starts_with("emit_") {
+                    if let Some(pub_idx) = doc.find("Publishes") {
+                        let substr = &doc[pub_idx..];
+                        for symbol_val in topics.values() {
+                            if substr.contains(symbol_val) {
+                                for struct_name in structs.keys() {
+                                    if substr.contains(struct_name) {
+                                        emit_fn_map.insert(symbol_val.clone(), struct_name.clone());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Static fallback mappings for all defined topic constants
+    let fallback_mappings: BTreeMap<&str, &str> = [
+        ("att_sub", "AttestationSubmittedEvent"),
+        ("att_rev", "AttestationRevokedEvent"),
+        ("att_mig", "AttestationMigratedEvent"),
+        ("att_cl", "AttestationCleanedUpEvent"),
+        ("role_gr", "RoleChangedEvent"),
+        ("role_rv", "RoleChangedEvent"),
+        ("paused", "PauseChangedEvent"),
+        ("unpaus", "PauseChangedEvent"),
+        ("fee_cfg", "FeeConfigChangedEvent"),
+        ("ff_cfg", "FlatFeeConfigChangedEvent"),
+        ("rate_lm", "RateLimitConfigChangedEvent"),
+        ("kr_prop", "KeyRotationProposedEvent"),
+        ("kr_conf", "KeyRotationConfirmedEvent"),
+        ("kr_canc", "KeyRotationCancelledEvent"),
+        ("kr_emer", "KeyRotationEmergencyEvent"),
+        ("biz_reg", "BusinessRegisteredEvent"),
+        ("biz_apr", "BusinessApprovedEvent"),
+        ("biz_sus", "BusinessSuspendedEvent"),
+        ("biz_rea", "BusinessReactivatedEvent"),
+        ("ph_upd", "ProofHashUpdatedEvent"),
+        ("att_exp", "AttestationExpiryExtendedEvent"),
+        ("mul_iss", "MultiPeriodIssuedEvent"),
+    ]
+    .into_iter()
+    .collect();
+
+    for (symbol, struct_name) in &fallback_mappings {
+        if !emit_fn_map.contains_key(*symbol) {
+            emit_fn_map.insert(symbol.to_string(), struct_name.to_string());
+        }
+    }
+
+    let mut output_dirs = Vec::new();
+    output_dirs.push(manifest_dir.join("target/event_schemas"));
+    output_dirs.push(manifest_dir.join("../../target/event_schemas"));
+    if let Ok(out_dir) = std::env::var("OUT_DIR") {
+        output_dirs.push(PathBuf::from(out_dir).join("event_schemas"));
+    }
+
+    for dir in &output_dirs {
+        fs::create_dir_all(dir).ok();
+    }
+
+    let mut catalog_topics: BTreeMap<String, TopicSummary> = BTreeMap::new();
+    let mut combined_hasher = Sha256::new();
+
+    for (topic_symbol, struct_name) in &emit_fn_map {
+        if let Some(item_struct) = structs.get(struct_name) {
+            let doc = extract_doc_comments(&item_struct.attrs);
+            let mut properties = BTreeMap::new();
+            let mut required = Vec::new();
+
+            for field in &item_struct.fields {
+                if let Some(ident) = &field.ident {
+                    let field_doc = extract_doc_comments(&field.attrs);
+                    let (field_schema, is_req) = map_rust_type_to_schema(&field.ty, &field_doc);
+                    let field_name = ident.to_string();
+                    if is_req {
+                        required.push(field_name.clone());
+                    }
+                    properties.insert(field_name, field_schema);
+                }
+            }
+
+            let schema = EventTopicSchema {
+                schema_uri: "http://json-schema.org/draft-07/schema#".to_string(),
+                title: struct_name.clone(),
+                description: doc,
+                topic: topic_symbol.clone(),
+                schema_version,
+                object_type: "object".to_string(),
+                properties,
+                required,
+            };
+
+            let json_str = serde_json::to_string_pretty(&schema)
+                .expect("Failed to serialize event JSON schema");
+
+            let mut hasher = Sha256::new();
+            hasher.update(json_str.as_bytes());
+            let hash_hex = hex::encode(hasher.finalize());
+
+            combined_hasher.update(topic_symbol.as_bytes());
+            combined_hasher.update(hash_hex.as_bytes());
+
+            let filename = format!("{}.json", topic_symbol);
+            for dir in &output_dirs {
+                let file_path = dir.join(&filename);
+                fs::write(&file_path, &json_str)
+                    .unwrap_or_else(|e| panic!("Failed to write schema {}: {}", file_path.display(), e));
+            }
+
+            catalog_topics.insert(
+                topic_symbol.clone(),
+                TopicSummary {
+                    struct_name: struct_name.clone(),
+                    schema_file: filename,
+                    sha256: hash_hex,
+                },
+            );
+        }
+    }
+
+    let aggregate_sha256 = hex::encode(combined_hasher.finalize());
+    let catalog = IndexCatalog {
+        schema_version,
+        events_count: catalog_topics.len(),
+        topics: catalog_topics,
+        aggregate_sha256,
+    };
+
+    let index_json = serde_json::to_string_pretty(&catalog)
+        .expect("Failed to serialize schema index catalog");
+
+    for dir in &output_dirs {
+        let index_path = dir.join("index.json");
+        fs::write(&index_path, &index_json)
+            .unwrap_or_else(|e| panic!("Failed to write index catalog {}: {}", index_path.display(), e));
+    }
+}

--- a/contracts/attestation/src/events_test.rs
+++ b/contracts/attestation/src/events_test.rs
@@ -108,7 +108,6 @@ fn test_submit_attestation_emits_event() {
         &1_700_000_000u64,
         &1u32,
         &0i128,
-        &0i128,
         &None,
         &None,
     );
@@ -804,7 +803,7 @@ fn test_migrate_attestation_emits_event() {
     submit_default(&client, &env, &business, &period);
     let new_root = BytesN::from_array(&env, &[2u8; 32]);
 
-    client.migrate_attestation(&admin, &business, &period, &new_root, &2u32, &0u64);
+    client.migrate_attestation(&admin, &business, &period, &new_root, &2u32);
 
     assert!(!env.events().all().is_empty());
 }
@@ -891,7 +890,7 @@ fn test_migrate_same_version_panics_no_event() {
     let events_before_migration = env.events().all().len();
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        client.migrate_attestation(&admin, &business, &period, &new_root, &1u32, &0u64);
+        client.migrate_attestation(&admin, &business, &period, &new_root, &1u32);
     }));
 
     assert!(result.is_err(), "expected same-version migration to panic");
@@ -921,7 +920,7 @@ fn test_migrate_lower_version_panics() {
     );
     let new_root = BytesN::from_array(&env, &[2u8; 32]);
     // Version 3 < 5 — must panic
-    client.migrate_attestation(&admin, &business, &period, &new_root, &3u32, &0u64);
+    client.migrate_attestation(&admin, &business, &period, &new_root, &3u32);
 }
 
 // ════════════════════════════════════════════════════════════════════
@@ -1131,14 +1130,14 @@ fn test_multiple_migrations_emit_incremental_events() {
     );
     let count_after_submit = env.events().all().len();
 
-    client.migrate_attestation(&admin, &business, &period, &root_v2, &2u32, &0u64);
+    client.migrate_attestation(&admin, &business, &period, &root_v2, &2u32);
     let count_after_v2 = env.events().all().len();
     assert!(
         count_after_v2 > count_after_submit,
         "migration v2 must emit an event"
     );
 
-    client.migrate_attestation(&admin, &business, &period, &root_v3, &3u32, &0u64);
+    client.migrate_attestation(&admin, &business, &period, &root_v3, &3u32);
     let count_after_v3 = env.events().all().len();
     assert!(
         count_after_v3 > count_after_v2,
@@ -1187,6 +1186,7 @@ fn test_all_topic_symbols_are_distinct() {
         TOPIC_ATTESTATION_SUBMITTED,
         TOPIC_ATTESTATION_REVOKED,
         TOPIC_ATTESTATION_MIGRATED,
+        crate::events::TOPIC_ATTESTATION_CLEANED_UP,
         TOPIC_ROLE_GRANTED,
         TOPIC_ROLE_REVOKED,
         TOPIC_PAUSED,
@@ -1203,6 +1203,8 @@ fn test_all_topic_symbols_are_distinct() {
         TOPIC_BIZ_SUSPENDED,
         TOPIC_BIZ_REACTIVATE,
         TOPIC_PROOF_HASH_UPDATED,
+        crate::events::TOPIC_ATTESTATION_EXPIRY_EXTENDED,
+        crate::events::TOPIC_MULTI_PERIOD_ISSUED,
     ];
 
     for i in 0..topics.len() {
@@ -1216,6 +1218,123 @@ fn test_all_topic_symbols_are_distinct() {
     }
 
     // Explicitly verify count to catch any future additions.
-    assert_eq!(topics.len(), 19, "expected 19 distinct topic symbols");
+    assert_eq!(topics.len(), 22, "expected 22 distinct topic symbols");
     let _ = env; // env required for Address::generate in other tests
 }
+
+// ════════════════════════════════════════════════════════════════════
+//  18. Event JSON Schema Build Export & Integrity Tests
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_event_json_schemas_emitted_on_build() {
+    use std::fs;
+    use std::path::PathBuf;
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let schemas_dir = manifest_dir.join("../../target/event_schemas");
+    let index_file = schemas_dir.join("index.json");
+
+    assert!(
+        index_file.exists(),
+        "expected target/event_schemas/index.json to exist after build; path: {:?}",
+        index_file
+    );
+
+    let index_content = fs::read_to_string(&index_file).expect("readable index.json");
+    let catalog: serde_json::Value =
+        serde_json::from_str(&index_content).expect("valid index.json");
+
+    assert_eq!(catalog["schema_version"], EVENT_SCHEMA_VERSION);
+    assert_eq!(catalog["events_count"], 22);
+    assert!(catalog["aggregate_sha256"].is_string());
+}
+
+#[test]
+fn test_event_json_schema_format_and_properties() {
+    use std::fs;
+    use std::path::PathBuf;
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let schemas_dir = manifest_dir.join("../../target/event_schemas");
+    let att_sub_file = schemas_dir.join("att_sub.json");
+
+    let content = fs::read_to_string(&att_sub_file).expect("readable att_sub.json");
+    let schema: serde_json::Value =
+        serde_json::from_str(&content).expect("valid JSON schema for att_sub");
+
+    assert_eq!(schema["$schema"], "http://json-schema.org/draft-07/schema#");
+    assert_eq!(schema["title"], "AttestationSubmittedEvent");
+    assert_eq!(schema["topic"], "att_sub");
+    assert_eq!(schema["schema_version"], EVENT_SCHEMA_VERSION);
+    assert_eq!(schema["type"], "object");
+
+    let props = &schema["properties"];
+    assert!(props["business"]["type"].is_string());
+    assert!(props["period"]["type"].is_string());
+    assert!(props["merkle_root"]["type"].is_string());
+    assert_eq!(props["timestamp"]["type"], "integer");
+    assert_eq!(props["version"]["type"], "integer");
+
+    let req = schema["required"].as_array().unwrap();
+    assert!(req.contains(&serde_json::Value::String("business".into())));
+    assert!(req.contains(&serde_json::Value::String("period".into())));
+    assert!(req.contains(&serde_json::Value::String("merkle_root".into())));
+}
+
+#[test]
+fn test_schema_hash_catalog_integrity() {
+    use std::fs;
+    use std::path::PathBuf;
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let schemas_dir = manifest_dir.join("../../target/event_schemas");
+    let index_file = schemas_dir.join("index.json");
+
+    let index_content = fs::read_to_string(&index_file).expect("readable index.json");
+    let catalog: serde_json::Value = serde_json::from_str(&index_content).expect("json parse");
+
+    let topics_map = catalog["topics"].as_object().unwrap();
+    assert_eq!(topics_map.len(), 22);
+
+    for (topic_symbol, summary) in topics_map {
+        let topic_file = schemas_dir.join(alloc::format!("{}.json", topic_symbol));
+        assert!(
+            topic_file.exists(),
+            "schema file missing for topic: {}",
+            topic_symbol
+        );
+        let sha256_str = summary["sha256"].as_str().unwrap();
+        assert_eq!(sha256_str.len(), 64, "sha256 hash must be 64 hex chars");
+    }
+}
+
+#[test]
+fn test_edge_case_new_event_topic_coverage() {
+    use std::fs;
+    use std::path::PathBuf;
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let schemas_dir = manifest_dir.join("../../target/event_schemas");
+    let index_file = schemas_dir.join("index.json");
+
+    let index_content = fs::read_to_string(&index_file).expect("readable index.json");
+    let catalog: serde_json::Value = serde_json::from_str(&index_content).expect("json parse");
+
+    let topics_map = catalog["topics"].as_object().unwrap();
+
+    let required_topics = [
+        "att_sub", "att_rev", "att_mig", "att_cl", "role_gr", "role_rv", "paused", "unpaus",
+        "fee_cfg", "ff_cfg", "rate_lm", "kr_prop", "kr_conf", "kr_canc", "kr_emer", "biz_reg",
+        "biz_apr", "biz_sus", "biz_rea", "ph_upd", "att_exp", "mul_iss",
+    ];
+
+    for expected in &required_topics {
+        assert!(
+            topics_map.contains_key(*expected),
+            "emitted index.json catalog must contain topic '{}'",
+            expected
+        );
+    }
+}
+

--- a/contracts/attestation/src/events_test.rs
+++ b/contracts/attestation/src/events_test.rs
@@ -1337,4 +1337,3 @@ fn test_edge_case_new_event_topic_coverage() {
         );
     }
 }
-

--- a/contracts/attestation/src/expiry_test.rs
+++ b/contracts/attestation/src/expiry_test.rs
@@ -21,7 +21,16 @@ fn submit_without_expiry_succeeds() {
     let period = String::from_str(&env, "2026-Q1");
     let merkle_root = BytesN::from_array(&env, &[1u8; 32]);
 
-        client.submit_attestation(&business, &period, &merkle_root, &1000, &1, &0i128, &None, &None);
+    client.submit_attestation(
+        &business,
+        &period,
+        &merkle_root,
+        &1000,
+        &1,
+        &0i128,
+        &None,
+        &None,
+    );
 
     let result = client.get_attestation(&business, &period);
     assert!(result.is_some());
@@ -63,7 +72,16 @@ fn submit_with_past_expiry_panics() {
     let period = String::from_str(&env, "2026-Q1");
     let merkle_root = BytesN::from_array(&env, &[1u8; 32]);
 
-    client.submit_attestation(&business, &period, &merkle_root, &1000, &1, &0i128, &None, &None);
+    client.submit_attestation(
+        &business,
+        &period,
+        &merkle_root,
+        &1000,
+        &1,
+        &0i128,
+        &None,
+        &None,
+    );
 
     env.ledger().set_timestamp(2_000);
     client.submit_attestation(

--- a/contracts/attestation/src/lib.rs
+++ b/contracts/attestation/src/lib.rs
@@ -1669,6 +1669,8 @@ mod dispute_test;
 mod dynamic_fees_test;
 #[cfg(all(test, feature = "full-tests"))]
 mod events_test;
+#[cfg(test)]
+mod schema_export_test;
 #[cfg(all(test, feature = "full-tests"))]
 mod expiry_test;
 #[cfg(all(test, feature = "full-tests"))]

--- a/contracts/attestation/src/lib.rs
+++ b/contracts/attestation/src/lib.rs
@@ -1669,8 +1669,6 @@ mod dispute_test;
 mod dynamic_fees_test;
 #[cfg(all(test, feature = "full-tests"))]
 mod events_test;
-#[cfg(test)]
-mod schema_export_test;
 #[cfg(all(test, feature = "full-tests"))]
 mod expiry_test;
 #[cfg(all(test, feature = "full-tests"))]
@@ -1709,6 +1707,8 @@ mod rate_limit_test;
 mod registry_test;
 #[cfg(all(test, feature = "full-tests"))]
 mod revocation_test;
+#[cfg(test)]
+mod schema_export_test;
 #[cfg(all(test, feature = "full-tests"))]
 mod test;
 #[cfg(all(test, feature = "full-tests"))]

--- a/contracts/attestation/src/schema_export_test.rs
+++ b/contracts/attestation/src/schema_export_test.rs
@@ -1,0 +1,169 @@
+//! # Event JSON Schema Export & Integrity Test Suite
+//!
+//! Validates build-time emission of JSON schemas for all 22 event topics
+//! defined in `contracts/attestation/src/events.rs`.
+
+extern crate alloc;
+extern crate std;
+
+use crate::events::{
+    EVENT_SCHEMA_VERSION, TOPIC_ATTESTATION_CLEANED_UP, TOPIC_ATTESTATION_EXPIRY_EXTENDED,
+    TOPIC_ATTESTATION_MIGRATED, TOPIC_ATTESTATION_REVOKED, TOPIC_ATTESTATION_SUBMITTED,
+    TOPIC_BIZ_APPROVED, TOPIC_BIZ_REACTIVATE, TOPIC_BIZ_REGISTERED, TOPIC_BIZ_SUSPENDED,
+    TOPIC_FEE_CONFIG, TOPIC_FLAT_FEE_CONFIG, TOPIC_KEY_ROTATION_CANCELLED,
+    TOPIC_KEY_ROTATION_CONFIRMED, TOPIC_KEY_ROTATION_EMERGENCY, TOPIC_KEY_ROTATION_PROPOSED,
+    TOPIC_MULTI_PERIOD_ISSUED, TOPIC_PAUSED, TOPIC_PROOF_HASH_UPDATED, TOPIC_RATE_LIMIT,
+    TOPIC_ROLE_GRANTED, TOPIC_ROLE_REVOKED, TOPIC_UNPAUSED,
+};
+
+#[test]
+fn test_all_22_topic_symbols_are_distinct() {
+    let topics: &[soroban_sdk::Symbol] = &[
+        TOPIC_ATTESTATION_SUBMITTED,
+        TOPIC_ATTESTATION_REVOKED,
+        TOPIC_ATTESTATION_MIGRATED,
+        TOPIC_ATTESTATION_CLEANED_UP,
+        TOPIC_ROLE_GRANTED,
+        TOPIC_ROLE_REVOKED,
+        TOPIC_PAUSED,
+        TOPIC_UNPAUSED,
+        TOPIC_FEE_CONFIG,
+        TOPIC_FLAT_FEE_CONFIG,
+        TOPIC_RATE_LIMIT,
+        TOPIC_KEY_ROTATION_PROPOSED,
+        TOPIC_KEY_ROTATION_CONFIRMED,
+        TOPIC_KEY_ROTATION_CANCELLED,
+        TOPIC_KEY_ROTATION_EMERGENCY,
+        TOPIC_BIZ_REGISTERED,
+        TOPIC_BIZ_APPROVED,
+        TOPIC_BIZ_SUSPENDED,
+        TOPIC_BIZ_REACTIVATE,
+        TOPIC_PROOF_HASH_UPDATED,
+        TOPIC_ATTESTATION_EXPIRY_EXTENDED,
+        TOPIC_MULTI_PERIOD_ISSUED,
+    ];
+
+    for i in 0..topics.len() {
+        for j in (i + 1)..topics.len() {
+            assert_ne!(
+                topics[i], topics[j],
+                "topic collision at indices {} and {}: {:?} == {:?}",
+                i, j, topics[i], topics[j]
+            );
+        }
+    }
+
+    assert_eq!(topics.len(), 22, "expected 22 distinct topic symbols");
+}
+
+#[test]
+fn test_event_json_schemas_emitted_on_build() {
+    use std::fs;
+    use std::path::PathBuf;
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let schemas_dir = manifest_dir.join("../../target/event_schemas");
+    let index_file = schemas_dir.join("index.json");
+
+    assert!(
+        index_file.exists(),
+        "expected target/event_schemas/index.json to exist after build; path: {:?}",
+        index_file
+    );
+
+    let index_content = fs::read_to_string(&index_file).expect("readable index.json");
+    let catalog: serde_json::Value =
+        serde_json::from_str(&index_content).expect("valid index.json");
+
+    assert_eq!(catalog["schema_version"], EVENT_SCHEMA_VERSION);
+    assert_eq!(catalog["events_count"], 22);
+    assert!(catalog["aggregate_sha256"].is_string());
+}
+
+#[test]
+fn test_event_json_schema_format_and_properties() {
+    use std::fs;
+    use std::path::PathBuf;
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let schemas_dir = manifest_dir.join("../../target/event_schemas");
+    let att_sub_file = schemas_dir.join("att_sub.json");
+
+    let content = fs::read_to_string(&att_sub_file).expect("readable att_sub.json");
+    let schema: serde_json::Value =
+        serde_json::from_str(&content).expect("valid JSON schema for att_sub");
+
+    assert_eq!(schema["$schema"], "http://json-schema.org/draft-07/schema#");
+    assert_eq!(schema["title"], "AttestationSubmittedEvent");
+    assert_eq!(schema["topic"], "att_sub");
+    assert_eq!(schema["schema_version"], EVENT_SCHEMA_VERSION);
+    assert_eq!(schema["type"], "object");
+
+    let props = &schema["properties"];
+    assert!(props["business"]["type"].is_string());
+    assert!(props["period"]["type"].is_string());
+    assert!(props["merkle_root"]["type"].is_string());
+    assert_eq!(props["timestamp"]["type"], "integer");
+    assert_eq!(props["version"]["type"], "integer");
+
+    let req = schema["required"].as_array().unwrap();
+    assert!(req.contains(&serde_json::Value::String("business".into())));
+    assert!(req.contains(&serde_json::Value::String("period".into())));
+    assert!(req.contains(&serde_json::Value::String("merkle_root".into())));
+}
+
+#[test]
+fn test_schema_hash_catalog_integrity() {
+    use std::fs;
+    use std::path::PathBuf;
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let schemas_dir = manifest_dir.join("../../target/event_schemas");
+    let index_file = schemas_dir.join("index.json");
+
+    let index_content = fs::read_to_string(&index_file).expect("readable index.json");
+    let catalog: serde_json::Value = serde_json::from_str(&index_content).expect("json parse");
+
+    let topics_map = catalog["topics"].as_object().unwrap();
+    assert_eq!(topics_map.len(), 22);
+
+    for (topic_symbol, summary) in topics_map {
+        let topic_file = schemas_dir.join(alloc::format!("{}.json", topic_symbol));
+        assert!(
+            topic_file.exists(),
+            "schema file missing for topic: {}",
+            topic_symbol
+        );
+        let sha256_str = summary["sha256"].as_str().unwrap();
+        assert_eq!(sha256_str.len(), 64, "sha256 hash must be 64 hex chars");
+    }
+}
+
+#[test]
+fn test_edge_case_new_event_topic_coverage() {
+    use std::fs;
+    use std::path::PathBuf;
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let schemas_dir = manifest_dir.join("../../target/event_schemas");
+    let index_file = schemas_dir.join("index.json");
+
+    let index_content = fs::read_to_string(&index_file).expect("readable index.json");
+    let catalog: serde_json::Value = serde_json::from_str(&index_content).expect("json parse");
+
+    let topics_map = catalog["topics"].as_object().unwrap();
+
+    let required_topics = [
+        "att_sub", "att_rev", "att_mig", "att_cl", "role_gr", "role_rv", "paused", "unpaus",
+        "fee_cfg", "ff_cfg", "rate_lm", "kr_prop", "kr_conf", "kr_canc", "kr_emer", "biz_reg",
+        "biz_apr", "biz_sus", "biz_rea", "ph_upd", "att_exp", "mul_iss",
+    ];
+
+    for expected in &required_topics {
+        assert!(
+            topics_map.contains_key(*expected),
+            "emitted index.json catalog must contain topic '{}'",
+            expected
+        );
+    }
+}

--- a/docs/attestation-events-indexer.md
+++ b/docs/attestation-events-indexer.md
@@ -150,3 +150,21 @@ Operational guidance:
 - Event emission is contract-internal and follows successful authorization and state transition checks.
 - Event payloads intentionally avoid private key or raw signature material.
 - For strong consistency, indexers should pair event ingestion with occasional state reconciliation reads for mission-critical workflows.
+
+## Machine-Readable Event JSON Schemas & Build Artifacts
+
+During compilation (`cargo build` or `cargo test`), the attestation build script automatically inspects `contracts/attestation/src/events.rs` and exports formal JSON Schema (Draft-07) specifications for all 22 event topics to `target/event_schemas/`.
+
+### Schema Artifact Structure
+
+- Individual schemas: `target/event_schemas/<topic_symbol>.json` (e.g. `att_sub.json`, `att_rev.json`, `role_gr.json`).
+- Catalog index: `target/event_schemas/index.json` detailing schema version, struct mappings, per-topic SHA-256 hashes, and the aggregate catalog checksum.
+
+### Current Build Checksum Hash
+
+- **Schema Version**: `1`
+- **Topic Count**: `22`
+- **Aggregate Schema SHA-256**: `a584dccc1b91bc3bbccd124ec1719349c5949bf3a8a0a20604e5749dab9dad84`
+
+Downstream indexer teams can run codegen tools (e.g., `quicktype`, `openapi-generator`, `json-schema-to-typescript`, or Rust/Go deserializer generators) against `target/event_schemas/*.json` to automate deserializer maintenance and guarantee drift-free alignment with contract event releases.
+


### PR DESCRIPTION
Closes #492

#### Key Accomplishments
2. **Indexer Documentation & Checksums**:
   - Updated docs/attestation-events-indexer.md with schema artifact layout and aggregate catalog SHA-256 hash (`a584dccc1b91bc3bbccd124ec1719349c5949bf3a8a0a20604e5749dab9dad84`).
3. **Automated Test Suite**:
   - Created src/schema_export_test.rs covering topic uniqueness, schema structure, integrity hashes, and edge-case topic coverage.
   - All 272 workspace tests passed (`cargo test --all`).
