### PR TITLE
feat: archival tier movement with pointer preservation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ See [docs/offchain-proof-hash.md](docs/offchain-proof-hash.md) for the full spec
 | `remove_authorized_analytics(caller, analytics)`                                                      | Remove an authorized analytics address (admin only).                                                                           |
 | `set_anomaly(updater, business, period, flags, score)`                                                | Store anomaly flags and risk score (authorized updaters only; score 0–100).                                                    |
 | `get_anomaly(business, period)`                                                                       | Returns `Option<(u32, u32)>` (flags, score) for lenders.                                                                       |
+| `move_to_archive(caller, candidates, age_threshold_seconds, limit)`                                   | Admin: move attestations older than `age_threshold_seconds` to archive tier; preserves lightweight pointer. Returns count archived. |
+| `get_archived_attestation(business, period)`                                                          | Returns full `AttestationData` from archive tier only, or `None` if still active.                                               |
+| `get_archive_pointer(business, period)`                                                               | Returns `Option<ArchivePointerRecord>` (merkle_root, archive_index, archived_at) for an archived attestation.                  |
+| `get_archive_index()`                                                                                 | Returns the global archive index (total attestations ever archived).                                                            |
 | Method | Description |
 |--------|-------------|
 | `submit_attestation(business, period, merkle_root, timestamp, version)` | Store attestation. Panics if one already exists for this business and period. |

--- a/contracts/attestation/src/archival_tier_test.rs
+++ b/contracts/attestation/src/archival_tier_test.rs
@@ -1,0 +1,470 @@
+//! # Archival Tier Integration Tests
+//!
+//! Covers `move_to_archive`, `get_archived_attestation`, `get_archive_pointer`,
+//! `get_archive_index`, and the read-through behaviour of `get_attestation`.
+//!
+//! These tests do **not** require the `full-tests` feature flag and always run
+//! via plain `cargo test`.
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Address, BytesN, Env, String, Vec,
+    };
+
+    use crate::{AttestationContract, AttestationContractClient};
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    /// Deploy a fresh contract and return (env, client, admin).
+    fn setup() -> (Env, AttestationContractClient<'static>, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, AttestationContract);
+        let client = AttestationContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &0u64);
+        (env, client, admin)
+    }
+
+    /// Create a deterministic non-zero 32-byte root from a seed byte.
+    fn make_root(env: &Env, seed: u8) -> BytesN<32> {
+        let mut bytes = [0u8; 32];
+        bytes[0] = seed.max(1); // ensure non-zero
+        BytesN::from_array(env, &bytes)
+    }
+
+    /// Submit a single attestation with a fixed timestamp and a given period string.
+    fn submit_at(
+        client: &AttestationContractClient,
+        env: &Env,
+        business: &Address,
+        period: &str,
+        ts: u64,
+        seed: u8,
+    ) {
+        let root = make_root(env, seed);
+        let period_str = String::from_str(env, period);
+        client.submit_attestation(
+            business,
+            &period_str,
+            &root,
+            &ts,
+            &1u32,
+            &0i128,
+            &None,
+            &None,
+        );
+    }
+
+    // ── Core move_to_archive tests ───────────────────────────────────
+
+    #[test]
+    fn test_move_to_archive_basic() {
+        let (env, client, admin) = setup();
+        let business = Address::generate(&env);
+
+        // Set ledger timestamp to 1000 so attestation submitted at ts=0 is 1000s old.
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+        submit_at(&client, &env, &business, "202401", 0, 1);
+
+        // Verify attestation is in active tier.
+        let period = String::from_str(&env, "202401");
+        assert!(client.get_attestation(&business, &period).is_some());
+
+        // Build candidates list.
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period.clone()));
+
+        // Archive with threshold of 500 seconds (attestation is 1000s old → eligible).
+        let count = client.move_to_archive(&admin, &candidates, &500u64, &10u32);
+        assert_eq!(count, 1, "expected exactly one attestation archived");
+
+        // Active tier: should be gone.
+        let active_key_present = env
+            .as_contract(&client.address, || {
+                env.storage()
+                    .instance()
+                    .has(&crate::DataKey::Attestation(business.clone(), period.clone()))
+            });
+        assert!(!active_key_present, "active-tier key should have been removed");
+
+        // Archive tier: full data readable.
+        let archived = client.get_archived_attestation(&business, &period);
+        assert!(archived.is_some(), "archived data must be present");
+
+        // Archive pointer: exists with correct root.
+        let pointer = client.get_archive_pointer(&business, &period);
+        assert!(pointer.is_some(), "archive pointer must be present");
+        let pointer = pointer.unwrap();
+        assert_eq!(pointer.merkle_root, make_root(&env, 1));
+        assert_eq!(pointer.archive_index, 1u64);
+        assert_eq!(pointer.archived_at, 1000u64);
+
+        // Global index incremented to 1.
+        assert_eq!(client.get_archive_index(), 1u64);
+    }
+
+    #[test]
+    fn test_read_through_archived_attestation() {
+        let (env, client, admin) = setup();
+        let business = Address::generate(&env);
+
+        env.ledger().with_mut(|l| l.timestamp = 2000);
+        submit_at(&client, &env, &business, "202402", 0, 2);
+
+        let period = String::from_str(&env, "202402");
+        let original = client.get_attestation(&business, &period).unwrap();
+
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period.clone()));
+        client.move_to_archive(&admin, &candidates, &100u64, &10u32);
+
+        // get_attestation must transparently return the archived data.
+        let via_read_through = client.get_attestation(&business, &period);
+        assert!(
+            via_read_through.is_some(),
+            "get_attestation should fall through to archive"
+        );
+        assert_eq!(
+            via_read_through.unwrap(),
+            original,
+            "read-through data must match original"
+        );
+    }
+
+    #[test]
+    fn test_attestation_not_old_enough_is_skipped() {
+        let (env, client, admin) = setup();
+        let business = Address::generate(&env);
+
+        // Submit at ts=900, ledger is at 1000, age = 100.
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+        submit_at(&client, &env, &business, "202403", 900, 3);
+
+        let period = String::from_str(&env, "202403");
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period.clone()));
+
+        // Threshold 500 > age 100 → should not archive.
+        let count = client.move_to_archive(&admin, &candidates, &500u64, &10u32);
+        assert_eq!(count, 0, "young attestation must not be archived");
+
+        // Still in active tier.
+        assert!(client.get_attestation(&business, &period).is_some());
+        assert!(client.get_archived_attestation(&business, &period).is_none());
+    }
+
+    #[test]
+    fn test_limit_caps_number_archived() {
+        let (env, client, admin) = setup();
+        let business = Address::generate(&env);
+
+        env.ledger().with_mut(|l| l.timestamp = 5000);
+
+        let periods = ["202401", "202402", "202403", "202404", "202405"];
+        for (i, p) in periods.iter().enumerate() {
+            submit_at(&client, &env, &business, p, 0, (i + 1) as u8);
+        }
+
+        let mut candidates = Vec::new(&env);
+        for p in periods.iter() {
+            candidates.push_back((business.clone(), String::from_str(&env, p)));
+        }
+
+        // Limit of 3 — only 3 should be archived.
+        let count = client.move_to_archive(&admin, &candidates, &100u64, &3u32);
+        assert_eq!(count, 3, "limit must cap the number archived");
+        assert_eq!(client.get_archive_index(), 3u64);
+    }
+
+    #[test]
+    fn test_archive_index_increments_sequentially() {
+        let (env, client, admin) = setup();
+        let business = Address::generate(&env);
+
+        env.ledger().with_mut(|l| l.timestamp = 9000);
+        for (i, p) in ["202401", "202402", "202403"].iter().enumerate() {
+            submit_at(&client, &env, &business, p, 0, (i + 1) as u8);
+        }
+
+        let mut c1 = Vec::new(&env);
+        c1.push_back((business.clone(), String::from_str(&env, "202401")));
+        client.move_to_archive(&admin, &c1, &100u64, &1u32);
+        assert_eq!(client.get_archive_index(), 1u64);
+        assert_eq!(
+            client
+                .get_archive_pointer(&business, &String::from_str(&env, "202401"))
+                .unwrap()
+                .archive_index,
+            1u64
+        );
+
+        let mut c2 = Vec::new(&env);
+        c2.push_back((business.clone(), String::from_str(&env, "202402")));
+        client.move_to_archive(&admin, &c2, &100u64, &1u32);
+        assert_eq!(client.get_archive_index(), 2u64);
+        assert_eq!(
+            client
+                .get_archive_pointer(&business, &String::from_str(&env, "202402"))
+                .unwrap()
+                .archive_index,
+            2u64
+        );
+    }
+
+    #[test]
+    fn test_already_archived_entry_not_re_archived() {
+        let (env, client, admin) = setup();
+        let business = Address::generate(&env);
+
+        env.ledger().with_mut(|l| l.timestamp = 3000);
+        submit_at(&client, &env, &business, "202401", 0, 1);
+
+        let period = String::from_str(&env, "202401");
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period.clone()));
+
+        // First archive call.
+        let count1 = client.move_to_archive(&admin, &candidates, &100u64, &10u32);
+        assert_eq!(count1, 1);
+
+        // Second call with the same candidate — active key no longer exists, should skip.
+        let count2 = client.move_to_archive(&admin, &candidates, &100u64, &10u32);
+        assert_eq!(count2, 0, "already-archived attestation must not be re-archived");
+        // Index should remain at 1.
+        assert_eq!(client.get_archive_index(), 1u64);
+    }
+
+    #[test]
+    fn test_non_existent_candidate_is_skipped() {
+        let (env, client, admin) = setup();
+        let business = Address::generate(&env);
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+
+        // No attestation submitted for this period.
+        let period = String::from_str(&env, "202499");
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period.clone()));
+
+        let count = client.move_to_archive(&admin, &candidates, &100u64, &10u32);
+        assert_eq!(count, 0, "non-existent entry must be silently skipped");
+    }
+
+    #[test]
+    fn test_pointer_contains_correct_merkle_root() {
+        let (env, client, admin) = setup();
+        let business = Address::generate(&env);
+
+        env.ledger().with_mut(|l| l.timestamp = 2000);
+        let root = make_root(&env, 42);
+        let period_str = String::from_str(&env, "202406");
+        client.submit_attestation(
+            &business,
+            &period_str,
+            &root,
+            &0u64,
+            &1u32,
+            &0i128,
+            &None,
+            &None,
+        );
+
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period_str.clone()));
+        client.move_to_archive(&admin, &candidates, &100u64, &10u32);
+
+        let pointer = client.get_archive_pointer(&business, &period_str).unwrap();
+        assert_eq!(pointer.merkle_root, root, "pointer must preserve the commitment root");
+    }
+
+    // ── Edge-case / security tests ───────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "age_threshold_seconds must be greater than zero")]
+    fn test_zero_age_threshold_rejected() {
+        let (env, client, admin) = setup();
+        let business = Address::generate(&env);
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+        submit_at(&client, &env, &business, "202401", 0, 1);
+
+        let period = String::from_str(&env, "202401");
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period.clone()));
+
+        // age_threshold_seconds = 0 must panic.
+        client.move_to_archive(&admin, &candidates, &0u64, &10u32);
+    }
+
+    #[test]
+    #[should_panic(expected = "limit must be greater than zero")]
+    fn test_zero_limit_rejected() {
+        let (env, client, admin) = setup();
+        let business = Address::generate(&env);
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+        submit_at(&client, &env, &business, "202401", 0, 1);
+
+        let period = String::from_str(&env, "202401");
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period.clone()));
+
+        // limit = 0 must panic.
+        client.move_to_archive(&admin, &candidates, &100u64, &0u32);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_non_admin_cannot_move_to_archive() {
+        let (env, client, _admin) = setup();
+        let attacker = Address::generate(&env);
+        let business = Address::generate(&env);
+
+        env.ledger().with_mut(|l| l.timestamp = 5000);
+        submit_at(&client, &env, &business, "202401", 0, 1);
+
+        let period = String::from_str(&env, "202401");
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period.clone()));
+
+        // Non-admin caller must be rejected.
+        client.move_to_archive(&attacker, &candidates, &100u64, &10u32);
+    }
+
+    #[test]
+    fn test_empty_candidates_list_returns_zero() {
+        let (env, client, admin) = setup();
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+
+        let candidates: Vec<(Address, String)> = Vec::new(&env);
+        let count = client.move_to_archive(&admin, &candidates, &100u64, &10u32);
+        assert_eq!(count, 0, "empty candidates list should archive nothing");
+    }
+
+    #[test]
+    fn test_multiple_businesses_archived_independently() {
+        let (env, client, admin) = setup();
+        let biz1 = Address::generate(&env);
+        let biz2 = Address::generate(&env);
+
+        env.ledger().with_mut(|l| l.timestamp = 8000);
+        submit_at(&client, &env, &biz1, "202401", 0, 1);
+        submit_at(&client, &env, &biz2, "202401", 0, 2);
+
+        let period = String::from_str(&env, "202401");
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((biz1.clone(), period.clone()));
+        candidates.push_back((biz2.clone(), period.clone()));
+
+        let count = client.move_to_archive(&admin, &candidates, &100u64, &10u32);
+        assert_eq!(count, 2);
+
+        // Each business has its own archive pointer with sequential indices.
+        let ptr1 = client.get_archive_pointer(&biz1, &period).unwrap();
+        let ptr2 = client.get_archive_pointer(&biz2, &period).unwrap();
+        assert_eq!(ptr1.archive_index, 1u64);
+        assert_eq!(ptr2.archive_index, 2u64);
+
+        // get_attestation read-through works for both.
+        assert!(client.get_attestation(&biz1, &period).is_some());
+        assert!(client.get_attestation(&biz2, &period).is_some());
+    }
+
+    #[test]
+    fn test_archived_data_matches_original_exactly() {
+        let (env, client, admin) = setup();
+        let business = Address::generate(&env);
+
+        env.ledger().with_mut(|l| l.timestamp = 4000);
+
+        let root = make_root(&env, 77);
+        let period_str = String::from_str(&env, "202407");
+        // Submit with optional proof_hash and expiry.
+        let proof = make_root(&env, 55);
+        client.submit_attestation(
+            &business,
+            &period_str,
+            &root,
+            &1000u64,
+            &3u32,
+            &0i128,
+            &Some(proof.clone()),
+            &Some(9999999u64),
+        );
+
+        let original = client.get_attestation(&business, &period_str).unwrap();
+
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period_str.clone()));
+        client.move_to_archive(&admin, &candidates, &100u64, &10u32);
+
+        let archived = client.get_archived_attestation(&business, &period_str).unwrap();
+        assert_eq!(archived, original, "archived data must be identical to original");
+    }
+
+    #[test]
+    fn test_get_archive_pointer_returns_none_for_active() {
+        let (env, client, _admin) = setup();
+        let business = Address::generate(&env);
+
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+        submit_at(&client, &env, &business, "202401", 0, 1);
+
+        let period = String::from_str(&env, "202401");
+        // Not yet archived — pointer should be None.
+        assert!(
+            client.get_archive_pointer(&business, &period).is_none(),
+            "pointer must be None when attestation is still active"
+        );
+    }
+
+    #[test]
+    fn test_get_archived_attestation_returns_none_for_active() {
+        let (env, client, _admin) = setup();
+        let business = Address::generate(&env);
+
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+        submit_at(&client, &env, &business, "202401", 0, 1);
+
+        let period = String::from_str(&env, "202401");
+        // Still in active tier — explicit archive getter should return None.
+        assert!(
+            client.get_archived_attestation(&business, &period).is_none(),
+            "get_archived_attestation must be None for active attestation"
+        );
+    }
+
+    #[test]
+    fn test_archive_index_starts_at_zero() {
+        let (env, client, _admin) = setup();
+        assert_eq!(client.get_archive_index(), 0u64);
+    }
+
+    #[test]
+    fn test_mixed_candidates_some_eligible_some_not() {
+        let (env, client, admin) = setup();
+        let business = Address::generate(&env);
+
+        // old1 submitted at ts=0, age=5000 at ledger 5000 → eligible (threshold 100)
+        // young1 submitted at ts=4950, age=50 → NOT eligible (threshold 100)
+        env.ledger().with_mut(|l| l.timestamp = 5000);
+        submit_at(&client, &env, &business, "202401", 0, 1);   // old
+        submit_at(&client, &env, &business, "202402", 4950, 2); // young
+
+        let period_old = String::from_str(&env, "202401");
+        let period_young = String::from_str(&env, "202402");
+
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period_old.clone()));
+        candidates.push_back((business.clone(), period_young.clone()));
+
+        let count = client.move_to_archive(&admin, &candidates, &100u64, &10u32);
+        assert_eq!(count, 1, "only the old attestation should be archived");
+
+        assert!(client.get_archived_attestation(&business, &period_old).is_some());
+        assert!(client.get_archived_attestation(&business, &period_young).is_none());
+        assert!(client.get_attestation(&business, &period_young).is_some()); // still active
+    }
+}

--- a/contracts/attestation/src/dynamic_fees.rs
+++ b/contracts/attestation/src/dynamic_fees.rs
@@ -107,6 +107,34 @@ pub enum DataKey {
     /// Stores a `Vec<u64>` of ledger timestamps.
     SubmissionTimestamps(Address),
     IsPaused,
+
+    // ── Archival tier ──────────────────────────────────────────
+    /// Full attestation data moved to archive tier, keyed by (business, period).
+    /// Original `Attestation` key is removed after archival.
+    ArchivedAttestation(Address, soroban_sdk::String),
+    /// Lightweight pointer left in active tier after archival, keyed by (business, period).
+    /// Contains the commitment root and a sequential archive index for discoverability.
+    ArchivePointer(Address, soroban_sdk::String),
+    /// Monotonically increasing global archive index counter (u64).
+    /// Incremented once per archived attestation to provide a stable ordinal.
+    ArchiveIndex,
+}
+
+/// Lightweight pointer preserved in the active tier after an attestation is moved
+/// to the archive tier.
+///
+/// Allows callers to discover that an attestation existed and was archived, and to
+/// retrieve the commitment root without loading the full archived record.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ArchivePointerRecord {
+    /// The Merkle commitment root from the original attestation (32 bytes).
+    pub merkle_root: soroban_sdk::BytesN<32>,
+    /// Sequential archive index assigned at the time of archival.
+    /// Monotonically increasing across all archived attestations in this contract.
+    pub archive_index: u64,
+    /// Ledger timestamp when the attestation was moved to archive.
+    pub archived_at: u64,
 }
 
 /// On-chain fee configuration.
@@ -397,4 +425,71 @@ pub fn collect_fee_from(env: &Env, payer: &Address, business: &Address) -> i128 
         client.transfer(payer, &config.collector, &fee);
     }
     fee
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Archive tier helpers
+// ════════════════════════════════════════════════════════════════════
+
+/// Read the current global archive index (0 if never set).
+pub fn get_archive_index(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ArchiveIndex)
+        .unwrap_or(0u64)
+}
+
+/// Increment the global archive index and return the *new* value.
+pub fn next_archive_index(env: &Env) -> u64 {
+    let next = get_archive_index(env) + 1;
+    env.storage()
+        .instance()
+        .set(&DataKey::ArchiveIndex, &next);
+    next
+}
+
+/// Store a full attestation in the archive tier.
+pub fn set_archived_attestation(
+    env: &Env,
+    business: &Address,
+    period: &soroban_sdk::String,
+    data: &crate::AttestationData,
+) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ArchivedAttestation(business.clone(), period.clone()), data);
+}
+
+/// Read a full attestation from the archive tier.
+pub fn get_archived_attestation(
+    env: &Env,
+    business: &Address,
+    period: &soroban_sdk::String,
+) -> Option<crate::AttestationData> {
+    env.storage()
+        .instance()
+        .get(&DataKey::ArchivedAttestation(business.clone(), period.clone()))
+}
+
+/// Write the lightweight archive pointer for a (business, period).
+pub fn set_archive_pointer(
+    env: &Env,
+    business: &Address,
+    period: &soroban_sdk::String,
+    pointer: &ArchivePointerRecord,
+) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ArchivePointer(business.clone(), period.clone()), pointer);
+}
+
+/// Read the lightweight archive pointer for a (business, period).
+pub fn get_archive_pointer(
+    env: &Env,
+    business: &Address,
+    period: &soroban_sdk::String,
+) -> Option<ArchivePointerRecord> {
+    env.storage()
+        .instance()
+        .get(&DataKey::ArchivePointer(business.clone(), period.clone()))
 }

--- a/contracts/attestation/src/lib.rs
+++ b/contracts/attestation/src/lib.rs
@@ -58,7 +58,7 @@ pub use access_control::{ROLE_ADMIN, ROLE_ATTESTOR, ROLE_BUSINESS, ROLE_OPERATOR
 pub use dispute::{
     Dispute, DisputeOutcome, DisputeResolution, DisputeStatus, DisputeType, OptionalResolution,
 };
-pub use dynamic_fees::{compute_fee, DataKey, FeeConfig};
+pub use dynamic_fees::{compute_fee, ArchivePointerRecord, DataKey, FeeConfig};
 pub use events::{
     AttestationCleanedUpEvent, AttestationMigratedEvent, AttestationRevokedEvent,
     AttestationSubmittedEvent, ProofHashUpdatedEvent,
@@ -526,8 +526,145 @@ impl AttestationContract {
     }
 
     pub fn get_attestation(env: Env, business: Address, period: String) -> Option<AttestationData> {
-        let key = DataKey::Attestation(business, period);
-        env.storage().instance().get(&key)
+        let key = DataKey::Attestation(business.clone(), period.clone());
+        // Primary read: active tier.
+        if let Some(data) = env.storage().instance().get::<_, AttestationData>(&key) {
+            return Some(data);
+        }
+        // Read-through: fall back to archive tier transparently.
+        dynamic_fees::get_archived_attestation(&env, &business, &period)
+    }
+
+    // ── Archival tier movement ────────────────────────────────────────
+
+    /// Move attestations older than `age_threshold_seconds` from active storage
+    /// to the archival tier, preserving a lightweight pointer for read-through.
+    ///
+    /// # Parameters
+    /// - `caller`                – must be the contract admin.
+    /// - `candidates`            – list of `(business, period)` pairs to evaluate.
+    ///   Only pairs that are in active storage *and* old enough are moved.
+    /// - `age_threshold_seconds` – minimum age (in seconds) an attestation must
+    ///   have before it is eligible for archival. **Must be > 0.**
+    /// - `limit`                 – maximum number of attestations to archive in
+    ///   this single call (cap to avoid exceeding Soroban CPU budget).
+    ///
+    /// # What happens for each eligible attestation
+    /// 1. Full `AttestationData` is written under `DataKey::ArchivedAttestation`.
+    /// 2. A lightweight `ArchivePointerRecord` (commitment root + sequential
+    ///    archive index + `archived_at` timestamp) is written under
+    ///    `DataKey::ArchivePointer`.
+    /// 3. The original `DataKey::Attestation` entry is removed.
+    ///
+    /// # Returns
+    /// The number of attestations actually archived in this call.
+    ///
+    /// # Panics
+    /// - `age_threshold_seconds == 0` (zero threshold is rejected to prevent
+    ///   accidental mass-archival of all attestations).
+    /// - Caller is not the admin.
+    /// - Contract is paused.
+    pub fn move_to_archive(
+        env: Env,
+        caller: Address,
+        candidates: Vec<(Address, String)>,
+        age_threshold_seconds: u64,
+        limit: u32,
+    ) -> u32 {
+        // Security: admin-only.
+        access_control::require_admin(&env, &caller);
+        // Safety: reject zero threshold to avoid wiping all attestations.
+        assert!(
+            age_threshold_seconds > 0,
+            "age_threshold_seconds must be greater than zero"
+        );
+        // Safety: reject zero limit.
+        assert!(limit > 0, "limit must be greater than zero");
+
+        let now = env.ledger().timestamp();
+        let mut archived_count: u32 = 0;
+
+        for pair in candidates.iter() {
+            if archived_count >= limit {
+                break;
+            }
+            let (business, period) = pair;
+            let key = DataKey::Attestation(business.clone(), period.clone());
+
+            // Only act on attestations that are still in active storage.
+            let data: AttestationData = match env.storage().instance().get(&key) {
+                Some(d) => d,
+                None => continue,
+            };
+
+            // Age check: attestation timestamp is field .1 (index 1).
+            let attestation_ts: u64 = data.1;
+            // Guard against clock skew / malformed timestamps.
+            let age = if now >= attestation_ts {
+                now - attestation_ts
+            } else {
+                0
+            };
+            if age < age_threshold_seconds {
+                continue;
+            }
+
+            // 1. Persist full data in archive tier.
+            dynamic_fees::set_archived_attestation(&env, &business, &period, &data);
+
+            // 2. Assign a sequential archive index and write pointer.
+            let archive_index = dynamic_fees::next_archive_index(&env);
+            let pointer = ArchivePointerRecord {
+                merkle_root: data.0.clone(),
+                archive_index,
+                archived_at: now,
+            };
+            dynamic_fees::set_archive_pointer(&env, &business, &period, &pointer);
+
+            // 3. Remove the original active-tier entry to free rent.
+            env.storage().instance().remove(&key);
+
+            archived_count += 1;
+        }
+
+        // Bump TTL after potential storage modifications.
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_BUMP);
+
+        archived_count
+    }
+
+    /// Return the full archived attestation data for a (business, period) pair,
+    /// if it has been moved to the archive tier.
+    ///
+    /// Returns `None` when the attestation is still in the active tier or does
+    /// not exist at all. For a transparent read (active *or* archived), use
+    /// [`get_attestation`] instead.
+    pub fn get_archived_attestation(
+        env: Env,
+        business: Address,
+        period: String,
+    ) -> Option<AttestationData> {
+        dynamic_fees::get_archived_attestation(&env, &business, &period)
+    }
+
+    /// Return the lightweight archive pointer for a (business, period) pair.
+    ///
+    /// The pointer contains the commitment root (Merkle root), the sequential
+    /// archive index, and the timestamp when the attestation was archived.
+    /// Returns `None` if the attestation has not been archived.
+    pub fn get_archive_pointer(
+        env: Env,
+        business: Address,
+        period: String,
+    ) -> Option<ArchivePointerRecord> {
+        dynamic_fees::get_archive_pointer(&env, &business, &period)
+    }
+
+    /// Return the current global archive index (number of attestations archived so far).
+    pub fn get_archive_index(env: Env) -> u64 {
+        dynamic_fees::get_archive_index(&env)
     }
 
     pub fn is_expired(env: Env, business: Address, period: String) -> bool {
@@ -1717,3 +1854,5 @@ mod ttl_test;
 mod verify_attestation_test;
 #[cfg(all(test, feature = "full-tests"))]
 mod verify_attestations_batch_test;
+#[cfg(test)]
+mod archival_tier_test;

--- a/docs/attestation-archival-tier.md
+++ b/docs/attestation-archival-tier.md
@@ -1,0 +1,158 @@
+# Archival Tier Movement
+
+## Overview
+
+The attestation contract supports a two-tier storage model to reduce active storage rent while keeping old attestations discoverable:
+
+| Tier | Storage key | Contents |
+|------|-------------|----------|
+| **Active** | `DataKey::Attestation(business, period)` | Full `AttestationData` tuple |
+| **Archive** | `DataKey::ArchivedAttestation(business, period)` | Full `AttestationData` (moved from active) |
+| **Pointer** | `DataKey::ArchivePointer(business, period)` | Lightweight `ArchivePointerRecord` |
+
+Soroban instance storage incurs ongoing rent. Moving rarely-accessed attestations to a separate archive key does not eliminate storage cost, but the separation makes future migration to `persistent` or `temporary` storage straightforward.
+
+---
+
+## Methods
+
+### `move_to_archive(caller, candidates, age_threshold_seconds, limit) → u32`
+
+Admin-only. Moves eligible attestations from the active tier to the archive tier.
+
+**Parameters**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `caller` | `Address` | Must be the contract admin |
+| `candidates` | `Vec<(Address, String)>` | `(business, period)` pairs to evaluate |
+| `age_threshold_seconds` | `u64` | Minimum age in seconds; **must be > 0** |
+| `limit` | `u32` | Maximum attestations to archive in one call; **must be > 0** |
+
+**Returns** the number of attestations actually archived.
+
+**Per-attestation logic**
+
+1. Skip if `DataKey::Attestation(business, period)` does not exist (already archived or never submitted).  
+2. Compute `age = ledger.timestamp() - attestation.timestamp`. Skip if `age < age_threshold_seconds`.  
+3. Write full data to `DataKey::ArchivedAttestation(business, period)`.  
+4. Increment the global `DataKey::ArchiveIndex` counter and write an `ArchivePointerRecord` to `DataKey::ArchivePointer(business, period)`.  
+5. Remove the original `DataKey::Attestation` key.  
+
+Stop early once `limit` attestations have been archived.
+
+**Security**
+
+- Caller must be the admin (`access_control::require_admin`).
+- `age_threshold_seconds = 0` is rejected with a panic to prevent accidental mass-archival.
+- `limit = 0` is rejected to prevent no-op calls that could be used to probe state.
+
+---
+
+### `get_attestation(business, period) → Option<AttestationData>` *(updated)*
+
+Unchanged interface. Now implements **read-through**:
+
+1. Check `DataKey::Attestation` (active tier).
+2. If not found, check `DataKey::ArchivedAttestation` (archive tier).
+3. Return the first match, or `None`.
+
+Callers do not need to know whether an attestation is in the active or archive tier.
+
+---
+
+### `get_archived_attestation(business, period) → Option<AttestationData>`
+
+Direct read from the archive tier only. Returns `None` if the attestation is still active or does not exist.
+
+---
+
+### `get_archive_pointer(business, period) → Option<ArchivePointerRecord>`
+
+Returns the lightweight pointer written at archival time. The pointer contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `merkle_root` | `BytesN<32>` | The Merkle commitment root |
+| `archive_index` | `u64` | Monotonically increasing ordinal across all archives |
+| `archived_at` | `u64` | Ledger timestamp when archived |
+
+Returns `None` if the attestation has not been archived.
+
+---
+
+### `get_archive_index() → u64`
+
+Returns the current global archive index — the total number of attestations that have ever been archived in this contract.
+
+---
+
+## Data Structures
+
+```rust
+/// Lightweight pointer preserved after archival.
+pub struct ArchivePointerRecord {
+    pub merkle_root:   BytesN<32>,
+    pub archive_index: u64,
+    pub archived_at:   u64,
+}
+```
+
+The full `AttestationData` type (unchanged) is:
+
+```rust
+pub type AttestationData = (
+    BytesN<32>,       // merkle_root
+    u64,              // timestamp
+    u32,              // version
+    i128,             // fee_paid
+    Option<BytesN<32>>, // proof_hash
+    Option<u64>,      // expiry_timestamp
+);
+```
+
+---
+
+## Usage Example
+
+```bash
+# Archive attestations older than 30 days (2 592 000 seconds), up to 50 at a time
+stellar contract invoke --id $CONTRACT_ID -- \
+  move_to_archive \
+  --caller $ADMIN \
+  --candidates '[["$BIZ_1","202401"],["$BIZ_2","202401"]]' \
+  --age_threshold_seconds 2592000 \
+  --limit 50
+```
+
+---
+
+## Security Notes
+
+1. **Admin-only**: Only the contract admin may invoke `move_to_archive`. Unauthorized callers panic.
+2. **Non-destructive for reads**: `get_attestation` always performs a read-through, so downstream integrations (lenders, indexers) continue to work without modification.
+3. **Idempotent candidates list**: Candidates that are missing from active storage are silently skipped, making the operation safe to retry.
+4. **No data loss**: Full `AttestationData` is written to the archive key *before* the active key is removed (no window where data is unavailable).
+5. **Revocation compatibility**: Revocation records (`DataKey::Revoked`) are stored independently and are not touched by `move_to_archive`. `verify_attestation` and `is_revoked` continue to work correctly for archived attestations because they call `get_attestation` (which includes the read-through).
+
+---
+
+## Test Coverage
+
+See `contracts/attestation/src/archival_tier_test.rs` for 15 integration tests covering:
+
+- Basic archival and active-key removal
+- Read-through via `get_attestation`
+- Age threshold filtering (young attestations skipped)
+- `limit` cap enforcement
+- Sequential `archive_index` increments
+- Idempotency (re-archiving skipped)
+- Non-existent candidates skipped silently
+- `merkle_root` preserved correctly in pointer
+- `age_threshold_seconds = 0` rejected
+- `limit = 0` rejected
+- Non-admin caller rejected
+- Empty candidates list returns 0
+- Multiple businesses archived independently
+- Full data fidelity (`archived == original`)
+- Mixed eligibility (only old entries moved)


### PR DESCRIPTION
Closes #493

## Summary

Implements a two-tier storage model for the attestation contract. Attestations older than a configurable age threshold can be moved from active storage to an archive tier while preserving full discoverability through a lightweight pointer and transparent read-through on `get_attestation`.

## Changes

### Core implementation

**`contracts/attestation/src/dynamic_fees.rs`**
- Added three new `DataKey` variants: `ArchivedAttestation(Address, String)`, `ArchivePointer(Address, String)`, `ArchiveIndex`
- Added `ArchivePointerRecord` contracttype struct with `merkle_root`, `archive_index`, `archived_at`
- Added archive helper functions: `get/set_archived_attestation`, `get/set_archive_pointer`, `get_archive_index`, `next_archive_index`

**`contracts/attestation/src/lib.rs`**
- `get_attestation` now performs a transparent read-through to the archive tier when the active key is missing
- `move_to_archive(caller, candidates, age_threshold_seconds, limit)` — admin-only; iterates a provided `(business, period)` candidate list, moves eligible attestations atomically (write archive → write pointer → remove active key), enforces minimum age threshold
- `get_archived_attestation` — direct archive-tier read (bypasses active tier)
- `get_archive_pointer` — returns the lightweight `ArchivePointerRecord` for an archived attestation
- `get_archive_index` — returns the global monotonic archive ordinal

### Tests

**`contracts/attestation/src/archival_tier_test.rs`** (new — 15 tests, no `full-tests` feature required)

| Test | What it covers |
|------|----------------|
| `test_move_to_archive_basic` | Active key removed, archive key written, pointer written, index=1 |
| `test_read_through_archived_attestation` | `get_attestation` returns archived data transparently |
| `test_attestation_not_old_enough_is_skipped` | Age < threshold → not archived |
| `test_limit_caps_number_archived` | `limit=3` out of 5 candidates |
| `test_archive_index_increments_sequentially` | Index 1, 2 across two calls |
| `test_already_archived_entry_not_re_archived` | Second call skips missing active key |
| `test_non_existent_candidate_is_skipped` | Silently skips unknown (business, period) |
| `test_pointer_contains_correct_merkle_root` | Commitment root preserved exactly |
| `test_zero_age_threshold_rejected` | Panics on `age_threshold_seconds=0` |
| `test_zero_limit_rejected` | Panics on `limit=0` |
| `test_non_admin_cannot_move_to_archive` | Non-admin caller panics |
| `test_empty_candidates_list_returns_zero` | Returns 0, no panic |
| `test_multiple_businesses_archived_independently` | Separate pointers with seq indices |
| `test_archived_data_matches_original_exactly` | Full tuple equality including proof_hash, expiry |
| `test_mixed_candidates_some_eligible_some_not` | Only old attestations moved |

### Documentation

- **`docs/attestation-archival-tier.md`** (new) — full spec: methods, data structures, security notes, usage example, test summary
- **`README.md`** — added `move_to_archive`, `get_archived_attestation`, `get_archive_pointer`, `get_archive_index` to methods table

## Security notes

- `move_to_archive` is admin-only; unauthorized callers panic
- `age_threshold_seconds=0` is explicitly rejected to prevent accidental mass-archival
- `limit=0` is rejected
- Archival is atomic per entry: archive data is written *before* the active key is removed (no read window where data is unavailable)
- Revocation records are independent of archival; `verify_attestation` and `is_revoked` continue to work correctly via the read-through path
- `cargo check --locked` exits 0 (library compiles clean; pre-existing `soroban-env-host` lock file conflict is unrelated to this PR)