### PR TITLE
feat: add multisig proposal expiry auto-cleanup after grace period (#486)

### DIFF
--- a/contracts/attestation/src/events.rs
+++ b/contracts/attestation/src/events.rs
@@ -68,6 +68,7 @@
 //! - No private keys, raw signatures, or personal data are included in any
 //!   event payload.
 
+use crate::multisig::ProposalAction;
 use soroban_sdk::{contracttype, symbol_short, Address, BytesN, Env, String, Symbol};
 
 // ════════════════════════════════════════════════════════════════════
@@ -128,6 +129,8 @@ pub const TOPIC_BIZ_SUSPENDED: Symbol = symbol_short!("biz_sus");
 pub const TOPIC_BIZ_REACTIVATE: Symbol = symbol_short!("biz_rea");
 /// Topic: proof hash updated
 pub const TOPIC_PROOF_HASH_UPDATED: Symbol = symbol_short!("ph_upd");
+/// Topic: proposal cleaned up after expiry + grace period
+pub const TOPIC_PROPOSAL_CLEANED: Symbol = symbol_short!("prp_cl");
 
 // ════════════════════════════════════════════════════════════════════
 //  Normalized Event Data Structures
@@ -435,13 +438,20 @@ pub struct ProofHashUpdatedEvent {
     pub updated_by: Address,
 }
 
-// ════════════════════════════════════════════════════════════════════
-//  Event Emission Functions
-//
-//  Naming: emit_<snake_case_event_name>
-//  Topic:  always (TOPIC_CONSTANT, …secondary_key?) – never raw strings
-//  Data:   always a typed struct – never a raw tuple
-// ════════════════════════════════════════════════════════════════════
+/// Normalized payload for `ProposalCleaned` events.
+///
+/// Emitted when an expired proposal is removed from storage after the
+/// admin-configurable grace period has elapsed.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ProposalCleanedEvent {
+    /// Unique identifier of the cleaned proposal.
+    pub proposal_id: u64,
+    /// The action that the proposal carried.
+    pub action: ProposalAction,
+    /// Ledger sequence number when the cleanup occurred
+    pub cleaned_at: u32,
+}
 
 // ── Attestation lifecycle ─────────────────────────────────────────
 
@@ -1062,4 +1072,28 @@ pub fn emit_proof_hash_updated(
     };
     env.events()
         .publish((TOPIC_PROOF_HASH_UPDATED, business.clone()), event);
+}
+
+/// Emit a `ProposalCleaned` event.
+///
+/// Call this after an expired proposal and its associated storage entries
+/// have been removed.
+///
+/// # Arguments
+///
+/// * `env`          – Soroban execution environment.
+/// * `proposal_id`  – Unique identifier of the cleaned proposal.
+/// * `action`       – The action that the proposal carried.
+/// * `cleaned_at`   – Ledger sequence number when cleanup occurred.
+///
+/// # Events
+///
+/// Publishes `(prp_cl,)` → `ProposalCleanedEvent`.
+pub fn emit_proposal_cleaned(env: &Env, proposal_id: u64, action: &ProposalAction, cleaned_at: u32) {
+    let event = ProposalCleanedEvent {
+        proposal_id,
+        action: action.clone(),
+        cleaned_at,
+    };
+    env.events().publish((TOPIC_PROPOSAL_CLEANED,), event);
 }

--- a/contracts/attestation/src/lib.rs
+++ b/contracts/attestation/src/lib.rs
@@ -844,6 +844,19 @@ impl AttestationContract {
         multisig::is_owner(&env, &address)
     }
 
+    pub fn cleanup_expired_proposals(env: Env, limit: u32) -> u32 {
+        multisig::cleanup_expired_proposals(&env, limit)
+    }
+
+    pub fn set_proposal_expiry_grace(env: Env, caller: Address, grace: u32) {
+        access_control::require_admin(&env, &caller);
+        multisig::set_proposal_expiry_grace(&env, grace);
+    }
+
+    pub fn get_proposal_expiry_grace(env: Env) -> u32 {
+        multisig::get_proposal_expiry_grace(&env)
+    }
+
     /// Admin-gated method to manually bump the instance TTL
     pub fn bump_ttl(env: Env, caller: Address) {
         access_control::require_admin(&env, &caller);

--- a/contracts/attestation/src/multisig.rs
+++ b/contracts/attestation/src/multisig.rs
@@ -5,8 +5,13 @@
 
 use soroban_sdk::{contracttype, Address, Env, Vec};
 
+use crate::events;
+
 /// Default proposal expiry, expressed in ledger sequences after creation.
 pub const DEFAULT_PROPOSAL_EXPIRY: u32 = 100_000;
+
+/// Default grace period after proposal expiry before auto-cleanup (ledger sequences)
+pub const DEFAULT_PROPOSAL_EXPIRY_GRACE: u32 = 10_000;
 
 // ════════════════════════════════════════════════════════════════════
 //  Storage Types
@@ -28,6 +33,8 @@ pub enum MultisigKey {
     NextProposalId,
     /// Expiry ledger for a proposal
     ProposalExpiry(u64),
+    /// Admin-configurable grace period in ledger sequences after expiry
+    ProposalExpiryGrace,
 }
 
 /// Types of actions that can be proposed
@@ -301,4 +308,49 @@ pub fn remove_owner(env: &Env, owner: &Address) {
         "cannot remove owner: would drop below threshold"
     );
     set_owners(env, &next);
+}
+
+pub fn get_next_proposal_id(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&MultisigKey::NextProposalId)
+        .unwrap_or(0)
+}
+
+pub fn set_proposal_expiry_grace(env: &Env, grace: u32) {
+    env.storage()
+        .instance()
+        .set(&MultisigKey::ProposalExpiryGrace, &grace);
+}
+
+pub fn get_proposal_expiry_grace(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&MultisigKey::ProposalExpiryGrace)
+        .unwrap_or(DEFAULT_PROPOSAL_EXPIRY_GRACE)
+}
+
+pub fn cleanup_expired_proposals(env: &Env, limit: u32) -> u32 {
+    let grace = get_proposal_expiry_grace(env);
+    let next_id = get_next_proposal_id(env);
+    let current_seq = env.ledger().sequence();
+    let mut cleaned = 0;
+    let max = if limit < next_id { limit } else { next_id };
+    for id in 0..max {
+        let expiry_key = MultisigKey::ProposalExpiry(id);
+        if let Some(expiry) = env.storage().instance().get::<_, u32>(&expiry_key) {
+            if current_seq > expiry + grace {
+                if let Some(proposal) = env.storage().instance().get::<_, Proposal>(&MultisigKey::Proposal(id)) {
+                    let action = proposal.action.clone();
+                    let cleaned_at = env.ledger().sequence();
+                    env.storage().instance().remove(&MultisigKey::Proposal(id));
+                    env.storage().instance().remove(&MultisigKey::Approvals(id));
+                    env.storage().instance().remove(&expiry_key);
+                    events::emit_proposal_cleaned(env, id, &action, cleaned_at);
+                    cleaned += 1;
+                }
+            }
+        }
+    }
+    cleaned
 }

--- a/contracts/attestation/src/multisig_e2e_test.rs
+++ b/contracts/attestation/src/multisig_e2e_test.rs
@@ -283,3 +283,77 @@ fn e2e_remove_owner_mid_proposal_requires_reapproval_path() {
     ctx.client.execute_proposal(&proposer, &pause_id, &3u64);
     assert!(ctx.client.is_paused());
 }
+
+
+// ── Cleanup / Grace Period Tests ──────────────────────────────────
+
+#[test]
+fn e2e_cleanup_expired_proposals_basic() {
+    let ctx = setup_3_of_5();
+    let proposer = ctx.owners.get(0).unwrap();
+    let id1 = ctx.client.create_proposal(&proposer, &ProposalAction::Pause, &0u64);
+    let id2 = ctx.client.create_proposal(&proposer, &ProposalAction::Unpause, &1u64);
+    let id3 = ctx.client.create_proposal(&proposer, &ProposalAction::Pause, &2u64);
+    let current_seq = ctx.env.ledger().sequence();
+    let advance = DEFAULT_PROPOSAL_EXPIRY + 10001;
+    ctx.env.ledger().set_sequence_number(current_seq + advance);
+    assert!(ctx.client.is_proposal_expired(&id1));
+    assert!(ctx.client.is_proposal_expired(&id2));
+    assert!(ctx.client.is_proposal_expired(&id3));
+    let cleaned = ctx.client.cleanup_expired_proposals(&2u32);
+    assert_eq!(cleaned, 2);
+    assert!(ctx.client.get_proposal(&id3).is_some());
+}
+
+#[test]
+fn e2e_cleanup_expired_proposals_all() {
+    let ctx = setup_3_of_5();
+    let proposer = ctx.owners.get(0).unwrap();
+    let id1 = ctx.client.create_proposal(&proposer, &ProposalAction::Pause, &0u64);
+    let current_seq = ctx.env.ledger().sequence();
+    let advance = DEFAULT_PROPOSAL_EXPIRY + 10001;
+    ctx.env.ledger().set_sequence_number(current_seq + advance);
+    let cleaned = ctx.client.cleanup_expired_proposals(&10u32);
+    assert_eq!(cleaned, 1);
+    assert!(ctx.client.get_proposal(&id1).is_none());
+}
+
+#[test]
+fn e2e_cleanup_no_expired_proposals() {
+    let ctx = setup_3_of_5();
+    let cleaned = ctx.client.cleanup_expired_proposals(&10u32);
+    assert_eq!(cleaned, 0);
+}
+
+#[test]
+fn e2e_cleanup_grace_period_not_elapsed() {
+    let ctx = setup_3_of_5();
+    let proposer = ctx.owners.get(0).unwrap();
+    let id1 = ctx.client.create_proposal(&proposer, &ProposalAction::Pause, &0u64);
+    let current_seq = ctx.env.ledger().sequence();
+    ctx.env.ledger().set_sequence_number(current_seq + DEFAULT_PROPOSAL_EXPIRY + 5000);
+    let cleaned = ctx.client.cleanup_expired_proposals(&10u32);
+    assert_eq!(cleaned, 0);
+    assert!(ctx.client.get_proposal(&id1).is_some());
+}
+
+#[test]
+fn e2e_cleanup_with_custom_grace_period() {
+    let ctx = setup_3_of_5();
+    let proposer = ctx.owners.get(0).unwrap();
+    let admin = ctx.owners.get(0).unwrap();
+    ctx.client.set_proposal_expiry_grace(&admin, &100u32);
+    let id1 = ctx.client.create_proposal(&proposer, &ProposalAction::Pause, &0u64);
+    let current_seq = ctx.env.ledger().sequence();
+    ctx.env.ledger().set_sequence_number(current_seq + DEFAULT_PROPOSAL_EXPIRY + 101);
+    let cleaned = ctx.client.cleanup_expired_proposals(&10u32);
+    assert_eq!(cleaned, 1);
+    assert!(ctx.client.get_proposal(&id1).is_none());
+}
+
+#[test]
+fn e2e_get_default_proposal_expiry_grace() {
+    let ctx = setup_3_of_5();
+    let grace = ctx.client.get_proposal_expiry_grace();
+    assert!(grace > 0);
+}


### PR DESCRIPTION
Closes #486. Introduces bounded cleanup_expired_proposals(limit) with admin-configurable grace periods in multisig.rs, emits ProposalCleaned events, handles empty states correctly, and includes comprehensive test coverage verifying cargo test --all.