### PR TITLE
feat(attestation): snapshot vote weight at proposal creation

### DIFF
--- a/contracts/attestation/src/events.rs
+++ b/contracts/attestation/src/events.rs
@@ -132,6 +132,12 @@ pub const TOPIC_BIZ_REACTIVATE: Symbol = symbol_short!("biz_rea");
 pub const TOPIC_PROOF_HASH_UPDATED: Symbol = symbol_short!("ph_upd");
 /// Topic: proposal cleaned up after expiry + grace period
 pub const TOPIC_PROPOSAL_CLEANED: Symbol = symbol_short!("prp_cl");
+/// Topic: vote-weight snapshot captured at proposal creation (issue #512).
+///
+/// Used by off-chain indexers and audit tools to reconstruct the exact
+/// owner set / threshold / total weight that governed a proposal's
+/// approval tally. The snapshot is immutable after creation.
+pub const TOPIC_VOTE_WEIGHT_SNAPSHOT_CREATED: Symbol = symbol_short!("vw_snap");
 
 // ════════════════════════════════════════════════════════════════════
 //  Normalized Event Data Structures
@@ -470,6 +476,38 @@ pub struct ProposalCleanedEvent {
     pub action: ProposalAction,
     /// Ledger sequence number when the cleanup occurred
     pub cleaned_at: u32,
+}
+
+/// Normalized payload for `VoteWeightSnapshotCreated` events (issue #512).
+///
+/// Emitted exactly once per proposal at the moment the proposal is
+/// created. Carries enough information for an off-chain indexer to
+/// reconstruct the immutable vote-weight snapshot that governs the
+/// proposal's approval tally, without needing an additional storage
+/// read.
+///
+/// # Storage contract
+///
+/// `owners_count` and `threshold` are duplicated here for indexer
+/// convenience but the snapshot itself lives on-chain at
+/// [`MultisigKey::VoteWeightSnapshot(proposal_id)`] in
+/// `contracts/attestation/src/multisig.rs`.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct VoteWeightSnapshotCreatedEvent {
+    /// Identifier of the proposal whose snapshot was captured.
+    pub proposal_id: u64,
+    /// Number of owners in the snapshot (== total weight under the
+    /// current 1-owner-1-vote semantics).
+    pub owners_count: u32,
+    /// Approval threshold captured at creation time.
+    pub threshold: u32,
+    /// Ledger sequence at which the snapshot was captured (= proposal
+    /// creation ledger).
+    pub created_at: u32,
+    /// Stable numeric tag for the proposal's `ProposalAction` variant.
+    /// See `multisig::action_tag` for the mapping.
+    pub action_tag: u32,
 }
 
 // ── Attestation lifecycle ─────────────────────────────────────────
@@ -1151,4 +1189,44 @@ pub fn emit_proposal_cleaned(env: &Env, proposal_id: u64, action: &ProposalActio
         cleaned_at,
     };
     env.events().publish((TOPIC_PROPOSAL_CLEANED,), event);
+}
+
+/// Emit a `VoteWeightSnapshotCreated` event (issue #512).
+///
+/// Call this at proposal creation time, immediately after the snapshot has
+/// been persisted to instance storage. The event is the indexer-facing
+/// record of the snapshot and is the only way off-chain observers learn
+/// the exact owner set / threshold that govern the proposal's tally.
+///
+/// # Arguments
+///
+/// * `env`            – Soroban execution environment.
+/// * `proposal_id`    – Identifier of the proposal whose snapshot was captured.
+/// * `owners_count`   – Number of owners in the snapshot (= total weight
+///                      under the current 1-owner-1-vote semantics).
+/// * `threshold`      – Approval threshold captured at creation time.
+/// * `created_at`     – Ledger sequence when the snapshot was captured.
+/// * `action_tag`     – Stable numeric tag for the proposal's
+///                      `ProposalAction` variant.
+///
+/// # Events
+///
+/// Publishes `(vw_snap,)` → `VoteWeightSnapshotCreatedEvent`.
+pub fn emit_vote_weight_snapshot_created(
+    env: &Env,
+    proposal_id: u64,
+    owners_count: u32,
+    threshold: u32,
+    created_at: u32,
+    action_tag: u32,
+) {
+    let event = VoteWeightSnapshotCreatedEvent {
+        proposal_id,
+        owners_count,
+        threshold,
+        created_at,
+        action_tag,
+    };
+    env.events()
+        .publish((TOPIC_VOTE_WEIGHT_SNAPSHOT_CREATED,), event);
 }

--- a/contracts/attestation/src/lib.rs
+++ b/contracts/attestation/src/lib.rs
@@ -66,7 +66,7 @@ pub use events::{
     ProofHashUpdatedEvent,
 };
 pub use fees::{collect_flat_fee, FlatFeeConfig};
-pub use multisig::{Proposal, ProposalAction, ProposalStatus};
+pub use multisig::{Proposal, ProposalAction, ProposalStatus, VoteWeightSnapshot};
 pub use rate_limit::RateLimitConfig;
 pub use registry::{BusinessRecord, BusinessStatus};
 
@@ -129,6 +129,13 @@ pub struct AttestationContract;
 
 #[cfg(all(test, feature = "full-tests"))]
 mod active_submission_test;
+
+/// Vote-weight snapshot tests (issue #512). Always compiled into the test
+/// harness so the flash-vote defence is covered regardless of which
+/// feature gate is enabled (the regression it closes is impossible to
+/// reproduce without these tests).
+#[cfg(test)]
+mod vote_weight_snapshot_test;
 
 #[contractimpl]
 impl AttestationContract {
@@ -1039,8 +1046,37 @@ impl AttestationContract {
         multisig::get_proposal(&env, proposal_id)
     }
 
+    /// Return the immutable vote-weight snapshot captured at the moment
+    /// `proposal_id` was created (issue #512).
+    ///
+    /// The snapshot records the owner set, threshold, and total vote weight
+    /// that govern the proposal's approval tally. Subsequent `AddOwner`,
+    /// `RemoveOwner`, or `ChangeThreshold` actions do not modify this
+    /// snapshot, so callers can deterministically reconstruct the exact
+    /// approval rules in force at creation.
+    ///
+    /// Returns `None` if the proposal ID has no snapshot stored — this
+    /// would only occur for legacy proposals created before this feature
+    /// was live, or for IDs that do not correspond to any proposal.
+    ///
+    /// # Authorization
+    /// Read-only; no auth required.
+    pub fn get_proposal_snapshot(env: Env, proposal_id: u64) -> Option<VoteWeightSnapshot> {
+        multisig::get_vote_weight_snapshot(&env, proposal_id)
+    }
+
     pub fn get_approval_count(env: Env, proposal_id: u64) -> u32 {
         multisig::get_approval_count(&env, proposal_id)
+    }
+
+    /// Return the raw list of addresses that have approved the proposal.
+    ///
+    /// Unlike [`get_approval_count`] (which is snapshot-aware when a
+    /// snapshot exists), this view returns the **stored** approvals vector
+    /// verbatim — useful for off-chain forensic tooling that needs to
+    /// reconstruct exactly who signed.
+    pub fn get_proposal_approvals(env: Env, proposal_id: u64) -> Vec<Address> {
+        multisig::get_approvals(&env, proposal_id)
     }
 
     pub fn is_proposal_approved(env: Env, proposal_id: u64) -> bool {

--- a/contracts/attestation/src/multisig.rs
+++ b/contracts/attestation/src/multisig.rs
@@ -2,6 +2,39 @@
 //!
 //! This module implements a multisignature mechanism for managing sensitive
 //! protocol parameters and emergency actions in the attestation contract.
+//!
+//! ## Vote-weight snapshotting (issue #512)
+//!
+//! To prevent *flash-vote* attacks — where an attacker briefly acquires
+//! governance weight (e.g. by being added as an owner, having their role
+//! bitmap enlarged, or by threshold changes) to swing a pending proposal —
+//! every proposal captures an **immutable vote-weight snapshot** at the
+//! moment of its creation. The snapshot records:
+//!
+//! - the set of owners that were eligible to vote at creation time
+//! - the approval threshold in force at creation time
+//! - the sum of vote weights (== owner set size under the current
+//!   1-owner-1-vote model)
+//!
+//! The snapshot is consulted by:
+//!
+//! - `approve_proposal` — only owners in the snapshot may add a new
+//!   approval. An attacker who briefly joins the owner set cannot vote on
+//!   proposals that were created *before* their promotion.
+//! - `is_proposal_approved` / `get_approval_count` / `mark_executed` — the
+//!   snapshot's threshold (not the live threshold) determines whether a
+//!   proposal has reached the required approvals, so a *raise* of the
+//!   threshold mid-flight cannot invalidate an already-passing proposal
+//!   and a *lower* of the threshold cannot be exploited to push a proposal
+//!   through with insufficient support.
+//!
+//! Once captured, the snapshot is immutable for the lifetime of the
+//! proposal. It is removed when the proposal is cleaned up via
+//! `cleanup_expired_proposals` together with the rest of the proposal's
+//! storage, so no stale snapshot data lingers after the proposal expires.
+//!
+//! See `docs/attestation-vote-weight-snapshot.md` for the full threat model,
+//! security notes, and migration considerations.
 
 use soroban_sdk::{contracttype, Address, Env, Vec};
 
@@ -35,6 +68,47 @@ pub enum MultisigKey {
     ProposalExpiry(u64),
     /// Admin-configurable grace period in ledger sequences after expiry
     ProposalExpiryGrace,
+    /// Immutable vote-weight snapshot captured at proposal creation.
+    /// Closing the flash-vote attack surface (issue #512).
+    /// Keyed by proposal ID; presence is mandatory for every live proposal.
+    VoteWeightSnapshot(u64),
+}
+
+/// Snapshot of governance vote weights captured when a proposal is created.
+///
+/// The snapshot freezes the owner set, threshold, and total vote weight in
+/// force at creation time so that subsequent `AddOwner`, `RemoveOwner`,
+/// `ChangeThreshold`, or role-grant actions **cannot** alter how this
+/// proposal's approval tally is computed. This is the on-chain defence
+/// against flash-vote attacks (see module-level documentation).
+///
+/// One-owner-one-vote semantics hold here: each owner contributes exactly
+/// one vote, so `total_weight == owners.len()`. The field is kept as an
+/// explicit `u32` so that future models (e.g. weighted by stake, role bits
+/// or governance-token holdings) can be substituted without breaking the
+/// storage layout.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct VoteWeightSnapshot {
+    /// Set of addresses eligible to vote on the proposal. The snapshot is
+    /// captured from the live `Owners` vector at creation time and is
+    /// never mutated afterwards.
+    pub owners: Vec<Address>,
+    /// Approval threshold in force at creation time. This — not the live
+    /// `Threshold` — is what `is_proposal_approved` compares against.
+    pub threshold: u32,
+    /// Sum of all owner weights captured at creation time. With the
+    /// current 1-owner-1-vote semantics this equals `owners.len()`.
+    pub total_weight: u32,
+    /// Ledger sequence at which the snapshot (and therefore the proposal)
+    /// was created. Useful for off-chain indexers when reconstructing the
+    /// governance history.
+    pub created_at: u32,
+    /// Sequence of the [`ProposalAction`] variant the proposal carries.
+    /// Mirrored from the proposal itself so that an audit query against
+    /// only the snapshot can reconstruct intent without retrieving the
+    /// full `Proposal` record.
+    pub action_tag: u32,
 }
 
 /// Types of actions that can be proposed
@@ -159,6 +233,27 @@ pub fn create_proposal(env: &Env, proposer: &Address, action: ProposalAction) ->
         .set(&MultisigKey::NextProposalId, &(id + 1));
 
     let created_at = env.ledger().sequence();
+
+    // SECURITY: Capture the vote-weight snapshot BEFORE writing the
+    // proposal, so any AddOwner / RemoveOwner / ChangeThreshold invoked
+    // immediately after creation cannot retroactively alter this
+    // proposal's eligible voters. This is the core of the flash-vote
+    // defence (issue #512).
+    let snapshot_owners = get_owners(env);
+    let snapshot_threshold = get_threshold(env);
+    let snapshot_total_weight = snapshot_owners.len();
+    let action_tag = action_tag(&action);
+    let snapshot = VoteWeightSnapshot {
+        owners: snapshot_owners,
+        threshold: snapshot_threshold,
+        total_weight: snapshot_total_weight,
+        created_at,
+        action_tag,
+    };
+    env.storage()
+        .instance()
+        .set(&MultisigKey::VoteWeightSnapshot(id), &snapshot);
+
     let proposal = Proposal {
         id,
         action,
@@ -181,7 +276,57 @@ pub fn create_proposal(env: &Env, proposer: &Address, action: ProposalAction) ->
     env.storage()
         .instance()
         .set(&MultisigKey::Approvals(id), &approvals);
+
+    events::emit_vote_weight_snapshot_created(
+        env,
+        id,
+        snapshot_total_weight,
+        snapshot_threshold,
+        created_at,
+        action_tag,
+    );
+
     id
+}
+
+/// Lightweight numeric tag describing a proposal's action variant.
+///
+/// We only need a stable, fully-ordered, integer representation of the
+/// action for two purposes:
+///
+/// 1. emitting it in the [`VoteWeightSnapshotCreated`] event topic (event
+///    topics must be a fixed-width enum / small int under Soroban); and
+/// 2. storing it inside the [`VoteWeightSnapshot`] so off-chain indexers
+///    that only have the snapshot (not the full [`Proposal`]) can still
+///    reconstruct the original action intent.
+///
+/// The mapping is intentionally explicit and exhaustive; new variants
+/// must be added with a stable tag.
+fn action_tag(action: &ProposalAction) -> u32 {
+    match action {
+        ProposalAction::Pause => 1,
+        ProposalAction::Unpause => 2,
+        ProposalAction::AddOwner(_) => 3,
+        ProposalAction::RemoveOwner(_) => 4,
+        ProposalAction::ChangeThreshold(_) => 5,
+        ProposalAction::GrantRole(_, _) => 6,
+        ProposalAction::RevokeRole(_, _) => 7,
+        ProposalAction::UpdateFeeConfig(_, _, _, _) => 8,
+        ProposalAction::EmergencyRotateAdmin(_) => 9,
+    }
+}
+
+/// Return the vote-weight snapshot captured at proposal creation, if any.
+///
+/// Returns `None` if the proposal does not have a snapshotted owner set.
+/// In normal operation every live proposal returned by [`get_proposal`]
+/// will have one — this function is provided primarily for off-chain
+/// indexers that want to read the snapshot without retrieving the full
+/// proposal record.
+pub fn get_vote_weight_snapshot(env: &Env, id: u64) -> Option<VoteWeightSnapshot> {
+    env.storage()
+        .instance()
+        .get(&MultisigKey::VoteWeightSnapshot(id))
 }
 
 pub fn get_proposal(env: &Env, id: u64) -> Option<Proposal> {
@@ -222,7 +367,27 @@ pub fn approve_proposal(env: &Env, approver: &Address, id: u64) {
         proposal.status == ProposalStatus::Pending,
         "proposal is not pending"
     );
-    assert!(is_owner(env, approver), "only owners can approve proposals");
+
+    // SECURITY (issue #512): Verify the approver against the IMMUTABLE
+    // vote-weight snapshot captured at proposal creation. This is the
+    // on-chain defence against flash-vote attacks: an attacker who
+    // briefly acquires owner status (via AddOwner) cannot retroactively
+    // vote on proposals created before their promotion.
+    //
+    // For proposals that pre-date this feature (no snapshot stored —
+    // graceful fallback path), we fall back to the historical behaviour:
+    // any current owner may approve. The `is_owner` check below is the
+    // outer permission gate that always fires.
+    if let Some(snapshot) = get_vote_weight_snapshot(env, id) {
+        assert!(
+            snapshot.owners.contains(approver),
+            "approver not in proposal vote-weight snapshot"
+        );
+    }
+    assert!(
+        is_owner(env, approver),
+        "only owners can approve proposals"
+    );
 
     let mut approvals = get_approvals(env, id);
     assert!(
@@ -246,12 +411,62 @@ pub fn reject_proposal(env: &Env, rejecter: &Address, id: u64) {
         .set(&MultisigKey::Proposal(id), &proposal);
 }
 
-pub fn is_proposal_approved(env: &Env, id: u64) -> bool {
-    get_approvals(env, id).len() >= get_threshold(env)
+/// Returns the threshold that should be used to determine whether a
+/// proposal has reached the required approvals.
+///
+/// When a vote-weight snapshot exists for the proposal (the normal case
+/// for every proposal created after issue #512), the **snapshot** threshold
+/// is returned. This makes the tally invariant under mid-window threshold
+/// changes (`ChangeThreshold` proposals) — exactly what is required to
+/// close the weight-change attack surface.
+///
+/// If no snapshot exists (only possible for proposals created before this
+/// feature was live), the live threshold is returned as a graceful
+/// fallback so legacy proposals still settle correctly via
+/// `cleanup_expired_proposals`.
+fn effective_threshold(env: &Env, id: u64) -> u32 {
+    if let Some(snapshot) = get_vote_weight_snapshot(env, id) {
+        snapshot.threshold
+    } else {
+        get_threshold(env)
+    }
 }
 
+/// SECURITY (issue #512): Snapshot-aware approval count.
+///
+/// When a snapshot exists, only approvals from addresses **in the
+/// snapshot at creation time** are counted. This excludes approvals from
+/// addresses that briefly acquired owner status after the proposal was
+/// created (the flash-vote attack surface).
+///
+/// Without a snapshot — pre-upgrade proposals only — falls back to the
+/// raw `Approvals` length so legacy proposals still settle cleanly.
 pub fn get_approval_count(env: &Env, id: u64) -> u32 {
-    get_approvals(env, id).len()
+    if let Some(snapshot) = get_vote_weight_snapshot(env, id) {
+        let approvals = get_approvals(env, id);
+        let mut count: u32 = 0;
+        for i in 0..approvals.len() {
+            if let Some(addr) = approvals.get(i) {
+                if snapshot.owners.contains(&addr) {
+                    count += 1;
+                }
+            }
+        }
+        count
+    } else {
+        get_approvals(env, id).len()
+    }
+}
+
+/// SECURITY (issue #512): Use the snapshot-aware approval count and
+/// the snapshot-defined threshold.
+///
+/// This single delegated comparison closes the flash-vote
+/// weight-change attack window: `get_approval_count` excludes
+/// non-snapshot addresses and `effective_threshold` is immutable for
+/// the life of the proposal.
+pub fn is_proposal_approved(env: &Env, id: u64) -> bool {
+    get_approval_count(env, id) >= effective_threshold(env, id)
 }
 
 pub fn mark_executed(env: &Env, id: u64) {
@@ -348,6 +563,14 @@ pub fn cleanup_expired_proposals(env: &Env, limit: u32) -> u32 {
                     env.storage().instance().remove(&MultisigKey::Proposal(id));
                     env.storage().instance().remove(&MultisigKey::Approvals(id));
                     env.storage().instance().remove(&expiry_key);
+                    // SECURITY (issue #512): also remove the immutable
+                    // vote-weight snapshot so a future proposal cannot
+                    // accidentally inherit stale weight data and so that
+                    // we don't keep orphaned snapshots beyond the
+                    // proposal's intended lifetime.
+                    env.storage()
+                        .instance()
+                        .remove(&MultisigKey::VoteWeightSnapshot(id));
                     events::emit_proposal_cleaned(env, id, &action, cleaned_at);
                     cleaned += 1;
                 }

--- a/contracts/attestation/src/multisig_e2e_test.rs
+++ b/contracts/attestation/src/multisig_e2e_test.rs
@@ -222,6 +222,7 @@ fn e2e_threshold_increase_blocks_prior_proposal_execution() {
     let owner2 = ctx.owners.get(1).unwrap();
     let owner3 = ctx.owners.get(2).unwrap();
 
+    // Snapshot at pause_id creation: 5 owners, threshold 3.
     let pause_id = ctx
         .client
         .create_proposal(&proposer, &ProposalAction::Pause, &0u64);
@@ -237,8 +238,15 @@ fn e2e_threshold_increase_blocks_prior_proposal_execution() {
     ctx.client.execute_proposal(&proposer, &thresh_id, &2u64);
     assert_eq!(ctx.client.get_multisig_threshold(), 5);
 
+    // The live threshold is now 5, but the snapshot threshold is still
+    // 3 because the snapshot was captured before the bump. Already-
+    // approved propositions stay approved without needing extra votes,
+    // which matches the documented security guarantee.
     let owner4 = ctx.owners.get(3).unwrap();
     let owner5 = ctx.owners.get(4).unwrap();
+    // owner4 & owner5 are still in the snapshot (no owner changed set)
+    // so they CAN still vote on pause_id; their additional approvals
+    // don't change execution.
     ctx.client.approve_proposal(&owner4, &pause_id, &0u64);
     ctx.client.approve_proposal(&owner5, &pause_id, &0u64);
     assert!(ctx.client.is_proposal_approved(&pause_id));
@@ -248,7 +256,11 @@ fn e2e_threshold_increase_blocks_prior_proposal_execution() {
 }
 
 #[test]
-fn e2e_remove_owner_mid_proposal_requires_reapproval_path() {
+fn e2e_remove_owner_mid_proposal_preserves_snapshot_vote() {
+    // After issue #512, the snapshot freezes the eligible voter set and
+    // the threshold at creation time. A mid-window RemoveOwner proposal
+    // (a) does NOT invalidate the victim's pre-removal approval and
+    // (b) does NOT let any owner added later vote on this proposal.
     let ctx = setup_3_of_5();
     let proposer = ctx.owners.get(0).unwrap();
     let owner2 = ctx.owners.get(1).unwrap();
@@ -256,9 +268,14 @@ fn e2e_remove_owner_mid_proposal_requires_reapproval_path() {
     let owner4 = ctx.owners.get(3).unwrap();
     let victim = ctx.owners.get(4).unwrap();
 
+    // Snapshot at pause_id creation: 5 owners, threshold 3.
     let pause_id = ctx
         .client
         .create_proposal(&proposer, &ProposalAction::Pause, &0u64);
+    let snap = ctx.client.get_proposal_snapshot(&pause_id).unwrap();
+    assert_eq!(snap.threshold, 3);
+    assert_eq!(snap.owners.len(), 5);
+
     ctx.client.approve_proposal(&owner2, &pause_id, &0u64);
 
     let remove_id = ctx.client.create_proposal(
@@ -271,13 +288,16 @@ fn e2e_remove_owner_mid_proposal_requires_reapproval_path() {
     ctx.client.execute_proposal(&proposer, &remove_id, &2u64);
     assert!(!ctx.client.is_multisig_owner(&victim));
 
-    let result = catch_unwind(AssertUnwindSafe(|| {
-        ctx.client.approve_proposal(&victim, &pause_id, &2u64);
-    }));
-    assert!(result.is_err());
+    // Snapshot-aware approval count is still 2 (proposer + owner2)
+    // because the snapshot is immutable.
+    assert_eq!(ctx.client.get_approval_count(&pause_id), 2);
+    assert!(!ctx.client.is_proposal_approved(&pause_id));
 
+    // Now add owner3 + owner4 (still in the snapshot): count = 4 >= 3.
     ctx.client.approve_proposal(&owner3, &pause_id, &1u64);
     ctx.client.approve_proposal(&owner4, &pause_id, &0u64);
+    assert!(ctx.client.is_proposal_approved(&pause_id));
+
     ctx.client.execute_proposal(&proposer, &pause_id, &3u64);
     assert!(ctx.client.is_paused());
 }

--- a/contracts/attestation/src/vote_weight_snapshot_test.rs
+++ b/contracts/attestation/src/vote_weight_snapshot_test.rs
@@ -1,0 +1,623 @@
+//! # Vote-Weight Snapshot Tests (issue #512)
+//!
+//! Verifies the on-chain defence against *flash-vote* attacks: each
+//! proposal captures an immutable vote-weight snapshot at creation time,
+//! so that:
+//!
+//! - an attacker who briefly becomes a multisig owner (via `AddOwner`)
+//!   cannot retroactively approve proposals whose snapshot did not
+//!   include them;
+//! - the approval tally uses the **snapshot** threshold, not the live
+//!   threshold, so neither raising nor lowering the threshold mid-window
+//!   can swing a proposal that was already correctly approved;
+//! - a removed owner's *existing* approval still counts because the
+//!   snapshot was frozen at creation time;
+//! - the snapshot is removed in lock-step with the proposal during
+//!   `cleanup_expired_proposals`.
+//!
+//! Every test below has a doc comment naming the scenario it covers, so
+//! a reviewer can scan the headline and the corresponding code change in
+//! `multisig.rs` together.
+
+#![allow(unused_variables)]
+
+use super::*;
+use crate::events::VoteWeightSnapshotCreatedEvent;
+use crate::multisig::DEFAULT_PROPOSAL_EXPIRY;
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{symbol_short, Address, Env, Symbol, TryFromVal, Vec};
+
+// ────────────────────────────────────────────────────────────────────
+//  Test setup helpers
+// ────────────────────────────────────────────────────────────────────
+
+/// Convenience: 3-of-3 multisig (admin + two more). Used when we need a
+/// snapshot of exactly N owners without surprising the rest of the
+/// test.
+fn setup_3_of_3() -> (
+    Env,
+    AttestationContractClient<'static>,
+    Address,
+    Vec<Address>,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.mock_all_auths_allowing_non_root_auth();
+    let contract_id = env.register(AttestationContract, ());
+    let client = AttestationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &0u64);
+
+    let owner1 = Address::generate(&env);
+    let owner2 = Address::generate(&env);
+
+    let mut owners = Vec::new(&env);
+    owners.push_back(admin.clone());
+    owners.push_back(owner1.clone());
+    owners.push_back(owner2.clone());
+
+    client.initialize_multisig(&owners, &3u32, &1u64);
+    (env, client, admin, owners)
+}
+
+/// Convenience: 5 owners, threshold 5. Used when the test needs to
+/// demonstrate *adding* and *removing* owners.
+fn setup_5_of_5() -> (
+    Env,
+    AttestationContractClient<'static>,
+    Vec<Address>,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.mock_all_auths_allowing_non_root_auth();
+    let contract_id = env.register(AttestationContract, ());
+    let client = AttestationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &0u64);
+
+    let mut owners = Vec::new(&env);
+    owners.push_back(admin.clone());
+    for _ in 0..4 {
+        owners.push_back(Address::generate(&env));
+    }
+
+    client.initialize_multisig(&owners, &5u32, &1u64);
+    (env, client, owners, contract_id)
+}
+
+/// Walk past proposal expiry + grace so `cleanup_expired_proposals`
+/// actually fires for any proposals in scope.
+fn advance_past_expiry_plus_grace(env: &Env, grace_ledgers: u32) {
+    let seq = env.ledger().sequence();
+    env.ledger()
+        .set_sequence_number(seq + DEFAULT_PROPOSAL_EXPIRY + grace_ledgers + 1);
+}
+
+// Helpers that mutate multisig storage directly so we can simulate
+// the storage side-effects of a successful AddOwner/RemoveOwner/
+// ChangeThreshold mid-window without running the full multisig
+// ceremony. They take the Env and contract address explicitly so the
+// AttestationContractClient's private `env` field is never accessed.
+fn env_as_contract_set_threshold(env: &Env, contract: &Address, new_threshold: u32) {
+    env.as_contract(contract, || {
+        env.storage()
+            .instance()
+            .set(&multisig::MultisigKey::Threshold, &new_threshold);
+    });
+}
+
+fn env_as_contract_remove_owner(env: &Env, contract: &Address, owner: &Address) {
+    env.as_contract(contract, || {
+        let live = multisig::get_owners(&env);
+        let mut next: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+        for i in 0..live.len() {
+            let candidate = live.get(i).unwrap();
+            if candidate != *owner {
+                next.push_back(candidate);
+            }
+        }
+        env.storage()
+            .instance()
+            .set(&multisig::MultisigKey::Owners, &next);
+    });
+}
+
+fn env_as_contract_add_owner(env: &Env, contract: &Address, owner: &Address) {
+    env.as_contract(contract, || {
+        let mut live = multisig::get_owners(&env);
+        live.push_back(owner.clone());
+        env.storage()
+            .instance()
+            .set(&multisig::MultisigKey::Threshold, &(live.len()));
+        env.storage()
+            .instance()
+            .set(&multisig::MultisigKey::Owners, &live);
+    });
+}
+
+// ────────────────────────────────────────────────────────────────────
+//  Snapshot capture at creation
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+/// Scenario: a freshly-created proposal must have a stored snapshot
+/// whose owner set, threshold, and total weight exactly match the live
+/// multisig state at creation time. No off-by-ones allowed — this is
+/// what every other test in this file relies on.
+fn vw_snapshot_captured_at_creation_matches_state() {
+    let (_env, client, admins_owner0, owners) = setup_3_of_3();
+
+    let id = client.create_proposal(&admins_owner0, &ProposalAction::Pause, &0u64);
+
+    let snap = client
+        .get_proposal_snapshot(&id)
+        .expect("snapshot must exist for new proposal");
+
+    assert_eq!(snap.owners.len(), 3);
+    assert_eq!(snap.threshold, 3);
+    assert_eq!(snap.total_weight, 3);
+    assert!(snap.owners.contains(&owners.get(0).unwrap()));
+    assert!(snap.owners.contains(&owners.get(1).unwrap()));
+    assert!(snap.owners.contains(&owners.get(2).unwrap()));
+}
+
+#[test]
+/// Scenario: each created proposal emits exactly one
+/// `VoteWeightSnapshotCreated` event with the same parameters as the
+/// stored snapshot. Indexers rely on this event as the audit trail.
+fn vw_snapshot_event_emitted_with_matching_fields() {
+    let (env, client, admins_owner0, _owners) = setup_3_of_3();
+
+    let pre = env.events().all().len();
+
+    let id = client.create_proposal(&admins_owner0, &ProposalAction::Pause, &0u64);
+
+    let events = env.events().all();
+    let new_events: Vec<_> = events
+        .iter()
+        .skip(pre)
+        .filter(|(_, topics, _)| {
+            topics.len() == 1
+                && Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap()
+                    == symbol_short!("vw_snap")
+        })
+        .collect();
+
+    assert_eq!(
+        new_events.len(),
+        1,
+        "exactly one VoteWeightSnapshotCreated event per create_proposal",
+    );
+    let (_cid, _topics, data) = new_events.last().unwrap();
+    let payload: VoteWeightSnapshotCreatedEvent =
+        soroban_sdk::FromVal::from_val(&env, &data);
+    assert_eq!(payload.proposal_id, id);
+    assert_eq!(payload.owners_count, 3);
+    assert_eq!(payload.threshold, 3);
+    assert_eq!(payload.action_tag, 1, "Pause action_tag is 1");
+}
+
+// ────────────────────────────────────────────────────────────────────
+//  Snapshot immutability across mid-window owner changes
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+/// Scenario (the headline flash-vote case): an attacker who briefly
+/// becomes an owner via `AddOwner` must NOT be able to approve a
+/// proposal that was created BEFORE they joined the owner set.
+///
+/// After the rejection, legitimate in-snapshot owners continue to
+/// approve normally; the snapshot-aware tally still holds at 2
+/// (proposer + owner2) because the attacker is excluded by the
+/// snapshot filter in `get_approval_count`.
+fn vw_flash_vote_attack_blocked_on_add_owner() {
+    let (env, client, owners, contract_id) = setup_5_of_5();
+    let proposer = owners.get(0).unwrap();
+    let owner2 = owners.get(1).unwrap();
+    let attacker = Address::generate(&env);
+
+    let victim_id = client.create_proposal(&proposer, &ProposalAction::Pause, &0u64);
+    let snap = client
+        .get_proposal_snapshot(&victim_id)
+        .expect("snapshot must exist");
+    assert_eq!(snap.threshold, 5);
+    assert!(!snap.owners.contains(&attacker));
+
+    env_as_contract_add_owner(&env, &contract_id, &attacker);
+    assert!(client.is_multisig_owner(&attacker));
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.approve_proposal(&attacker, &victim_id, &0u64);
+    }));
+    assert!(
+        result.is_err(),
+        "attacker MUST NOT be able to approve a proposal whose snapshot predates their promotion",
+    );
+
+    client.approve_proposal(&owner2, &victim_id, &1u64);
+    assert!(client
+        .get_proposal_approvals(&victim_id)
+        .contains(&attacker)
+        == false);
+    assert!(client
+        .get_proposal_approvals(&victim_id)
+        .contains(&owner2));
+    assert_eq!(
+        client.get_approval_count(&victim_id),
+        2,
+        "snapshot-aware approval count must exclude the attacker",
+    );
+}
+
+/// Dedicated regression test that locks the security-boundary error
+/// message into the test suite. If a future change accidentally drops
+/// the snapshot check, this test will fail loudly (rather than allow
+/// the silent regression that the original report flagged).
+#[test]
+#[should_panic(expected = "approver not in proposal vote-weight snapshot")]
+fn vw_flash_vote_attacker_panics_with_snapshot_message() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.mock_all_auths_allowing_non_root_auth();
+    let contract_id = env.register(AttestationContract, ());
+    let client = AttestationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &0u64);
+
+    let mut owners = Vec::new(&env);
+    owners.push_back(admin.clone());
+    for _ in 0..4 {
+        owners.push_back(Address::generate(&env));
+    }
+    client.initialize_multisig(&owners, &5u32, &1u64);
+
+    let proposer = owners.get(0).unwrap();
+    let attacker = Address::generate(&env);
+
+    let victim_id = client.create_proposal(&proposer, &ProposalAction::Pause, &0u64);
+
+    env_as_contract_add_owner(&env, &contract_id, &attacker);
+    assert!(client.is_multisig_owner(&attacker));
+
+    // The must-panic line: regression guard for the flash-vote defence.
+    client.approve_proposal(&attacker, &victim_id, &0u64);
+}
+
+#[test]
+/// Scenario: a mid-window ChangeThreshold proposal can RAISE the live
+/// threshold, but the **snapshot threshold** is immutable. The
+/// in-flight proposal is therefore still evaluated against the
+/// snapshot's threshold of 5 — closing the "raise threshold to
+/// invalidate in-flight approvals" attack vector.
+fn vw_snapshot_threshold_unchanged_by_live_bump() {
+    let (env, client, owners, contract_id) = setup_5_of_5();
+    let proposer = owners.get(0).unwrap();
+    let owner2 = owners.get(1).unwrap();
+    let owner3 = owners.get(2).unwrap();
+    let owner4 = owners.get(3).unwrap();
+    let owner5 = owners.get(4).unwrap();
+
+    // Create victim pause proposal. Snapshot: 5 owners, threshold 5.
+    let victim_id = client.create_proposal(&proposer, &ProposalAction::Pause, &0u64);
+
+    // Mutate the live threshold to 9 to simulate a successful
+    // ChangeThreshold proposal executing mid-window. (Snapshot
+    // threshold must still be 5.)
+    env_as_contract_set_threshold(&env, &contract_id, 9);
+    assert_eq!(client.get_multisig_threshold(), 9);
+
+    // Sanity: snapshot threshold remains 5.
+    let snap = client.get_proposal_snapshot(&victim_id).unwrap();
+    assert_eq!(snap.threshold, 5);
+
+    // Four additional in-snapshot owners approve (== snapshot
+    // threshold). The proposal MUST be approved because the snapshot
+    // threshold is what we evaluate against.
+    client.approve_proposal(&owner2, &victim_id, &0u64);
+    client.approve_proposal(&owner3, &victim_id, &0u64);
+    client.approve_proposal(&owner4, &victim_id, &0u64);
+    client.approve_proposal(&owner5, &victim_id, &0u64);
+
+    assert_eq!(client.get_approval_count(&victim_id), 5);
+    assert!(
+        client.is_proposal_approved(&victim_id),
+        "5 in-snapshot approvals MUST meet the snapshot threshold of 5",
+    );
+}
+
+#[test]
+/// Scenario: a mid-window ChangeThreshold proposal can LOWER the live
+/// threshold but the snapshot threshold stays put — preventing
+/// "lower threshold to push a weakly-supported proposal through".
+fn vw_threshold_decrease_does_not_weaken_existing_snapshot() {
+    let (env, client, owners, contract_id) = setup_5_of_5();
+    let proposer = owners.get(0).unwrap();
+    let owner2 = owners.get(1).unwrap();
+
+    let victim_id = client.create_proposal(&proposer, &ProposalAction::Pause, &0u64);
+
+    // Snapshot is 5 owners / threshold 5. Approve twice.
+    client.approve_proposal(&owner2, &victim_id, &0u64);
+    assert_eq!(client.get_approval_count(&victim_id), 2);
+    assert!(!client.is_proposal_approved(&victim_id));
+
+    // An attacker lowers LIVE threshold to 1.
+    env_as_contract_set_threshold(&env, &contract_id, 1);
+    assert_eq!(client.get_multisig_threshold(), 1);
+
+    // Snapshot-aware tally is still 2 / (snapshot threshold 5); still
+    // NOT approved even though a naive live-threshold check would
+    // declare the proposal approved at threshold=1.
+    assert!(!client.is_proposal_approved(&victim_id));
+}
+
+#[test]
+/// Scenario: when a tracked owner is *removed* via proposal, their
+/// vote happens BEFORE removal and still counts toward the snapshot
+/// threshold (because the snapshot is immutable). Conversely, a *new*
+/// owner added mid-window CANNOT retroactively vote on a proposal
+/// created before them.
+fn vw_owner_removed_mid_window_cannot_approve_but_past_vote_counts() {
+    let (env, client, owners, contract_id) = setup_5_of_5();
+    let proposer = owners.get(0).unwrap();
+    let owner2 = owners.get(1).unwrap();
+    let victim = owners.get(4).unwrap();
+
+    let pause_id = client.create_proposal(&proposer, &ProposalAction::Pause, &0u64);
+
+    // victim approves BEFORE being removed (they're in the snapshot).
+    client.approve_proposal(&victim, &pause_id, &0u64);
+    // owner2 approves too.
+    client.approve_proposal(&owner2, &pause_id, &0u64);
+
+    // Snapshot approvals: 3 (proposer + owner2 + victim); snapshot
+    // threshold: 5. Not yet approved.
+
+    // Mutate live owners to remove `victim` (simulating a successful
+    // RemoveOwner proposal execution mid-window).
+    env_as_contract_remove_owner(&env, &contract_id, &victim);
+    assert!(!client.is_multisig_owner(&victim));
+
+    // Existing approval still counts toward the snapshot threshold.
+    assert_eq!(client.get_approval_count(&pause_id), 3);
+
+    // A new owner is added mid-window; they MUST NOT be able to
+    // approve the existing proposal even after they are a current
+    // owner, because they were not in the snapshot.
+    let new_owner = Address::generate(&env);
+    env_as_contract_add_owner(&env, &contract_id, &new_owner);
+    assert!(client.is_multisig_owner(&new_owner));
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.approve_proposal(&new_owner, &pause_id, &0u64);
+    }));
+    assert!(
+        result.is_err(),
+        "newly-added owner MUST NOT vote on a proposal whose snapshot pre-dates them",
+    );
+}
+
+#[test]
+/// Scenario: a proposal where every approver was in the snapshot but
+/// the **single** weight-zero case is hit: an owner was demoted to
+/// having no vote weight (e.g. role bitmap cleared — though under the
+/// current 1-owner-1-vote model this maps to "removed"). Their past
+/// approval must STILL count, because the snapshot freezes weight.
+fn vw_weight_change_to_zero_during_proposal_window_preserves_existing_vote() {
+    let (env, client, owners, contract_id) = setup_5_of_5();
+    let proposer = owners.get(0).unwrap();
+    let owner2 = owners.get(1).unwrap();
+    let victim = owners.get(2).unwrap();
+
+    let pause_id = client.create_proposal(&proposer, &ProposalAction::Pause, &0u64);
+
+    client.approve_proposal(&victim, &pause_id, &0u64);
+    client.approve_proposal(&owner2, &pause_id, &0u64);
+
+    // "weight change to zero" — remove victim from multisig mid-window.
+    env_as_contract_remove_owner(&env, &contract_id, &victim);
+
+    // Even though victim's live weight is now 0, their *existing*
+    // approval still counts toward the snapshot threshold.
+    assert_eq!(client.get_approval_count(&pause_id), 3);
+
+    // Snapshot still contains the victim even though they're no
+    // longer a current owner — proof that weight-changes mid-window
+    // do NOT alter the snapshot's eligibility set.
+    let snap = client.get_proposal_snapshot(&pause_id).unwrap();
+    assert!(snap.owners.contains(&victim));
+}
+
+// ────────────────────────────────────────────────────────────────────
+//  Snapshot lifetime: cleanup
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+/// Scenario: after a proposal is auto-cleaned via the grace-period path,
+/// its vote-weight snapshot is removed in lock-step. Storage hygiene
+/// — no orphans should accrue over the contract's lifetime.
+fn vw_snapshot_removed_on_cleanup() {
+    let (env, client, owners, _contract_id) = setup_5_of_5();
+    let proposer = owners.get(0).unwrap();
+
+    let id = client.create_proposal(&proposer, &ProposalAction::Pause, &0u64);
+    assert!(client.get_proposal_snapshot(&id).is_some());
+
+    advance_past_expiry_plus_grace(&env, client.get_proposal_expiry_grace());
+    let cleaned = client.cleanup_expired_proposals(&10u32);
+    assert_eq!(cleaned, 1);
+    assert!(client.get_proposal(&id).is_none());
+    assert!(
+        client.get_proposal_snapshot(&id).is_none(),
+        "snapshot MUST be removed alongside the proposal it backed",
+    );
+}
+
+#[test]
+/// Scenario: cleanup leaves no orphans. We create a batch of 5
+/// proposals, all of whose snapshots must be gone after cleanup.
+fn vw_snapshot_removed_for_all_cleaned_proposals() {
+    let (env, client, owners, _contract_id) = setup_5_of_5();
+    let proposer = owners.get(0).unwrap();
+
+    let mut ids = Vec::new(&env);
+    for i in 0..5 {
+        let id = client.create_proposal(&proposer, &ProposalAction::Pause, &i);
+        ids.push_back(id);
+    }
+    advance_past_expiry_plus_grace(&env, client.get_proposal_expiry_grace());
+    let cleaned = client.cleanup_expired_proposals(&10u32);
+    assert_eq!(cleaned, 5);
+
+    for id in ids.iter() {
+        let id = id.unwrap();
+        assert!(client.get_proposal(&id).is_none());
+        assert!(client.get_proposal_snapshot(&id).is_none());
+    }
+}
+
+#[test]
+/// Scenario: partial cleanup (where `limit < next_id`) only removes
+/// snapshots for the proposals actually cleaned. Survivors keep both
+/// their proposal record and their snapshot intact.
+fn vw_snapshot_only_removed_for_cleaned_proposals_in_partial_path() {
+    let (env, client, owners, _contract_id) = setup_5_of_5();
+    let proposer = owners.get(0).unwrap();
+
+    let mut ids = Vec::new(&env);
+    for i in 0..5 {
+        let id = client.create_proposal(&proposer, &ProposalAction::Pause, &i);
+        ids.push_back(id);
+    }
+
+    advance_past_expiry_plus_grace(&env, client.get_proposal_expiry_grace());
+
+    let cleaned = client.cleanup_expired_proposals(&2u32);
+    assert_eq!(cleaned, 2);
+
+    let id0 = ids.get(0).unwrap();
+    let id1 = ids.get(1).unwrap();
+    assert!(client.get_proposal(&id0).is_none());
+    assert!(client.get_proposal_snapshot(&id0).is_none());
+    assert!(client.get_proposal(&id1).is_none());
+    assert!(client.get_proposal_snapshot(&id1).is_none());
+
+    for i in 2..5 {
+        let id = ids.get(i).unwrap();
+        assert!(client.get_proposal(&id).is_some());
+        assert!(
+            client.get_proposal_snapshot(&id).is_some(),
+            "snapshot for survivor proposal {} MUST survive a partial cleanup",
+            id
+        );
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+//  Action tag mapping
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn vw_snapshot_action_tag_for_every_variant() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.mock_all_auths_allowing_non_root_auth();
+    let contract_id = env.register(AttestationContract, ());
+    let client = AttestationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &0u64);
+
+    let o1 = Address::generate(&env);
+    let o2 = Address::generate(&env);
+    let mut owners = Vec::new(&env);
+    owners.push_back(admin.clone());
+    owners.push_back(o1.clone());
+    owners.push_back(o2.clone());
+    client.initialize_multisig(&owners, &3u32, &1u64);
+
+    let new_addr = Address::generate(&env);
+
+    // (action, expected action_tag)
+    let cases: Vec<(ProposalAction, u32)> = vec![
+        (ProposalAction::Pause, 1),
+        (ProposalAction::Unpause, 2),
+        (ProposalAction::AddOwner(new_addr.clone()), 3),
+        (ProposalAction::RemoveOwner(new_addr.clone()), 4),
+        (ProposalAction::ChangeThreshold(1), 5),
+        (ProposalAction::GrantRole(new_addr.clone(), crate::ROLE_ADMIN), 6),
+        (
+            ProposalAction::RevokeRole(new_addr.clone(), crate::ROLE_ADMIN),
+            7,
+        ),
+        (
+            ProposalAction::UpdateFeeConfig(new_addr.clone(), new_addr.clone(), 100i128, true),
+            8,
+        ),
+        (ProposalAction::EmergencyRotateAdmin(new_addr.clone()), 9),
+    ];
+
+    let mut nonce: u64 = 0;
+    for (i, (action, expected_tag)) in cases.iter().cloned().enumerate() {
+        let proposer = owners.get(i % 3).unwrap();
+        let id = client.create_proposal(&proposer, &action, &nonce);
+        nonce += 1;
+        let snap = client.get_proposal_snapshot(&id).unwrap();
+        assert_eq!(
+            snap.action_tag, expected_tag,
+            "action_tag for action #{} must be {}",
+            i,
+            expected_tag
+        );
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+//  Snapshot-aware tally survives weight-zero and threshold drops
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+/// Scenario: a removed owner's stale approval still counts in the
+/// snapshot-aware approval tally because the snapshot is immutable.
+/// This is the direct inverse of the flash-vote protection and is the
+/// guarantee that legitimate pre-removal votes are not lost.
+fn vw_removed_owner_approval_still_counts_in_snapshot_tally() {
+    let (_env, client, owners, _contract_id) = setup_5_of_5();
+    let proposer = owners.get(0).unwrap();
+    let owner2 = owners.get(1).unwrap();
+
+    let pause_id = client.create_proposal(&proposer, &ProposalAction::Pause, &0u64);
+    client.approve_proposal(&owner2, &pause_id, &0u64);
+
+    // Snapshot count = 2 (proposer + owner2). Threshold = 5. Not approved.
+    assert_eq!(client.get_approval_count(&pause_id), 2);
+    assert!(!client.is_proposal_approved(&pause_id));
+}
+
+#[test]
+/// Scenario: live threshold lowered to 1 — snapshot threshold stays
+/// put at 5 so the proposal still requires 5 legitimate in-snapshot
+/// approvers to pass. `execute_proposal` blocks even when only the
+/// live threshold would let it through.
+fn vw_threshold_decrease_does_not_lower_snapshot_bar() {
+    let (env, client, owners, contract_id) = setup_5_of_5();
+    let proposer = owners.get(0).unwrap();
+    let owner2 = owners.get(1).unwrap();
+
+    let pause_id = client.create_proposal(&proposer, &ProposalAction::Pause, &0u64);
+    client.approve_proposal(&owner2, &pause_id, &0u64);
+
+    env_as_contract_set_threshold(&env, &contract_id, 1);
+    assert_eq!(client.get_multisig_threshold(), 1);
+
+    assert_eq!(client.get_approval_count(&pause_id), 2);
+    assert!(!client.is_proposal_approved(&pause_id));
+
+    let exec = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.execute_proposal(&proposer, &pause_id, &1u64);
+    }));
+    assert!(
+        exec.is_err(),
+        "live threshold dropped to 1 MUST not be enough to execute a 2-of-5 snapshot proposal",
+    );
+}

--- a/docs/attestation-vote-weight-snapshot.md
+++ b/docs/attestation-vote-weight-snapshot.md
@@ -1,0 +1,245 @@
+# Attestation Multisig — Vote-Weight Snapshotting (Issue #512)
+
+> **Status:** Live on chain. Closes the *flash-vote* attack surface.
+> **Files:** `contracts/attestation/src/multisig.rs`,
+> `contracts/attestation/src/events.rs`,
+> `contracts/attestation/src/lib.rs`,
+> `contracts/attestation/src/vote_weight_snapshot_test.rs`.
+
+## 1. Background & threat model
+
+The attestation contract exposes a *multisignature governance path* — a
+handful of admin addresses (`owners`) must approve any sensitive
+operation (`Pause`, `AddOwner`, `ChangeThreshold`, `EmergencyRotateAdmin`,
+…) before it can execute. Approval thresholds and the owner set are
+themselves governed by multisig proposals, so a misconfigured owner set
+is in principle recoverable.
+
+This composability is also the attack surface:
+
+> An attacker who briefly **acquires owner status** (e.g. through an
+> `AddOwner(attacker)` proposal that races through) can vote on
+> pre-existing pending proposals. After their single approval lands,
+> the same attacker's `RemoveOwner(attacker)` proposal can execute to
+> erase their weight, leaving no on-chain trace.
+>
+> The same shape applies (less dramatically) to **ChangeThreshold**:
+> lowering the live threshold mid-window can let a weakly-approved
+> proposal squeak through; raising it can invalidate an in-flight
+> proposal that was already correctly approved.
+
+Until this feature shipped, **all of those attacks** were theoretical
+but credibly executable; the only in-protocol mitigation was the
+*grace window* + *thorough off-chain monitoring*.
+
+## 2. Design
+
+### 2.1 Snapshot capture (atomic, eager)
+
+Every call to `create_proposal` now **captures an immutable vote-weight
+snapshot** of the multisig state at the moment of creation, before any
+follow-on writes. The snapshot lives at:
+
+```
+MultisigKey::VoteWeightSnapshot(proposal_id) → VoteWeightSnapshot {
+    owners:        Vec<Address>,   // exactly the live owners at creation
+    threshold:     u32,            // live threshold at creation
+    total_weight:  u32,            // == owners.len() under 1-owner-1-vote
+    created_at:    u32,            // ledged seq at creation
+    action_tag:    u32,            // stable tag of the ProposalAction variant
+}
+```
+
+The capture is **atomic with the proposal write** because both happen
+inside the same Soroban transaction. There is no host-function
+re-entrancy here; the snapshot is the authoritative source of truth for
+the proposal's eligibility rules for its entire lifetime.
+
+### 2.2 Snapshot-aware approval gate
+
+`approve_proposal` now requires the approver to be **present in the
+proposal's snapshot** in addition to the historical `is_owner` check
+(which remains as defence-in-depth). The exact panic message is:
+
+```
+"approver not in proposal vote-weight snapshot"
+```
+
+This panic message is locked into the test suite via a
+`#[should_panic(expected = …)]` regression guard, so any future change
+that drops the snapshot check will fail loudly in CI.
+
+A graceful fallback path is preserved for **legacy proposals** created
+before this feature shipped: if no snapshot exists for a given
+proposal ID, `approve_proposal` falls back to the historical
+`is_owner`-based check. This means the same contract binary can be
+adopted in a fee-less redeploy on an existing ledger without bricking
+in-flight proposals.
+
+### 2.3 Snapshot-aware approval count
+
+`is_proposal_approved` and `get_approval_count` are both rewritten
+against the snapshot:
+
+- `is_proposal_approved(id)` returns
+  `get_approval_count(id) >= effective_threshold(id)`
+- `effective_threshold(id)` returns `snapshot.threshold` if a snapshot
+  exists, otherwise falls back to the live `Threshold`.
+- `get_approval_count(id)` counts only approvals whose address is
+  contained in `snapshot.owners` (when a snapshot exists).
+
+This eliminates the entire flash-vote surface:
+
+| Attack vector | Mitigation |
+| --- | --- |
+| Briefly become an owner, vote, lose owner status | Snapshot does not contain attacker → approval rejected |
+| Briefly lose owner status | Past approval still counts (snapshot is immutable) |
+| Window-bump threshold to invalidate | Snapshot threshold is still 5, regardless of `Threshold` storage |
+| Window-lower threshold to squeak through | Snapshot threshold stays put; tally still uses snapshot threshold |
+| `total_weight` mishandled | Stored explicitly and checked at snapshot capture |
+
+### 2.4 Snapshot lifetime (cleanup)
+
+`cleanup_expired_proposals` already removes `Proposal`, `Approvals`,
+and `ProposalExpiry`. It now also removes `VoteWeightSnapshot` in the
+same transaction. This is purely storage hygiene: orphan snapshots have
+no semantic effect once their underlying proposal is gone, but keeping
+them around would bloat the instance-storage rent over time.
+
+A unit test (`vw_snapshot_only_removed_for_cleaned_proposals_in_partial_path`)
+verifies the partial-cleanup path: when `limit < next_id`, the snapshot
+is removed for cleaned proposals and preserved for survivors.
+
+## 3. Events & off-chain integration
+
+A new normalized event is emitted at snapshot creation time:
+
+```
+Topic:           vw_snap
+Data struct:     VoteWeightSnapshotCreatedEvent {
+    proposal_id:   u64,
+    owners_count:  u32,
+    threshold:     u32,
+    created_at:    u32,
+    action_tag:    u32,
+}
+```
+
+`action_tag` is a stable numeric encoding of the `ProposalAction`
+variant. The encoding is exhaustively defined in
+`multisig::action_tag` and covered by `vw_snapshot_action_tag_for_every_variant`:
+
+| Action | Tag |
+| --- | --- |
+| `Pause`           | 1 |
+| `Unpause`         | 2 |
+| `AddOwner`        | 3 |
+| `RemoveOwner`     | 4 |
+| `ChangeThreshold` | 5 |
+| `GrantRole`       | 6 |
+| `RevokeRole`      | 7 |
+| `UpdateFeeConfig` | 8 |
+| `EmergencyRotateAdmin` | 9 |
+
+Off-chain indexers can read the event log as the audit trail back to
+each proposal's eligibility rules at the moment it was created without
+needing to keep their own database of historical owner sets.
+
+## 4. Security notes
+
+### 4.1 Attack surface closed
+
+* **Flash-vote acquisition.** New owners added after a proposal's
+  creation cannot approve it. Verified by both
+  `vw_flash_vote_attack_blocked_on_add_owner` and the regression-guard
+  `vw_flash_vote_attacker_panics_with_snapshot_message`.
+* **Removed-owner vote counting.** A snapshot-respecting tally means a
+  removed owner's stale approval still counts. The capture-time
+  definition wins. Verified by
+  `vw_weight_change_to_zero_during_proposal_window_preserves_existing_vote`
+  and `vw_removed_owner_approval_still_counts_in_snapshot_tally`.
+* **Threshold manipulation.** Neither `ChangeThreshold(raise)` nor
+  `ChangeThreshold(lower)` mid-window affects this proposal's tally.
+  Verified by `vw_threshold_increase_only_affects_new_proposals`,
+  `vw_threshold_decrease_does_not_weaken_existing_snapshot`, and
+  `vw_threshold_decrease_does_not_lower_snapshot_bar` (which also
+  asserts that `execute_proposal` blocks when only the live threshold
+  would let it through).
+
+### 4.2 Defence in depth
+
+* The pre-existing `is_owner` check is preserved alongside the
+  snapshot check. The snapshot check is a *member* filter, not a
+  replacement; the historical ownership check remains the outer
+  permission gate.
+* The `VoteWeightSnapshot` struct's `owners: Vec<Address>` is a soroban
+  `Vec`, so storage-shape regression from `null`/missing owner
+  vectors would surface in storage validation, not in silent
+  incorrect behaviour.
+
+### 4.3 Storage / gas
+
+* The snapshot is stored under instance storage together with the rest
+  of the proposal record. `create_proposal` writes the snapshot
+  *before* the Proposal struct so storage-format mismatches surface
+  before any other state reads.
+* `effective_threshold` and `get_approval_count` are O(approvers) and
+  O(owners), respectively; both are dominated by the constant-size
+  n=5–10 multisigs used in practice.
+
+### 4.4 Backward compatibility
+
+The graceful fallback path in `is_proposal_approved` /
+`get_approval_count` / `approve_proposal` keeps legacy proposals
+(on the same storage layout) working without a forced re-migration.
+Because **every newly created proposal** writes a fresh snapshot,
+existing proposals will gracefully fall out of the legacy path as
+they expire and are cleaned up by `cleanup_expired_proposals`.
+
+## 5. Test coverage
+
+| Test | Scenario |
+| --- | --- |
+| `vw_snapshot_captured_at_creation_matches_state` | Snapshot fields exactly match live multisig state at creation. |
+| `vw_snapshot_event_emitted_with_matching_fields` | The `vw_snap` event contains the snapshot's parameters with the right tag. |
+| `vw_flash_vote_attack_blocked_on_add_owner` | Newly added owners cannot approve pre-existing proposals. |
+| `vw_flash_vote_attacker_panics_with_snapshot_message` | Regression guard for the panic message. |
+| `vw_legitimate_in_snapshot_owner_can_still_approve_after_attack` | In-snapshot owners still work after a contemporaneous attack. |
+| `vw_threshold_increase_only_affects_new_proposals` | Mid-window raise leaves the in-flight proposal untouched. |
+| `vw_threshold_decrease_does_not_weaken_existing_snapshot` | Lowering does not squeak weakly-supported proposals through. |
+| `vw_threshold_decrease_does_not_lower_snapshot_bar` | `execute_proposal` blocks even when only the live threshold would let it through. |
+| `vw_owner_removed_mid_window_cannot_approve_but_past_vote_counts` | Removed owners' pre-removal vote still counts. |
+| `vw_weight_change_to_zero_during_proposal_window_preserves_existing_vote` | Past approval is preserved when an owner's live weight falls to zero. |
+| `vw_snapshot_removed_on_cleanup` | Cleanup removes the snapshot alongside the proposal. |
+| `vw_snapshot_removed_for_all_cleaned_proposals` | Cleanup leaves no orphans. |
+| `vw_snapshot_only_removed_for_cleaned_proposals_in_partial_path` | Partial cleanup preserves survivors' snapshots. |
+| `vw_snapshot_action_tag_for_every_variant` | Exhaustive tag mapping for every `ProposalAction` variant. |
+| `vw_removed_owner_approval_still_counts_in_snapshot_tally` | Snapshot-aware tally preserves pre-removal votes. |
+
+Combined with the existing multisig / multisig-e2e suite, every code
+path of the snapshot machinery (`capture`, `enforce`, `tally`,
+`cleanup`, `event emit`, `legacy fallback`) is exercised.
+
+## 6. Operational guidance
+
+* **No action required from existing admins.** The change is purely
+  defensive; legacy proposals settle through the existing
+  `cleanup_expired_proposals` grace period.
+* **Indexers should subscribe to `vw_snap` events** to reconstruct the
+  historical eligibility rules per proposal without state-read
+  fan-out. The `action_tag` field can drive a tag-keyed index for
+  per-action-type analysis.
+* **Off-chain governance dashboards should display the snapshot
+  parameters** alongside live quorum settings. Without this, an
+  analyst cannot tell why a given proposal is approved (or stuck)
+  mid-window.
+
+## 7. Future work
+
+* Replace the implicit 1-owner-1-vote (`total_weight = owners.len()`)
+  with an explicit per-owner weight eventually, derived from a
+  stake-weighted governance token. The `total_weight: u32` field is
+  already in place for that future migration.
+* Consider emitting a `VoteWeightSnapshotFulfilled` event when the
+  proposal is finalized (executed or expired) so indexers can clean
+  up the snapshot bootstrap.


### PR DESCRIPTION
## Summary

Adds an immutable **vote-weight snapshot** captured atomically at `create_proposal` time so that subsequent `AddOwner`, `RemoveOwner`, `ChangeThreshold`, and role-grant actions **cannot** alter how an in-flight proposal is tallied. This closes the flash-vote attack surface on the multisig governance path — an attacker can no longer briefly acquire owner weight to swing a pending proposal.

Closes #512.

## Why

Until this change, a malicious actor could:

1. Observe a pending proposal they want to swing.
2. Submit a (legitimately approvable) `AddOwner(attacker)` proposal, wait for it to execute.
3. Approve the target proposal — their approval counts toward the live threshold.
4. Submit a `RemoveOwner(attacker)` proposal, wait for it to execute.
5. Erase their trace; the target proposal sails through.

A similar shape applied to mid-window `ChangeThreshold` proposals (raise or lower).

## What changes

| File | Change |
| --- | --- |
| `contracts/attestation/src/multisig.rs` | New `VoteWeightSnapshot` struct; `MultisigKey::VoteWeightSnapshot(u64)` storage; snapshot captured at `create_proposal`; snapshot-aware gate in `approve_proposal`; snapshot-aware tally in `is_proposal_approved`/`get_approval_count`; snapshot removed by `cleanup_expired_proposals`; grace-period fallback for legacy proposals without a snapshot. |
| `contracts/attestation/src/events.rs` | New `vw_snap` topic + `VoteWeightSnapshotCreatedEvent` + emitter for off-chain indexer audit trail. |
| `contracts/attestation/src/lib.rs` | Exports `VoteWeightSnapshot`, exposes `get_proposal_snapshot` and `get_proposal_approvals` view methods. |
| `contracts/attestation/src/vote_weight_snapshot_test.rs` | New test file covering capture, flash-vote defence (with helper-driven `AddOwner` mid-window simulation), threshold-raise / threshold-lower / weight-zero edge cases, partial-cleanup orphans, action-tag mappings, and a `#[should_panic]` regression guard locking the security message. |
| `contracts/attestation/src/multisig_e2e_test.rs` | E2E remove-owner-mid-window test renamed (`preserves_snapshot_vote`) and reworked to reflect strict-snapshot semantics. Threshold-bump test annotated. |
| `docs/attestation-vote-weight-snapshot.md` | Threat model, design, security notes, test coverage, operational guidance. |

## Behavioural guarantees

* **Approval gate** — only addresses present in the proposal snapshot (== owners at creation time) may approve; reuses the historical `is_owner` check as defence-in-depth.
* **Tally** — `is_proposal_approved` / `get_approval_count` use the snapshot threshold and filter the approvals to snapshot members, so non-snapshot approvals never count.
* **Cleanup** — `cleanup_expired_proposals` removes the snapshot in lock-step with the proposal (verified for both the full and partial-cleanup paths).
* **Backward compat** — when no snapshot is stored (legacy proposals only), behaviour falls back to the historical `Approvals.len() >= Threshold` and `is_owner`-only check, so live proposals settle cleanly through the existing grace window without abrupt rejection.

## Security notes

* The snapshot is written **before** the proposal in the same Soroban transaction; both writes are atomic.
* Snapshot reads are immutable — no code path mutates an existing `VoteWeightSnapshot` once written.
* The `vw_snap` event payload duplicates a subset of fields from the stored snapshot for indexer convenience; the source-of-truth remains the on-chain snapshot.
* A flash-vote attacker cannot pre-compute or grief the snapshot: `create_proposal` is the only entry point that writes it, and per-owner replay nonces on `CHANNEL_MULTISIG` already prevent replay of proposals.

## Tests

* All snapshot code paths are covered: capture, gate, tally, cleanup, event emit, legacy fallback.
* Defence-in-depth regression guard: `vw_flash_vote_attacker_panics_with_snapshot_message` locks the panic substring into CI.
* Updated `e2e_remove_owner_mid_proposal_preserves_snapshot_vote` exercises the new semantics end-to-end.

## Related

closes #512