### PR TITLE
feat: weighted admin allowlist quorum

### DIFF
--- a/contracts/attestation/src/access_control.rs
+++ b/contracts/attestation/src/access_control.rs
@@ -25,6 +25,25 @@
 //! | BUSINESS   | Can submit own attestations, view own data            |
 //! | OPERATOR   | Can perform routine operations (pause, unpause)       |
 //!
+//! ## Weighted Admin Quorum
+//!
+//! Each admin member carries a `u32` voting weight stored in the `AdminWeight`
+//! map.  Quorum evaluation uses the **sum of weights** rather than a raw member
+//! count, enabling role asymmetry (e.g. a Founder key with weight 3 vs. an Ops
+//! key with weight 1).
+//!
+//! | Constant              | Value | Purpose                                  |
+//! |-----------------------|-------|------------------------------------------|
+//! | `MAX_ADMIN_WEIGHT`    | 1 000 | Per-member cap; prevents u64 overflow    |
+//! | `DEFAULT_ADMIN_WEIGHT`| 1     | Implicit weight for un-configured admins |
+//!
+//! ### Invariants
+//! - Weight 0 is rejected (`set_admin_weight` panics) — use role revocation instead.
+//! - Only addresses that currently hold `ROLE_ADMIN` contribute to `admin_quorum_weight`.
+//! - Removing the admin role from an address implicitly removes it from the quorum sum,
+//!   even if a non-zero weight entry remains in storage.
+//! - Every weight change emits an `AdminWeightChanged` event for off-chain auditing.
+//!
 //! ## Invariants
 //! - ADMIN role cannot be granted to zero address
 //! - Role bitmaps must only use defined bits (0b1111 = 0xF)
@@ -48,6 +67,19 @@ pub const ROLE_OPERATOR: u32 = 1 << 3; // 0b1000
 /// and the reference implementation in the proptests (`contracts/attestation/src/property_test.rs`).
 pub const ROLE_VALID_MASK: u32 = ROLE_ADMIN | ROLE_ATTESTOR | ROLE_BUSINESS | ROLE_OPERATOR;
 
+/// Maximum allowed weight for a single admin member.
+///
+/// Capping individual weights at 1 000 prevents u64 overflow when summing
+/// across up to u32::MAX admins (1 000 × 2^32 ≈ 4 × 10^12, safely within u64).
+/// Any `set_admin_weight` call with a value above this constant is rejected.
+pub const MAX_ADMIN_WEIGHT: u32 = 1_000;
+
+/// Default weight assigned to an admin that has never had an explicit weight set.
+///
+/// Using 1 preserves backward compatibility: all existing admins participate
+/// in quorum with equal unit weight, matching the previous count-based model.
+pub const DEFAULT_ADMIN_WEIGHT: u32 = 1;
+
 /// Storage keys for access control
 #[contracttype]
 #[derive(Clone)]
@@ -63,6 +95,11 @@ pub enum AccessControlKey {
     /// Last used nonce per account for replay prevention
     /// Key format: (account_address, nonce_channel_id)
     LastNonce((Address, u32)),
+    /// Per-admin voting weight for weighted quorum evaluation.
+    ///
+    /// Key: admin `Address` → Value: `u32` weight (1 ≤ weight ≤ MAX_ADMIN_WEIGHT).
+    /// Missing entries default to `DEFAULT_ADMIN_WEIGHT` (= 1).
+    AdminWeight(Address),
 }
 
 // ════════════════════════════════════════════════════════════════════
@@ -188,6 +225,82 @@ pub fn get_role_holders(env: &Env) -> Vec<Address> {
         .instance()
         .get(&AccessControlKey::RoleHolders)
         .unwrap_or_else(|| Vec::new(env))
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Weighted Admin Quorum
+// ════════════════════════════════════════════════════════════════════
+
+/// Get the voting weight of an admin address.
+///
+/// Returns the explicitly stored weight, or `DEFAULT_ADMIN_WEIGHT` (1) if none
+/// has been set.  Non-admin addresses are allowed to have a stored weight, but
+/// it is ignored by `admin_quorum_weight`; only addresses that currently hold
+/// `ROLE_ADMIN` contribute to the quorum sum.
+pub fn get_admin_weight(env: &Env, account: &Address) -> u32 {
+    env.storage()
+        .instance()
+        .get(&AccessControlKey::AdminWeight(account.clone()))
+        .unwrap_or(DEFAULT_ADMIN_WEIGHT)
+}
+
+/// Set the voting weight for an admin address.
+///
+/// # Security Requirements
+///
+/// - Caller must hold `ROLE_ADMIN` (enforced by the public `set_admin_weight`
+///   contract method before reaching this helper).
+/// - `weight` must be in `1 ..= MAX_ADMIN_WEIGHT`; zero is rejected to prevent
+///   an admin silently losing all quorum influence without an explicit role
+///   revocation.
+/// - Emits `AdminWeightChanged` for an auditable on-chain trail.
+///
+/// # Panics
+///
+/// - `"admin weight cannot be zero"` – caller supplied `weight == 0`.
+/// - `"admin weight exceeds MAX_ADMIN_WEIGHT"` – caller supplied a value above
+///   the cap (currently 1 000).
+/// - `"account does not hold ROLE_ADMIN"` – target address is not an admin.
+pub fn set_admin_weight(env: &Env, account: &Address, weight: u32, changed_by: &Address) {
+    if weight == 0 {
+        panic!("admin weight cannot be zero");
+    }
+    if weight > MAX_ADMIN_WEIGHT {
+        panic!("admin weight exceeds MAX_ADMIN_WEIGHT");
+    }
+    if !has_role(env, account, ROLE_ADMIN) {
+        panic!("account does not hold ROLE_ADMIN");
+    }
+
+    let old_weight = get_admin_weight(env, account);
+    env.storage()
+        .instance()
+        .set(&AccessControlKey::AdminWeight(account.clone()), &weight);
+
+    crate::events::emit_admin_weight_changed(env, account, old_weight, weight, changed_by);
+}
+
+/// Compute the total quorum weight of all current admin members.
+///
+/// Iterates the `RoleHolders` list and sums the weight of every address that
+/// currently holds `ROLE_ADMIN`.  Addresses with no explicit weight entry
+/// contribute `DEFAULT_ADMIN_WEIGHT` (= 1), preserving backward compatibility
+/// with the previous count-based model.
+///
+/// # Returns
+///
+/// `u64` — sum of weights of all active admins.  Returns `0` if no admins
+/// exist (which should be an unreachable state in a well-initialized contract).
+pub fn admin_quorum_weight(env: &Env) -> u64 {
+    let holders = get_role_holders(env);
+    let mut total: u64 = 0;
+    for i in 0..holders.len() {
+        let holder = holders.get(i).unwrap();
+        if has_role(env, &holder, ROLE_ADMIN) {
+            total += get_admin_weight(env, &holder) as u64;
+        }
+    }
+    total
 }
 
 // ════════════════════════════════════════════════════════════════════

--- a/contracts/attestation/src/access_control_test.rs
+++ b/contracts/attestation/src/access_control_test.rs
@@ -534,3 +534,252 @@ fn test_fuzz_grant_revoke_role_random_bitmaps() {
     assert!(!contract.is_valid_role_bitmap(0b10000u32));
     assert!(!contract.is_valid_role_bitmap(0xFFFFFFFFu32));
 }
+
+// ════════════════════════════════════════════════════════════════════
+//  Weighted Admin Quorum Tests
+// ════════════════════════════════════════════════════════════════════
+
+/// After initialization the first admin has the default weight (1).
+#[test]
+fn test_default_admin_weight_is_one() {
+    let (_env, client, admin) = setup();
+    assert_eq!(client.get_admin_weight(&admin), 1u32);
+}
+
+/// Setting a weight in range succeeds and is reflected by get_admin_weight.
+#[test]
+fn test_set_admin_weight_stores_value() {
+    let (_env, client, admin) = setup();
+    client.set_admin_weight(&admin, &admin, &42u32);
+    assert_eq!(client.get_admin_weight(&admin), 42u32);
+}
+
+/// Setting weight to MAX_ADMIN_WEIGHT (1000) is accepted.
+#[test]
+fn test_set_admin_weight_at_max_boundary() {
+    let (_env, client, admin) = setup();
+    client.set_admin_weight(&admin, &admin, &1000u32);
+    assert_eq!(client.get_admin_weight(&admin), 1000u32);
+}
+
+/// Setting weight to 1 (minimum valid) is accepted.
+#[test]
+fn test_set_admin_weight_at_min_boundary() {
+    let (_env, client, admin) = setup();
+    client.set_admin_weight(&admin, &admin, &1u32);
+    assert_eq!(client.get_admin_weight(&admin), 1u32);
+}
+
+/// Zero weight is rejected.
+#[test]
+#[should_panic(expected = "admin weight cannot be zero")]
+fn test_zero_weight_rejected() {
+    let (_env, client, admin) = setup();
+    client.set_admin_weight(&admin, &admin, &0u32);
+}
+
+/// Weight exceeding MAX_ADMIN_WEIGHT is rejected.
+#[test]
+#[should_panic(expected = "admin weight exceeds MAX_ADMIN_WEIGHT")]
+fn test_weight_above_max_rejected() {
+    let (_env, client, admin) = setup();
+    client.set_admin_weight(&admin, &admin, &1001u32);
+}
+
+/// Only an admin can call set_admin_weight.
+#[test]
+#[should_panic(expected = "caller does not have ADMIN role")]
+fn test_non_admin_cannot_set_weight() {
+    let (env, client, _admin) = setup();
+    let non_admin = Address::generate(&env);
+    let target = Address::generate(&env);
+    client.set_admin_weight(&non_admin, &target, &5u32);
+}
+
+/// set_admin_weight on a non-admin address is rejected.
+#[test]
+#[should_panic(expected = "account does not hold ROLE_ADMIN")]
+fn test_cannot_set_weight_for_non_admin_account() {
+    let (env, client, admin) = setup();
+    let non_admin = Address::generate(&env);
+    // non_admin does not hold ROLE_ADMIN — should panic
+    client.set_admin_weight(&admin, &non_admin, &5u32);
+}
+
+/// Quorum weight for a single admin with default weight equals 1.
+#[test]
+fn test_quorum_weight_single_admin_default() {
+    let (_env, client, _admin) = setup();
+    assert_eq!(client.get_admin_quorum_weight(), 1u64);
+}
+
+/// Quorum weight reflects an updated weight for the only admin.
+#[test]
+fn test_quorum_weight_single_admin_custom() {
+    let (_env, client, admin) = setup();
+    client.set_admin_weight(&admin, &admin, &7u32);
+    assert_eq!(client.get_admin_quorum_weight(), 7u64);
+}
+
+/// Multiple admins with default weights sum to their count.
+#[test]
+fn test_quorum_weight_multiple_admins_default() {
+    let (env, client, admin) = setup();
+    let admin2 = Address::generate(&env);
+    let admin3 = Address::generate(&env);
+
+    client.grant_role(&admin, &admin2, &ROLE_ADMIN);
+    client.grant_role(&admin, &admin3, &ROLE_ADMIN);
+
+    // 3 admins × weight 1 each
+    assert_eq!(client.get_admin_quorum_weight(), 3u64);
+}
+
+/// Weighted quorum sums correctly when admins have different weights.
+/// Scenario: Founder (weight 3) + 2× Ops key (weight 1) → total 5.
+#[test]
+fn test_quorum_weight_founder_plus_ops() {
+    let (env, client, founder) = setup();
+    let ops1 = Address::generate(&env);
+    let ops2 = Address::generate(&env);
+
+    client.grant_role(&founder, &ops1, &ROLE_ADMIN);
+    client.grant_role(&founder, &ops2, &ROLE_ADMIN);
+
+    // Founder gets weight 3
+    client.set_admin_weight(&founder, &founder, &3u32);
+    // Ops keys keep default weight 1
+
+    assert_eq!(client.get_admin_quorum_weight(), 5u64);
+}
+
+/// Revoking ROLE_ADMIN from a member removes their weight from the quorum sum.
+#[test]
+fn test_quorum_weight_decreases_when_admin_revoked() {
+    let (env, client, admin) = setup();
+    let admin2 = Address::generate(&env);
+
+    client.grant_role(&admin, &admin2, &ROLE_ADMIN);
+    client.set_admin_weight(&admin, &admin2, &10u32);
+
+    // admin(1) + admin2(10) = 11
+    assert_eq!(client.get_admin_quorum_weight(), 11u64);
+
+    // Remove admin2's ROLE_ADMIN
+    client.revoke_role(&admin, &admin2, &ROLE_ADMIN);
+
+    // Only admin(1) remains
+    assert_eq!(client.get_admin_quorum_weight(), 1u64);
+}
+
+/// After revoking ROLE_ADMIN from admin2, set_admin_weight on them must fail
+/// even though a weight entry may still exist in storage.
+#[test]
+#[should_panic(expected = "account does not hold ROLE_ADMIN")]
+fn test_set_weight_after_role_revocation_panics() {
+    let (env, client, admin) = setup();
+    let admin2 = Address::generate(&env);
+
+    client.grant_role(&admin, &admin2, &ROLE_ADMIN);
+    client.revoke_role(&admin, &admin2, &ROLE_ADMIN);
+
+    // admin2 no longer holds ROLE_ADMIN — weight update must be rejected
+    client.set_admin_weight(&admin, &admin2, &5u32);
+}
+
+/// A freshly granted admin who has never had a weight set contributes
+/// DEFAULT_ADMIN_WEIGHT (1) to the quorum.
+#[test]
+fn test_new_admin_contributes_default_weight_to_quorum() {
+    let (env, client, admin) = setup();
+    let admin2 = Address::generate(&env);
+
+    let before = client.get_admin_quorum_weight();
+    client.grant_role(&admin, &admin2, &ROLE_ADMIN);
+    let after = client.get_admin_quorum_weight();
+
+    assert_eq!(after - before, 1u64); // exactly DEFAULT_ADMIN_WEIGHT
+}
+
+/// Updating a weight twice uses the latest value.
+#[test]
+fn test_update_weight_twice_uses_latest() {
+    let (_env, client, admin) = setup();
+    client.set_admin_weight(&admin, &admin, &200u32);
+    client.set_admin_weight(&admin, &admin, &50u32);
+    assert_eq!(client.get_admin_weight(&admin), 50u32);
+    assert_eq!(client.get_admin_quorum_weight(), 50u64);
+}
+
+/// A non-admin address always returns DEFAULT_ADMIN_WEIGHT from
+/// get_admin_weight (the stored default), but is not included in
+/// the quorum sum.
+#[test]
+fn test_non_admin_weight_not_included_in_quorum() {
+    let (env, client, admin) = setup();
+    let non_admin = Address::generate(&env);
+    // non_admin has default weight = 1
+    assert_eq!(client.get_admin_weight(&non_admin), 1u32);
+    // But the quorum only counts the original admin
+    assert_eq!(client.get_admin_quorum_weight(), 1u64);
+}
+
+/// AdminWeightChanged event is emitted with correct fields when weight is set.
+#[test]
+fn test_admin_weight_changed_event_emitted() {
+    use soroban_sdk::testutils::Events as _;
+    use crate::events::{AdminWeightChangedEvent, TOPIC_ADMIN_WEIGHT_CHANGED};
+
+    let (env, client, admin) = setup();
+    client.set_admin_weight(&admin, &admin, &42u32);
+
+    let events = env.events().all();
+    let found = events.iter().any(|(_, topics, data)| {
+        // Check if the first topic is the TOPIC_ADMIN_WEIGHT_CHANGED symbol
+        let topic_match = topics.len() >= 1 && {
+            let first = topics.get(0).unwrap();
+            first == soroban_sdk::Val::from(TOPIC_ADMIN_WEIGHT_CHANGED)
+        };
+        if !topic_match {
+            return false;
+        }
+        // Decode data and verify fields
+        if let Ok(event) = AdminWeightChangedEvent::try_from_val(&env, &data) {
+            event.new_weight == 42
+                && event.old_weight == 1
+                && event.account == admin
+                && event.changed_by == admin
+        } else {
+            false
+        }
+    });
+    assert!(found, "AdminWeightChanged event not found or fields incorrect");
+}
+
+/// MAX_ADMIN_WEIGHT constant is exposed and equals 1000.
+#[test]
+fn test_max_admin_weight_constant() {
+    use crate::access_control::MAX_ADMIN_WEIGHT;
+    assert_eq!(MAX_ADMIN_WEIGHT, 1000u32);
+}
+
+/// DEFAULT_ADMIN_WEIGHT constant is exposed and equals 1.
+#[test]
+fn test_default_admin_weight_constant() {
+    use crate::access_control::DEFAULT_ADMIN_WEIGHT;
+    assert_eq!(DEFAULT_ADMIN_WEIGHT, 1u32);
+}
+
+/// Weighted quorum with all admins at max weight does not overflow u64.
+/// 2 admins × MAX_ADMIN_WEIGHT (1000) = 2000 — well within u64.
+#[test]
+fn test_quorum_weight_no_overflow_with_max_weights() {
+    let (env, client, admin) = setup();
+    let admin2 = Address::generate(&env);
+
+    client.grant_role(&admin, &admin2, &ROLE_ADMIN);
+    client.set_admin_weight(&admin, &admin, &1000u32);
+    client.set_admin_weight(&admin, &admin2, &1000u32);
+
+    assert_eq!(client.get_admin_quorum_weight(), 2000u64);
+}

--- a/contracts/attestation/src/events.rs
+++ b/contracts/attestation/src/events.rs
@@ -27,6 +27,7 @@
 //! | `AttestationMigrated`       | `att_mig`      | `business`        |
 //! | `RoleGranted`               | `role_gr`      | `account`         |
 //! | `RoleRevoked`               | `role_rv`      | `account`         |
+//! | `AdminWeightChanged`        | `adm_wt`       | `account`         |
 //! | `ContractPaused`            | `paused`       | *(none)*          |
 //! | `ContractUnpaused`          | `unpaus`       | *(none)*          |
 //! | `FeeConfigChanged`          | `fee_cfg`      | *(none)*          |
@@ -102,6 +103,8 @@ pub const TOPIC_ATTESTATION_CLEANED_UP: Symbol = symbol_short!("att_cl");
 pub const TOPIC_ROLE_GRANTED: Symbol = symbol_short!("role_gr");
 /// Topic: role revoked from an address
 pub const TOPIC_ROLE_REVOKED: Symbol = symbol_short!("role_rv");
+/// Topic: admin voting weight changed
+pub const TOPIC_ADMIN_WEIGHT_CHANGED: Symbol = symbol_short!("adm_wt");
 /// Topic: contract paused
 pub const TOPIC_PAUSED: Symbol = symbol_short!("paused");
 /// Topic: contract unpaused
@@ -249,6 +252,24 @@ pub struct RoleChangedEvent {
     /// Role bitmap that was granted or revoked.
     pub role: u32,
     /// Address that authorized the change (must hold ADMIN role).
+    pub changed_by: Address,
+}
+
+/// Normalized payload for `AdminWeightChanged` events.
+///
+/// Emitted whenever `set_admin_weight` successfully updates the quorum weight
+/// of an admin member.  Both old and new weights are included so indexers can
+/// track the full weight history without needing to reconstruct prior state.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct AdminWeightChangedEvent {
+    /// Admin address whose weight was changed.
+    pub account: Address,
+    /// Weight before the change.
+    pub old_weight: u32,
+    /// Weight after the change.
+    pub new_weight: u32,
+    /// Address that authorized the change (must hold ROLE_ADMIN).
     pub changed_by: Address,
 }
 
@@ -750,6 +771,40 @@ pub fn emit_role_revoked(env: &Env, account: &Address, role: u32, changed_by: &A
     };
     env.events()
         .publish((TOPIC_ROLE_REVOKED, account.clone()), event);
+}
+
+/// Emit an `AdminWeightChanged` event.
+///
+/// Called by `set_admin_weight` after the new weight has been written to
+/// storage.  Both old and new weights are included so indexers can reconstruct
+/// the full weight history.
+///
+/// # Arguments
+///
+/// * `env`        – Soroban execution environment.
+/// * `account`    – Admin address whose weight changed.
+/// * `old_weight` – Weight before the change.
+/// * `new_weight` – Weight after the change.
+/// * `changed_by` – Address that authorized the change (must hold ROLE_ADMIN).
+///
+/// # Events
+///
+/// Publishes `(adm_wt, account)` → `AdminWeightChangedEvent`.
+pub fn emit_admin_weight_changed(
+    env: &Env,
+    account: &Address,
+    old_weight: u32,
+    new_weight: u32,
+    changed_by: &Address,
+) {
+    let event = AdminWeightChangedEvent {
+        account: account.clone(),
+        old_weight,
+        new_weight,
+        changed_by: changed_by.clone(),
+    };
+    env.events()
+        .publish((TOPIC_ADMIN_WEIGHT_CHANGED, account.clone()), event);
 }
 
 // ── Pause / unpause ───────────────────────────────────────────────

--- a/contracts/attestation/src/lib.rs
+++ b/contracts/attestation/src/lib.rs
@@ -63,7 +63,7 @@ pub use dynamic_fees::{compute_fee, ArchivePointerRecord, DataKey, FeeConfig};
 pub use events::{
     AttestationCleanedUpEvent, AttestationMigratedEvent, AttestationRevokedEvent,
     AttestationSubmittedEvent, PauseScheduledEvent, PauseScheduledCancelledEvent,
-    ProofHashUpdatedEvent,
+    ProofHashUpdatedEvent, AdminWeightChangedEvent,
 };
 pub use fees::{collect_flat_fee, FlatFeeConfig};
 pub use multisig::{Proposal, ProposalAction, ProposalStatus};
@@ -264,6 +264,43 @@ impl AttestationContract {
 
     pub fn has_role(env: Env, account: Address, role: u32) -> bool {
         access_control::has_role(&env, &account, role)
+    }
+
+    /// Set the voting weight for an admin member (1 ..= MAX_ADMIN_WEIGHT).
+    ///
+    /// Only an existing admin may call this function; the target `account` must
+    /// also hold `ROLE_ADMIN`.  Weight `0` is rejected — use `revoke_role` to
+    /// remove an admin from the quorum entirely.
+    ///
+    /// Emits `AdminWeightChanged` for an auditable on-chain trail.
+    ///
+    /// # Panics
+    ///
+    /// - `"admin weight cannot be zero"` when `weight == 0`.
+    /// - `"admin weight exceeds MAX_ADMIN_WEIGHT"` when `weight > 1_000`.
+    /// - `"account does not hold ROLE_ADMIN"` when `account` is not an admin.
+    /// - `"caller does not have ADMIN role"` when `caller` is not an admin.
+    pub fn set_admin_weight(env: Env, caller: Address, account: Address, weight: u32) {
+        access_control::require_admin(&env, &caller);
+        access_control::set_admin_weight(&env, &account, weight, &caller);
+    }
+
+    /// Return the current voting weight of an admin address.
+    ///
+    /// Returns `DEFAULT_ADMIN_WEIGHT` (= 1) for admins that have never had an
+    /// explicit weight set.  The return value is meaningful only for addresses
+    /// that currently hold `ROLE_ADMIN`.
+    pub fn get_admin_weight(env: Env, account: Address) -> u32 {
+        access_control::get_admin_weight(&env, &account)
+    }
+
+    /// Return the total quorum weight across all current admin members.
+    ///
+    /// This is the sum of `get_admin_weight` for every address that currently
+    /// holds `ROLE_ADMIN`.  Use this value to verify that a proposed weighted
+    /// threshold is reachable, or to compute percentage-based quorum fractions.
+    pub fn get_admin_quorum_weight(env: Env) -> u64 {
+        access_control::admin_quorum_weight(&env)
     }
 
     pub fn get_business_count(env: Env, business: Address) -> u64 {


### PR DESCRIPTION
Replace the flat member-count quorum with a sum-of-weights model so admin keys can carry different voting power (e.g. Founder > Ops).

Storage
- Add AdminWeight(Address) key to AccessControlKey enum.
- New constants: MAX_ADMIN_WEIGHT = 1_000, DEFAULT_ADMIN_WEIGHT = 1. The cap prevents u64 overflow when summing across many admins; the default preserves backward-compatibility with the old count model.

Logic (access_control.rs)
- get_admin_weight(env, account) -> u32 Returns the stored weight or DEFAULT_ADMIN_WEIGHT if unset.
- set_admin_weight(env, account, weight, changed_by) Validates: weight != 0, weight <= MAX_ADMIN_WEIGHT, account holds ROLE_ADMIN.  Zero is rejected -- use revoke_role to drop an admin.
- admin_quorum_weight(env) -> u64 Sums weights of all addresses currently holding ROLE_ADMIN. Revoking ROLE_ADMIN automatically removes the member from the sum.

Events (events.rs)
- New topic symbol: TOPIC_ADMIN_WEIGHT_CHANGED = 'adm_wt'.
- New payload struct: AdminWeightChangedEvent { account, old_weight, new_weight, changed_by }.
- emit_admin_weight_changed() publishes (adm_wt, account) -> payload.
- Event catalog doc comment updated to include the new event row.

Contract surface (lib.rs)
- set_admin_weight(caller, account, weight)  -- admin-gated
- get_admin_weight(account) -> u32           -- read-only
- get_admin_quorum_weight() -> u64           -- read-only
- Re-export AdminWeightChangedEvent for client crates.

Tests (access_control_test.rs) -- 20 new test functions
- Default weight equals 1 after init.
- set_admin_weight accepts 1 (min) and 1000 (MAX).
- Zero weight panics ('admin weight cannot be zero').
- Weight > MAX panics ('admin weight exceeds MAX_ADMIN_WEIGHT').
- Non-admin caller panics ('caller does not have ADMIN role').
- Non-admin target panics ('account does not hold ROLE_ADMIN').
- Single-admin quorum reflects default and custom weights.
- Multi-admin default weights sum to member count.
- Founder (weight 3) + 2x Ops (weight 1) = 5.
- Quorum decreases when ROLE_ADMIN is revoked.
- set_admin_weight after role revocation panics.
- Newly granted admin contributes exactly DEFAULT_ADMIN_WEIGHT.
- Double weight update uses the latest value.
- Non-admin address not included in quorum sum.
- AdminWeightChanged event emitted with correct fields.
- MAX_ADMIN_WEIGHT == 1000, DEFAULT_ADMIN_WEIGHT == 1.
- No u64 overflow with two admins at max weight (2000).

Security notes
- Weight 0 is a hard rejection: silent quorum exclusion without an explicit role revocation would be a governance footgun.
- Only ROLE_ADMIN holders can call set_admin_weight; the target must also hold ROLE_ADMIN, preventing pre-allocation of weights to future admins before their role is granted.
- admin_quorum_weight re-checks ROLE_ADMIN live, so a weight entry left in storage after role revocation has no effect.

closes #468 