### PR TITLE
feat: time-locked fee configuration

### DIFF
--- a/contracts/attestation/src/dynamic_fees.rs
+++ b/contracts/attestation/src/dynamic_fees.rs
@@ -65,6 +65,10 @@ pub const MAX_TIER: u32 = 9;
 /// When the ledger timestamp crosses a multiple of this window, the epoch advances.
 pub const FEE_BUCKET_WINDOW_SECONDS: u64 = 86400; // 24 * 60 * 60
 
+/// Minimum delay in seconds between proposing and committing a fee configuration change.
+/// Users must have at least this window to observe and react to pending fee changes.
+pub const FEE_TIMELOCK_SECONDS: u64 = 86400; // 24 hours
+
 
 // ════════════════════════════════════════════════════════════════════
 //  Storage types
@@ -92,6 +96,8 @@ pub enum DataKey {
     Admin,
     /// Core fee configuration (`FeeConfig`).
     FeeConfig,
+    /// Pending fee configuration with activation timestamp (`PendingFeeConfig`).
+    PendingFeeConfig,
     /// Discount in basis points for tier `u32`.
     TierDiscount(u32),
     /// Business-specific tier assignment.
@@ -162,6 +168,20 @@ pub struct FeeConfig {
     pub enabled: bool,
 }
 
+/// A pending fee configuration waiting for the timelock to expire.
+///
+/// Stored under [`DataKey::PendingFeeConfig`].
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct PendingFeeConfig {
+    /// The fee configuration to apply.
+    pub config: FeeConfig,
+    /// Ledger timestamp after which the configuration may be committed.
+    pub effective_at: u64,
+    /// Address that proposed this configuration change.
+    pub proposed_by: Address,
+}
+
 // ════════════════════════════════════════════════════════════════════
 //  Admin helpers
 // ════════════════════════════════════════════════════════════════════
@@ -206,6 +226,44 @@ pub fn set_fee_enabled(env: &Env, enabled: bool) {
         config.enabled = enabled;
         set_fee_config(env, &config);
     }
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Pending Fee Config (time-locked) helpers
+// ════════════════════════════════════════════════════════════════════
+
+/// Read the pending fee configuration, if any.
+pub fn get_pending_fee_config(env: &Env) -> Option<PendingFeeConfig> {
+    env.storage().instance().get(&DataKey::PendingFeeConfig)
+}
+
+/// Store a pending fee configuration.
+pub fn set_pending_fee_config(env: &Env, pending: &PendingFeeConfig) {
+    env.storage()
+        .instance()
+        .set(&DataKey::PendingFeeConfig, pending);
+}
+
+/// Remove any pending fee configuration.
+pub fn clear_pending_fee_config(env: &Env) {
+    env.storage()
+        .instance()
+        .remove(&DataKey::PendingFeeConfig);
+}
+
+/// If a pending fee config's timelock has expired, apply it to the live config
+/// and clear the pending state.
+///
+/// Returns `true` if a pending config was applied, `false` otherwise.
+pub fn check_and_apply_pending_fee_config(env: &Env) -> bool {
+    if let Some(pending) = get_pending_fee_config(env) {
+        if env.ledger().timestamp() >= pending.effective_at {
+            set_fee_config(env, &pending.config);
+            clear_pending_fee_config(env);
+            return true;
+        }
+    }
+    false
 }
 
 pub fn set_paused(env: &Env, paused: bool) {

--- a/contracts/attestation/src/events.rs
+++ b/contracts/attestation/src/events.rs
@@ -30,6 +30,8 @@
 //! | `ContractPaused`            | `paused`       | *(none)*          |
 //! | `ContractUnpaused`          | `unpaus`       | *(none)*          |
 //! | `FeeConfigChanged`          | `fee_cfg`      | *(none)*          |
+//! | `FeeConfigProposed`         | `fee_prop`     | *(none)*          |
+//! | `FeeConfigCommitted`        | `fee_com`      | *(none)*          |
 //! | `RateLimitConfigChanged`    | `rate_lm`      | *(none)*          |
 //! | `KeyRotationProposed`       | `kr_prop`      | *(none)*          |
 //! | `KeyRotationConfirmed`      | `kr_conf`      | *(none)*          |
@@ -108,6 +110,10 @@ pub const TOPIC_PAUSED: Symbol = symbol_short!("paused");
 pub const TOPIC_UNPAUSED: Symbol = symbol_short!("unpaus");
 /// Topic: fee configuration updated
 pub const TOPIC_FEE_CONFIG: Symbol = symbol_short!("fee_cfg");
+/// Topic: fee configuration proposed (time-locked)
+pub const TOPIC_FEE_CONFIG_PROPOSED: Symbol = symbol_short!("fee_prop");
+/// Topic: fee configuration committed after timelock
+pub const TOPIC_FEE_CONFIG_COMMITTED: Symbol = symbol_short!("fee_com");
 /// Topic: flat fee configuration updated
 pub const TOPIC_FLAT_FEE_CONFIG: Symbol = symbol_short!("ff_cfg");
 /// Topic: rate-limit configuration updated
@@ -312,6 +318,56 @@ pub struct FlatFeeConfigChangedEvent {
     pub enabled: bool,
     /// Address that made the configuration change.
     pub changed_by: Address,
+}
+
+/// Normalized payload for `FeeConfigProposed` events.
+///
+/// Emitted when a fee configuration change is proposed and enters the
+/// time-locked pending state.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct FeeConfigProposedEvent {
+    /// Proposed token contract for fee collection.
+    pub token: Address,
+    /// Proposed destination address for fee collection.
+    pub collector: Address,
+    /// Proposed base fee amount.
+    pub base_fee: i128,
+    /// Proposed enabled state.
+    pub enabled: bool,
+    /// Address that proposed the change.
+    pub proposed_by: Address,
+    /// Ledger timestamp after which the change may be committed.
+    pub effective_at: u64,
+}
+
+/// Normalized payload for `FeeConfigCommitted` events.
+///
+/// Emitted when a previously proposed fee configuration is applied
+/// after the timelock has expired.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct FeeConfigCommittedEvent {
+    /// Token contract now used for fee collection.
+    pub token: Address,
+    /// Destination address now receiving fees.
+    pub collector: Address,
+    /// Base fee amount now in effect.
+    pub base_fee: i128,
+    /// Whether fee collection is now enabled.
+    pub enabled: bool,
+    /// Address that committed the change.
+    pub committed_by: Address,
+}
+
+/// Normalized payload for `FeeConfigCancelled` events.
+///
+/// Emitted when a pending fee configuration proposal is cancelled.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct FeeConfigCancelledEvent {
+    /// Address that cancelled the proposal.
+    pub cancelled_by: Address,
 }
 
 // ── Rate limiting ─────────────────────────────────────────────────
@@ -862,6 +918,100 @@ pub fn emit_flat_fee_config_changed(
         changed_by: changed_by.clone(),
     };
     env.events().publish((TOPIC_FLAT_FEE_CONFIG,), event);
+}
+
+/// Emit a `FeeConfigProposed` event.
+///
+/// Call this after a fee configuration change has been stored in the
+/// pending state with its timelock timestamp.
+///
+/// # Arguments
+///
+/// * `env`         – Soroban execution environment.
+/// * `token`       – Proposed token contract.
+/// * `collector`   – Proposed destination address.
+/// * `base_fee`    – Proposed base fee amount.
+/// * `enabled`     – Proposed enabled state.
+/// * `proposed_by` – Address that proposed the change.
+/// * `effective_at` – Timestamp after which the change may be committed.
+///
+/// # Events
+///
+/// Publishes `(fee_prop,)` → `FeeConfigProposedEvent`.
+pub fn emit_fee_config_proposed(
+    env: &Env,
+    token: &Address,
+    collector: &Address,
+    base_fee: i128,
+    enabled: bool,
+    proposed_by: &Address,
+    effective_at: u64,
+) {
+    let event = FeeConfigProposedEvent {
+        token: token.clone(),
+        collector: collector.clone(),
+        base_fee,
+        enabled,
+        proposed_by: proposed_by.clone(),
+        effective_at,
+    };
+    env.events().publish((TOPIC_FEE_CONFIG_PROPOSED,), event);
+}
+
+/// Emit a `FeeConfigCommitted` event.
+///
+/// Call this after a previously proposed fee configuration has been
+/// applied following timelock expiry.
+///
+/// # Arguments
+///
+/// * `env`          – Soroban execution environment.
+/// * `token`        – Token contract now in effect.
+/// * `collector`    – Destination address now in effect.
+/// * `base_fee`     – Base fee now in effect.
+/// * `enabled`      – Enabled state now in effect.
+/// * `committed_by` – Address that committed the change.
+///
+/// # Events
+///
+/// Publishes `(fee_com,)` → `FeeConfigCommittedEvent`.
+pub fn emit_fee_config_committed(
+    env: &Env,
+    token: &Address,
+    collector: &Address,
+    base_fee: i128,
+    enabled: bool,
+    committed_by: &Address,
+) {
+    let event = FeeConfigCommittedEvent {
+        token: token.clone(),
+        collector: collector.clone(),
+        base_fee,
+        enabled,
+        committed_by: committed_by.clone(),
+    };
+    env.events().publish((TOPIC_FEE_CONFIG_COMMITTED,), event);
+}
+
+/// Emit a `FeeConfigCancelled` event.
+///
+/// Call this after a pending fee configuration proposal has been cancelled.
+///
+/// # Arguments
+///
+/// * `env`          – Soroban execution environment.
+/// * `cancelled_by` – Address that cancelled the proposal.
+///
+/// # Events
+///
+/// Publishes `(fee_cfg, )` → `FeeConfigCancelledEvent` is not used;
+/// instead this emits on the same `TOPIC_FEE_CONFIG` for consistency.
+pub fn emit_fee_config_cancelled(env: &Env, cancelled_by: &Address) {
+    let event = FeeConfigCancelledEvent {
+        cancelled_by: cancelled_by.clone(),
+    };
+    env.events()
+        .publish((TOPIC_FEE_CONFIG_PROPOSED, cancelled_by.clone()), event);
 }
 
 // ── Rate limiting ─────────────────────────────────────────────────

--- a/contracts/attestation/src/lib.rs
+++ b/contracts/attestation/src/lib.rs
@@ -59,7 +59,10 @@ pub use access_control::{ROLE_ADMIN, ROLE_ATTESTOR, ROLE_BUSINESS, ROLE_OPERATOR
 pub use dispute::{
     Dispute, DisputeOutcome, DisputeResolution, DisputeStatus, DisputeType, OptionalResolution,
 };
-pub use dynamic_fees::{compute_fee, ArchivePointerRecord, DataKey, FeeConfig};
+pub use dynamic_fees::{
+    compute_fee, ArchivePointerRecord, DataKey, FeeConfig, PendingFeeConfig,
+    FEE_TIMELOCK_SECONDS,
+};
 pub use events::{
     AttestationCleanedUpEvent, AttestationMigratedEvent, AttestationRevokedEvent,
     AttestationSubmittedEvent, PauseScheduledEvent, PauseScheduledCancelledEvent,
@@ -166,6 +169,106 @@ impl AttestationContract {
             config.enabled,
             &admin,
         );
+    }
+
+    /// Propose a fee configuration change that enters a time-locked pending state.
+    ///
+    /// The configuration will not take effect until `FEE_TIMELOCK_SECONDS` have
+    /// elapsed and `commit_fee_config` is called. Only one pending proposal may
+    /// exist at a time.
+    ///
+    /// # Panics
+    /// - Caller does not have ADMIN role
+    /// - `base_fee` is negative
+    /// - A pending fee config is already scheduled (cancel it first)
+    pub fn propose_fee_config(
+        env: Env,
+        caller: Address,
+        token: Address,
+        collector: Address,
+        base_fee: i128,
+        enabled: bool,
+        nonce: u64,
+    ) {
+        let admin = dynamic_fees::require_admin(&env);
+        replay_protection::verify_and_increment_nonce(&env, &admin, NONCE_CHANNEL_ADMIN, nonce);
+        assert!(base_fee >= 0, "base_fee must be non-negative");
+        assert!(
+            dynamic_fees::get_pending_fee_config(&env).is_none(),
+            "pending fee config already scheduled"
+        );
+        let effective_at = env.ledger().timestamp() + FEE_TIMELOCK_SECONDS;
+        let config = FeeConfig {
+            token,
+            collector,
+            base_fee,
+            enabled,
+        };
+        let pending = dynamic_fees::PendingFeeConfig {
+            config,
+            effective_at,
+            proposed_by: admin,
+        };
+        dynamic_fees::set_pending_fee_config(&env, &pending);
+        events::emit_fee_config_proposed(
+            &env,
+            &pending.config.token,
+            &pending.config.collector,
+            pending.config.base_fee,
+            pending.config.enabled,
+            &pending.proposed_by,
+            effective_at,
+        );
+    }
+
+    /// Commit a previously proposed fee configuration after its timelock has expired.
+    ///
+    /// Applies the pending configuration to the live fee config and clears the pending state.
+    ///
+    /// # Panics
+    /// - Caller does not have ADMIN role
+    /// - No pending fee config exists
+    /// - Timelock has not yet expired
+    pub fn commit_fee_config(env: Env, caller: Address, nonce: u64) {
+        let admin = dynamic_fees::require_admin(&env);
+        replay_protection::verify_and_increment_nonce(&env, &admin, NONCE_CHANNEL_ADMIN, nonce);
+        let pending = dynamic_fees::get_pending_fee_config(&env)
+            .expect("no pending fee config to commit");
+        assert!(
+            env.ledger().timestamp() >= pending.effective_at,
+            "timelock not yet expired"
+        );
+        dynamic_fees::set_fee_config(&env, &pending.config);
+        dynamic_fees::clear_pending_fee_config(&env);
+        events::emit_fee_config_committed(
+            &env,
+            &pending.config.token,
+            &pending.config.collector,
+            pending.config.base_fee,
+            pending.config.enabled,
+            &admin,
+        );
+    }
+
+    /// Cancel a previously proposed fee configuration change.
+    ///
+    /// # Panics
+    /// - Caller does not have ADMIN role
+    /// - No pending fee config exists
+    pub fn cancel_pending_fee_config(env: Env, caller: Address, nonce: u64) {
+        let admin = dynamic_fees::require_admin(&env);
+        replay_protection::verify_and_increment_nonce(&env, &admin, NONCE_CHANNEL_ADMIN, nonce);
+        assert!(
+            dynamic_fees::get_pending_fee_config(&env).is_some(),
+            "no pending fee config to cancel"
+        );
+        dynamic_fees::clear_pending_fee_config(&env);
+        events::emit_fee_config_cancelled(&env, &admin);
+    }
+
+    /// Returns the pending fee configuration, if any.
+    pub fn get_pending_fee_config(env: Env) -> Option<PendingFeeConfig> {
+        dynamic_fees::get_pending_fee_config(&env)
     }
 
     pub fn set_tier_discount(env: Env, tier: u32, discount_bps: u32) {
@@ -1994,6 +2097,8 @@ mod multisig_e2e_test;
 mod multisig_test;
 #[cfg(test)]
 mod pause_test;
+#[cfg(test)]
+mod timelock_fees_test;
 #[cfg(all(test, feature = "full-tests"))]
 mod proof_hash_test;
 #[cfg(all(test, feature = "full-tests"))]

--- a/contracts/attestation/src/timelock_fees_test.rs
+++ b/contracts/attestation/src/timelock_fees_test.rs
@@ -1,0 +1,486 @@
+//! # Time-Locked Fee Configuration Tests
+//!
+//! Tests for the propose → commit → apply fee configuration flow with
+//! mandatory timelock. Covers positive paths, edge cases, authorization
+//! failures, and event emission.
+
+use super::*;
+use crate::access_control::ROLE_ADMIN;
+use crate::dynamic_fees::FEE_TIMELOCK_SECONDS;
+use crate::events::{
+    FeeConfigCancelledEvent, FeeConfigCommittedEvent, FeeConfigProposedEvent,
+    TOPIC_FEE_CONFIG_COMMITTED, TOPIC_FEE_CONFIG_PROPOSED,
+};
+use soroban_sdk::testutils::{Address as _, Events as _, Ledger as _};
+use soroban_sdk::{Address, Env, Symbol, TryFromVal};
+
+/// Helper: register the contract and return `(env, client, admin)`.
+fn setup() -> (Env, AttestationContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AttestationContract, ());
+    let client = AttestationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &0u64);
+    (env, client, admin)
+}
+
+fn advance_time(env: &Env, seconds: u64) {
+    let now = env.ledger().timestamp();
+    env.ledger().set_timestamp(now + seconds);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Happy Path Tests
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_propose_and_commit_fee_config() {
+    let (env, client, admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.propose_fee_config(&admin, &token, &collector, &1_000i128, &true, &1u64);
+
+    // Config should NOT be live yet
+    assert!(client.get_fee_config().is_none());
+
+    // Advance past timelock
+    advance_time(&env, FEE_TIMELOCK_SECONDS + 1);
+
+    client.commit_fee_config(&admin, &2u64);
+
+    // Config should now be live
+    let config = client.get_fee_config().unwrap();
+    assert_eq!(config.token, token);
+    assert_eq!(config.collector, collector);
+    assert_eq!(config.base_fee, 1_000i128);
+    assert!(config.enabled);
+}
+
+#[test]
+fn test_propose_emits_fee_config_proposed_event() {
+    let (env, client, admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    let before_ts = env.ledger().timestamp();
+
+    client.propose_fee_config(&admin, &token, &collector, &500i128, &false, &1u64);
+
+    let expected_effective_at = before_ts + FEE_TIMELOCK_SECONDS;
+
+    let events = env.events().all();
+    let last = events.last().unwrap();
+    let topics = last.1.clone();
+
+    assert_eq!(topics.len(), 1);
+    assert_eq!(
+        Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap(),
+        TOPIC_FEE_CONFIG_PROPOSED
+    );
+
+    let ev = FeeConfigProposedEvent::try_from_val(&env, &last.2).unwrap();
+    assert_eq!(ev.token, token);
+    assert_eq!(ev.collector, collector);
+    assert_eq!(ev.base_fee, 500i128);
+    assert!(!ev.enabled);
+    assert_eq!(ev.proposed_by, admin);
+    assert_eq!(ev.effective_at, expected_effective_at);
+}
+
+#[test]
+fn test_commit_emits_fee_config_committed_event() {
+    let (env, client, admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.propose_fee_config(&admin, &token, &collector, &2_000i128, &true, &1u64);
+    advance_time(&env, FEE_TIMELOCK_SECONDS + 1);
+
+    client.commit_fee_config(&admin, &2u64);
+
+    let events = env.events().all();
+    let last = events.last().unwrap();
+    let topics = last.1.clone();
+
+    assert_eq!(topics.len(), 1);
+    assert_eq!(
+        Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap(),
+        TOPIC_FEE_CONFIG_COMMITTED
+    );
+
+    let ev = FeeConfigCommittedEvent::try_from_val(&env, &last.2).unwrap();
+    assert_eq!(ev.token, token);
+    assert_eq!(ev.collector, collector);
+    assert_eq!(ev.base_fee, 2_000i128);
+    assert!(ev.enabled);
+    assert_eq!(ev.committed_by, admin);
+}
+
+#[test]
+fn test_get_pending_fee_config_after_propose() {
+    let (env, client, admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    assert!(client.get_pending_fee_config().is_none());
+
+    client.propose_fee_config(&admin, &token, &collector, &750i128, &true, &1u64);
+
+    let pending = client.get_pending_fee_config().unwrap();
+    assert_eq!(pending.config.token, token);
+    assert_eq!(pending.config.collector, collector);
+    assert_eq!(pending.config.base_fee, 750i128);
+    assert!(pending.config.enabled);
+    assert_eq!(pending.proposed_by, admin);
+}
+
+#[test]
+fn test_get_pending_fee_config_none_after_commit() {
+    let (env, client, admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.propose_fee_config(&admin, &token, &collector, &100i128, &true, &1u64);
+    advance_time(&env, FEE_TIMELOCK_SECONDS + 1);
+    client.commit_fee_config(&admin, &2u64);
+
+    assert!(client.get_pending_fee_config().is_none());
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Cancel Tests
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_cancel_pending_fee_config() {
+    let (env, client, admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.propose_fee_config(&admin, &token, &collector, &300i128, &true, &1u64);
+    assert!(client.get_pending_fee_config().is_some());
+
+    client.cancel_pending_fee_config(&admin, &2u64);
+
+    assert!(client.get_pending_fee_config().is_none());
+    // Live config should still be unaffected
+    assert!(client.get_fee_config().is_none());
+}
+
+#[test]
+fn test_cancel_emits_fee_config_cancelled_event() {
+    let (env, client, admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.propose_fee_config(&admin, &token, &collector, &100i128, &true, &1u64);
+
+    let events_before = env.events().all().len();
+
+    client.cancel_pending_fee_config(&admin, &2u64);
+
+    let all_events = env.events().all();
+    assert!(all_events.len() > events_before);
+}
+
+#[test]
+#[should_panic(expected = "no pending fee config to cancel")]
+fn test_cancel_with_no_pending_panics() {
+    let (_env, client, admin) = setup();
+
+    client.cancel_pending_fee_config(&admin, &1u64);
+}
+
+#[test]
+fn test_can_propose_after_cancel() {
+    let (env, client, admin) = setup();
+    let token_a = Address::generate(&env);
+    let collector_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+    let collector_b = Address::generate(&env);
+
+    client.propose_fee_config(&admin, &token_a, &collector_a, &100i128, &true, &1u64);
+    client.cancel_pending_fee_config(&admin, &2u64);
+
+    // Should be able to propose a new config
+    client.propose_fee_config(&admin, &token_b, &collector_b, &200i128, &false, &3u64);
+
+    let pending = client.get_pending_fee_config().unwrap();
+    assert_eq!(pending.config.token, token_b);
+    assert_eq!(pending.config.base_fee, 200i128);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Timelock Enforcement Tests
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+#[should_panic(expected = "timelock not yet expired")]
+fn test_commit_before_timelock_panics() {
+    let (env, client, admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.propose_fee_config(&admin, &token, &collector, &1_000i128, &true, &1u64);
+
+    // Advance but NOT past timelock
+    advance_time(&env, FEE_TIMELOCK_SECONDS / 2);
+
+    client.commit_fee_config(&admin, &2u64);
+}
+
+#[test]
+#[should_panic(expected = "timelock not yet expired")]
+fn test_commit_one_second_before_timelock_panics() {
+    let (env, client, admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.propose_fee_config(&admin, &token, &collector, &1_000i128, &true, &1u64);
+
+    // Advance to exactly 1 second before timelock
+    advance_time(&env, FEE_TIMELOCK_SECONDS - 1);
+
+    client.commit_fee_config(&admin, &2u64);
+}
+
+#[test]
+fn test_commit_at_exact_timelock_succeeds() {
+    let (env, client, admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.propose_fee_config(&admin, &token, &collector, &1_000i128, &true, &1u64);
+
+    // Advance to exactly the timelock boundary
+    advance_time(&env, FEE_TIMELOCK_SECONDS);
+
+    client.commit_fee_config(&admin, &2u64);
+
+    let config = client.get_fee_config().unwrap();
+    assert_eq!(config.base_fee, 1_000i128);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  No Double Proposal
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+#[should_panic(expected = "pending fee config already scheduled")]
+fn test_propose_twice_without_cancel_panics() {
+    let (env, client, admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.propose_fee_config(&admin, &token, &collector, &100i128, &true, &1u64);
+    client.propose_fee_config(&admin, &token, &collector, &200i128, &true, &2u64);
+}
+
+#[test]
+fn test_can_propose_after_commit() {
+    let (env, client, admin) = setup();
+    let token_a = Address::generate(&env);
+    let collector_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+    let collector_b = Address::generate(&env);
+
+    client.propose_fee_config(&admin, &token_a, &collector_a, &100i128, &true, &1u64);
+    advance_time(&env, FEE_TIMELOCK_SECONDS + 1);
+    client.commit_fee_config(&admin, &2u64);
+
+    // Should be able to propose again after commit
+    client.propose_fee_config(&admin, &token_b, &collector_b, &200i128, &false, &3u64);
+
+    let pending = client.get_pending_fee_config().unwrap();
+    assert_eq!(pending.config.base_fee, 200i128);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Authorization Tests
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+#[should_panic(expected = "caller does not have ADMIN role")]
+fn test_non_admin_cannot_propose() {
+    let (env, client, _admin) = setup();
+    let non_admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.propose_fee_config(&non_admin, &token, &collector, &100i128, &true, &0u64);
+}
+
+#[test]
+#[should_panic(expected = "caller does not have ADMIN role")]
+fn test_non_admin_cannot_commit() {
+    let (env, client, admin) = setup();
+    let non_admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.propose_fee_config(&admin, &token, &collector, &100i128, &true, &1u64);
+    advance_time(&env, FEE_TIMELOCK_SECONDS + 1);
+
+    client.commit_fee_config(&non_admin, &0u64);
+}
+
+#[test]
+#[should_panic(expected = "caller does not have ADMIN role")]
+fn test_non_admin_cannot_cancel() {
+    let (env, client, admin) = setup();
+    let non_admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.propose_fee_config(&admin, &token, &collector, &100i128, &true, &1u64);
+
+    client.cancel_pending_fee_config(&non_admin, &0u64);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Input Validation Tests
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+#[should_panic(expected = "base_fee must be non-negative")]
+fn test_propose_negative_base_fee_panics() {
+    let (env, client, admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.propose_fee_config(&admin, &token, &collector, &(-1i128), &true, &1u64);
+}
+
+#[test]
+fn test_propose_zero_base_fee_succeeds() {
+    let (env, client, admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.propose_fee_config(&admin, &token, &collector, &0i128, &false, &1u64);
+
+    let pending = client.get_pending_fee_config().unwrap();
+    assert_eq!(pending.config.base_fee, 0);
+    assert!(!pending.config.enabled);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Edge Cases
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_propose_does_not_affect_live_config() {
+    let (env, client, admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    // Set an existing live config
+    client.configure_fees(&token, &collector, &500i128, &true);
+    let before = client.get_fee_config().unwrap();
+    assert_eq!(before.base_fee, 500i128);
+
+    // Propose a different config
+    let token2 = Address::generate(&env);
+    let collector2 = Address::generate(&env);
+    client.propose_fee_config(&admin, &token2, &collector2, &999i128, &false, &1u64);
+
+    // Live config must be unchanged
+    let after = client.get_fee_config().unwrap();
+    assert_eq!(after.base_fee, 500i128);
+    assert!(after.enabled);
+}
+
+#[test]
+fn test_commit_overwrites_live_config() {
+    let (env, client, admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.configure_fees(&token, &collector, &500i128, &true);
+
+    let token2 = Address::generate(&env);
+    let collector2 = Address::generate(&env);
+    client.propose_fee_config(&admin, &token2, &collector2, &999i128, &false, &1u64);
+    advance_time(&env, FEE_TIMELOCK_SECONDS + 1);
+    client.commit_fee_config(&admin, &2u64);
+
+    let config = client.get_fee_config().unwrap();
+    assert_eq!(config.token, token2);
+    assert_eq!(config.collector, collector2);
+    assert_eq!(config.base_fee, 999i128);
+    assert!(!config.enabled);
+}
+
+#[test]
+fn test_cancel_does_not_affect_live_config() {
+    let (env, client, admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.configure_fees(&token, &collector, &500i128, &true);
+
+    let token2 = Address::generate(&env);
+    let collector2 = Address::generate(&env);
+    client.propose_fee_config(&admin, &token2, &collector2, &999i128, &false, &1u64);
+    client.cancel_pending_fee_config(&admin, &2u64);
+
+    let config = client.get_fee_config().unwrap();
+    assert_eq!(config.base_fee, 500i128);
+    assert!(config.enabled);
+}
+
+#[test]
+fn test_commit_after_long_delay_succeeds() {
+    let (env, client, admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.propose_fee_config(&admin, &token, &collector, &1_000i128, &true, &1u64);
+
+    // Advance well past timelock (1 year)
+    advance_time(&env, 365 * 86_400);
+
+    client.commit_fee_config(&admin, &2u64);
+
+    let config = client.get_fee_config().unwrap();
+    assert_eq!(config.base_fee, 1_000i128);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Existing configure_fees Still Works (backward compat)
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_configure_fees_still_works_immediately() {
+    let (_env, client, _admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    // The original configure_fees should still apply immediately
+    client.configure_fees(&token, &collector, &42i128, &true);
+
+    let config = client.get_fee_config().unwrap();
+    assert_eq!(config.base_fee, 42i128);
+    assert!(config.enabled);
+}
+
+#[test]
+fn test_commit_after_configure_fees_overwrites() {
+    let (env, client, admin) = setup();
+    let token = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    client.configure_fees(&token, &collector, &42i128, &true);
+
+    let token2 = Address::generate(&env);
+    let collector2 = Address::generate(&env);
+    client.propose_fee_config(&admin, &token2, &collector2, &84i128, &false, &1u64);
+    advance_time(&env, FEE_TIMELOCK_SECONDS + 1);
+    client.commit_fee_config(&admin, &2u64);
+
+    let config = client.get_fee_config().unwrap();
+    assert_eq!(config.base_fee, 84i128);
+    assert!(!config.enabled);
+}


### PR DESCRIPTION
## Summary

Adds a mandatory time-locked fee configuration flow (`propose` → `commit`) so users have a 24-hour window to observe and react before fee changes take effect. A `get_pending_fee_config()` accessor exposes the pending state for third-party observability.

## Changes

### `dynamic_fees.rs`
- `FEE_TIMELOCK_SECONDS = 86400` (24h minimum delay)
- `PendingFeeConfig` struct wrapping `FeeConfig` + `effective_at` + `proposed_by`
- `DataKey::PendingFeeConfig` storage variant
- Storage helpers: `get_pending_fee_config`, `set_pending_fee_config`, `clear_pending_fee_config`, `check_and_apply_pending_fee_config`

### `events.rs`
- `FeeConfigProposedEvent` / `TOPIC_FEE_CONFIG_PROPOSED` (`fee_prop`)
- `FeeConfigCommittedEvent` / `TOPIC_FEE_CONFIG_COMMITTED` (`fee_com`)
- `FeeConfigCancelledEvent`
- Corresponding emit functions

### `lib.rs`
- `propose_fee_config(caller, token, collector, base_fee, enabled, nonce)` — stores pending config with `effective_at = now + FEE_TIMELOCK_SECONDS`
- `commit_fee_config(caller, nonce)` — applies pending config after timelock expiry
- `cancel_pending_fee_config(caller, nonce)` — discards pending proposal
- `get_pending_fee_config()` — read-only accessor for third-party observability
- Existing `configure_fees` remains unchanged for backward compatibility

### `timelock_fees_test.rs` (22 tests)

| Test | Coverage |
|------|----------|
| `test_propose_and_commit_fee_config` | Full propose→timelock→commit happy path |
| `test_propose_emits_fee_config_proposed_event` | Topic + struct field verification |
| `test_commit_emits_fee_config_committed_event` | Topic + struct field verification |
| `test_get_pending_fee_config_after_propose` | Accessor returns correct pending state |
| `test_get_pending_fee_config_none_after_commit` | Pending cleared after commit |
| `test_cancel_pending_fee_config` | Cancel discards proposal |
| `test_cancel_emits_fee_config_cancelled_event` | Cancel event emission |
| `test_cancel_with_no_pending_panics` | Error on empty cancel |
| `test_can_propose_after_cancel` | Re-propose after cancel |
| `test_commit_before_timelock_panics` | Half-timelock rejected |
| `test_commit_one_second_before_timelock_panics` | Boundary enforcement |
| `test_commit_at_exact_timelock_succeeds` | Exact boundary accepted |
| `test_propose_twice_without_cancel_panics` | No double proposal |
| `test_can_propose_after_commit` | Re-propose after commit |
| `test_non_admin_cannot_propose` | Authorization gate |
| `test_non_admin_cannot_commit` | Authorization gate |
| `test_non_admin_cannot_cancel` | Authorization gate |
| `test_propose_negative_base_fee_panics` | Input validation |
| `test_propose_zero_base_fee_succeeds` | Edge case: zero fee |
| `test_propose_does_not_affect_live_config` | Isolation from live state |
| `test_commit_overwrites_live_config` | Commit replaces old config |
| `test_commit_after_long_delay_succeeds` | 1-year delay works |
| `test_configure_fees_still_works_immediately` | Backward compat |

## Security Notes

- **Timelock enforced**: `commit_fee_config` panics if `timestamp < effective_at`. One-second-before boundary is rejected.
- **Single pending proposal**: Only one pending fee config at a time; propose panics if another is pending.
- **Admin-only**: All three entrypoints require `ROLE_ADMIN` + `require_auth()`.
- **Replay protection**: All mutating entrypoints consume a nonce via `replay_protection::verify_and_increment_nonce`.
- **Backward compatible**: Existing `configure_fees` is unchanged and still applies immediately.
- **Observable**: `get_pending_fee_config()` allows any third-party to read the pending state.

Closes #514