### PR TITLE
perf: profile is_paused across hot and cold reads

### DIFF
--- a/contracts/attestation/src/gas_benchmark_test.rs
+++ b/contracts/attestation/src/gas_benchmark_test.rs
@@ -37,6 +37,8 @@
 //! | pause (hot) | < 220k | < 6k | < 1k |
 //! | unpause (cold) | < 250k | < 7k | < 1k |
 //! | unpause (hot) | < 220k | < 6k | < 1k |
+//! | is_paused (cold) | < 80k | < 2k | < 500 |
+//! | is_paused (hot) | < 80k | < 2k | < 500 |
 //!
 //! ## Regression Detection
 //!
@@ -1037,6 +1039,194 @@ fn bench_unpause_hot() {
     cost.assert_within_target("unpause (hot)", 220_000, 6_000);
 }
 
+// ── is_paused Read Benchmarks ──────────────────────────────────────
+//
+// is_paused() is called on every hot path (submit_attestation,
+// verify_attestation, etc.) to gate execution before any state mutation.
+// Its cost is paid on *every* contract invocation, so even a small
+// regression compounds across the protocol.
+//
+// Cold: The Paused flag has never been written to instance storage.
+//       The contract is freshly deployed and no pause() call has run.
+//       `is_paused` returns `false` via the `unwrap_or(false)` default.
+//       This is the worst-case ledger I/O cost because the entry is not
+//       in the instance-storage cache.
+//
+// Hot:  The Paused flag has been written at least once (pause() was called
+//       and the entry is in instance storage).  The ledger cache already
+//       holds the value, so the I/O cost is minimal.
+//
+// Target: comparable to has_role (< 80 000 CPU / < 2 000 memory), since
+// both are single instance-storage boolean reads.
+
+/// Benchmark is_paused on a freshly deployed contract (cold read).
+///
+/// The Paused key has never been written to storage; the read falls through
+/// to the `unwrap_or(false)` default path.  This is the worst-case cost
+/// paid on the very first invocation after deployment or after a long
+/// period with no pause activity.
+#[test]
+fn bench_is_paused_cold() {
+    // Fresh contract — Paused key has NEVER been written.
+    let (env, client, _admin) = setup_basic();
+
+    let before = BudgetSnapshot::capture(&env);
+    let result = client.is_paused();
+    let after = BudgetSnapshot::capture(&env);
+
+    // Contract is not paused after initialization.
+    assert!(!result, "freshly deployed contract must not be paused");
+
+    let cost = before.delta(&after);
+    cost.print("is_paused (cold – Paused key absent from storage)");
+    cost.assert_within_target("is_paused (cold)", 80_000, 2_000);
+    append_to_csv("is_paused_cold", cost.cpu_insns, cost.mem_bytes);
+}
+
+/// Benchmark is_paused when the Paused flag is warm in instance storage.
+///
+/// After at least one pause() call the Paused key is present in instance
+/// storage and already loaded by the contract runtime.  This is the steady-
+/// state cost for all subsequent hot-path checks while the contract is live.
+#[test]
+fn bench_is_paused_hot() {
+    let (env, client, admin) = setup_basic();
+
+    // Write the Paused key to instance storage so it is warm.
+    client.pause(&admin, &1u64);
+
+    let before = BudgetSnapshot::capture(&env);
+    let result = client.is_paused();
+    let after = BudgetSnapshot::capture(&env);
+
+    // Contract is paused after pause() call.
+    assert!(result, "contract must be paused after pause()");
+
+    let cost = before.delta(&after);
+    cost.print("is_paused (hot – Paused key present in storage)");
+    cost.assert_within_target("is_paused (hot)", 80_000, 2_000);
+    append_to_csv("is_paused_hot", cost.cpu_insns, cost.mem_bytes);
+}
+
+/// Cold/hot comparison for is_paused — emits a structured report.
+///
+/// Runs both scenarios in sequence and prints a JSON summary so that
+/// automated pipelines can track the delta over time.
+#[test]
+fn bench_is_paused_cold_hot_comparison() {
+    std::println!("\n╔════════════════════════════════════════════════════════════════╗");
+    std::println!("║          is_paused Cold vs Hot Storage Report                  ║");
+    std::println!("╚════════════════════════════════════════════════════════════════╝");
+    std::println!("Security note: is_paused is a read-only, no-auth single flag read.");
+    std::println!("It is called on every hot path; cold overhead is paid at most once");
+    std::println!("per ledger (first call after deployment or long idle periods).");
+
+    // ── Cold measurement ──────────────────────────────────────────
+    let cold_cpu;
+    let cold_mem;
+    {
+        let (env, client, _admin) = setup_basic();
+
+        let before = BudgetSnapshot::capture(&env);
+        let result = client.is_paused();
+        let after = BudgetSnapshot::capture(&env);
+        assert!(!result);
+
+        let cold = before.delta(&after);
+        cold.print("COLD is_paused");
+        cold_cpu = cold.cpu_insns;
+        cold_mem = cold.mem_bytes;
+    }
+
+    // ── Hot measurement ───────────────────────────────────────────
+    let hot_cpu;
+    let hot_mem;
+    {
+        let (env, client, admin) = setup_basic();
+        client.pause(&admin, &1u64);
+
+        let before = BudgetSnapshot::capture(&env);
+        let result = client.is_paused();
+        let after = BudgetSnapshot::capture(&env);
+        assert!(result);
+
+        let hot = before.delta(&after);
+        hot.print("HOT is_paused");
+        hot_cpu = hot.cpu_insns;
+        hot_mem = hot.mem_bytes;
+    }
+
+    // ── Delta summary ─────────────────────────────────────────────
+    std::println!("\n=== COLD → HOT DELTA ===");
+    if cold_cpu > 0 && hot_cpu > 0 {
+        let cpu_savings = cold_cpu.saturating_sub(hot_cpu);
+        let cpu_pct = (cpu_savings as f64 / cold_cpu as f64) * 100.0;
+        std::println!("CPU savings: {} ({:.1}% reduction)", cpu_savings, cpu_pct);
+    } else {
+        std::println!(
+            "CPU: cold={} hot={} (delta unavailable in test env)",
+            cold_cpu,
+            hot_cpu
+        );
+    }
+    if cold_mem > 0 && hot_mem > 0 {
+        let mem_savings = cold_mem.saturating_sub(hot_mem);
+        let mem_pct = (mem_savings as f64 / cold_mem as f64) * 100.0;
+        std::println!(
+            "Memory savings: {} ({:.1}% reduction)",
+            mem_savings,
+            mem_pct
+        );
+    } else {
+        std::println!(
+            "Memory: cold={} hot={} (delta unavailable in test env)",
+            cold_mem,
+            hot_mem
+        );
+    }
+
+    // Structured JSON for automated consumers.
+    std::println!(
+        "{{\"benchmark\": \"is_paused_cold_hot\", \"cold_cpu\": {}, \"hot_cpu\": {}, \"cold_mem\": {}, \"hot_mem\": {}}}",
+        cold_cpu, hot_cpu, cold_mem, hot_mem
+    );
+
+    // Both paths must stay within the fast-path budget.
+    let budget_cpu: u64 = 80_000;
+    let budget_mem: u64 = 2_000;
+    let limit_cpu = budget_cpu + budget_cpu / 2; // 150 %
+    let limit_mem = budget_mem + budget_mem / 2;
+
+    for (label, cpu, mem) in [
+        ("is_paused_cold", cold_cpu, cold_mem),
+        ("is_paused_hot", hot_cpu, hot_mem),
+    ] {
+        if cpu == 0 && mem == 0 {
+            std::println!(
+                "{}: skipping budget assertion (test env returned 0)",
+                label
+            );
+            continue;
+        }
+        assert!(
+            cpu <= limit_cpu,
+            "{}: CPU {} exceeds fast-path limit {} (target: {})",
+            label,
+            cpu,
+            limit_cpu,
+            budget_cpu
+        );
+        assert!(
+            mem <= limit_mem,
+            "{}: Memory {} exceeds fast-path limit {} (target: {})",
+            label,
+            mem,
+            limit_mem,
+            budget_mem
+        );
+    }
+}
+
 // ── Worst-Case Scenarios ────────────────────────────────────────────
 
 #[test]
@@ -1175,6 +1365,8 @@ fn bench_summary_report() {
     std::println!("  • pause (hot):                   < 220k / < 6k");
     std::println!("  • unpause (cold):                < 250k / < 7k");
     std::println!("  • unpause (hot):                 < 220k / < 6k");
+    std::println!("  • is_paused (cold):              < 80k  / < 2k  [fast-path budget]");
+    std::println!("  • is_paused (hot):               < 80k  / < 2k  [fast-path budget]");
     std::println!("\nRegression threshold: 150% of target values");
     std::println!("\nFor detailed results, run:");
     std::println!("  cargo test --test gas_benchmark_test -- --nocapture\n");
@@ -1528,6 +1720,51 @@ fn regression_unpause_hot_threshold() {
     let cost = before.delta(&after);
     cost.print("regression: unpause (hot)");
     cost.assert_within_target("regression_unpause_hot", 220_000, 6_000);
+}
+
+/// Regression: is_paused (cold) must stay within the fast-path budget.
+///
+/// Cold path = Paused key absent from instance storage (freshly deployed
+/// contract, no prior pause() call).  The read falls through to the
+/// `unwrap_or(false)` default.  Budget is identical to `has_role` because
+/// both are single instance-storage boolean reads.
+#[test]
+fn regression_is_paused_cold_threshold() {
+    // Fresh contract — Paused key has never been written.
+    let (env, client, _admin) = setup_basic();
+
+    let before = BudgetSnapshot::capture(&env);
+    let result = client.is_paused();
+    let after = BudgetSnapshot::capture(&env);
+
+    assert!(!result, "freshly deployed contract must not be paused");
+
+    let cost = before.delta(&after);
+    cost.print("regression: is_paused (cold)");
+    // Fast-path budget: same as has_role (single boolean flag read).
+    cost.assert_within_target("regression_is_paused_cold", 80_000, 2_000);
+}
+
+/// Regression: is_paused (hot) must stay within the fast-path budget.
+///
+/// Hot path = Paused key is present in instance storage (written by a
+/// prior pause() call).  This is the steady-state cost paid on every
+/// contract invocation while the protocol is live.
+#[test]
+fn regression_is_paused_hot_threshold() {
+    let (env, client, admin) = setup_basic();
+    // Write the Paused key so it is warm in instance storage.
+    client.pause(&admin, &1u64);
+
+    let before = BudgetSnapshot::capture(&env);
+    let result = client.is_paused();
+    let after = BudgetSnapshot::capture(&env);
+
+    assert!(result, "contract must be paused after pause()");
+
+    let cost = before.delta(&after);
+    cost.print("regression: is_paused (hot)");
+    cost.assert_within_target("regression_is_paused_hot", 80_000, 2_000);
 }
 
 // ── WASM Size Budget Edge Cases ──────────────────────────────────────

--- a/docs/contract-gas-benchmarks.md
+++ b/docs/contract-gas-benchmarks.md
@@ -80,6 +80,38 @@ Based on Soroban's resource limits and operation complexity:
 | `revoke_role` (keep in holders) | < 150,000 | < 4,000 | Role revoked, address retains other roles |
 | `revoke_role` (remove from holders) | < 250,000 | < 7,000 | Role revoked, address removed from holders |
 | `has_role` | < 80,000 | < 2,000 | Access control check |
+| `is_paused` (cold) | < 80,000 | < 2,000 | Paused key absent — `unwrap_or(false)` default |
+| `is_paused` (hot) | < 80,000 | < 2,000 | Paused key present in instance storage |
+
+### Cold vs Warm Storage: is_paused
+
+`is_paused` is a read-only query that checks a single boolean flag in instance
+storage.  It is called on every hot path (submit_attestation,
+verify_attestation, migrate_attestation, etc.) before any state mutation is
+allowed, so its cost compounds across all protocol invocations.
+
+| Scenario | CPU Instructions | Memory Bytes | Notes |
+|----------|-----------------|--------------|-------|
+| `is_paused` (cold) | < 80,000 | < 2,000 | Paused key absent — read returns `false` via `unwrap_or` |
+| `is_paused` (hot) | < 80,000 | < 2,000 | Paused key present in instance storage |
+
+**Cold path**: On a freshly deployed contract — or after a long idle period
+where instance storage was not touched — the `Paused` key does not exist.
+`is_paused` calls `env.storage().instance().get(…).unwrap_or(false)`, paying
+the full ledger-entry read cost.
+
+**Hot path**: After the first `pause()` or `unpause()` call the key is written
+and remains resident in instance storage.  Subsequent reads are cheaper because
+the entry is already in the ledger cache.
+
+**Fast-path budget**: Both scenarios must stay under **< 80,000 CPU
+instructions / < 2,000 memory bytes** — the same ceiling as `has_role`, since
+both are single instance-storage boolean reads.  This ensures `is_paused`
+contributes negligible overhead to every call that uses it as a gate.
+
+The comparison report (`bench_is_paused_cold_hot_comparison`) emits a
+JSON-formatted summary for automated gas planning pipelines and prints the
+cold → hot savings percentage.
 
 ### Cold vs Warm Storage: verify_attestation
 
@@ -441,6 +473,8 @@ In addition to benchmarks, dedicated regression tests enforce hard cost ceilings
 | `regression_grant_role_threshold` | grant_role | < 375,000 | < 10,500 |
 | `regression_is_revoked_active_threshold` | is_revoked (active) | < 300,000 | < 7,500 |
 | `regression_is_revoked_after_revoke_threshold` | is_revoked (revoked) | < 375,000 | < 9,000 |
+| `regression_is_paused_cold_threshold` | is_paused (cold) | < 120,000 | < 3,000 |
+| `regression_is_paused_hot_threshold` | is_paused (hot) | < 120,000 | < 3,000 |
 
 ### Running Regression Tests
 ```bash
@@ -548,6 +582,15 @@ O(N) → O(N²) regressions across the three batch sizes.
 ---
 
 ## Changelog
+
+### 2026-07-28
+
+- Added `is_paused` hot/cold benchmark pair (`bench_is_paused_cold`, `bench_is_paused_hot`)
+- Added `bench_is_paused_cold_hot_comparison` — structured JSON report for automated pipelines
+- Added regression guards: `regression_is_paused_cold_threshold`, `regression_is_paused_hot_threshold`
+- Both paths emit CSV rows via `append_to_csv` to `target/gas_benchmarks.csv`
+- Fast-path budget confirmed: `< 80 000 CPU / < 2 000 memory` (same as `has_role`; single instance-storage boolean read)
+- Security note: `is_paused` is called on every hot path; its read cost compounds across all protocol invocations
 
 ### 2026-07-28
 


### PR DESCRIPTION
Add hot/cold benchmark pair for is_paused(), which is called on every hot path (submit_attestation, verify_attestation, etc.) before any state mutation is allowed.

Changes:
- bench_is_paused_cold: freshly deployed contract, Paused key absent from instance storage — measures the unwrap_or(false) default path
- bench_is_paused_hot: Paused key present after a prior pause() call
- bench_is_paused_cold_hot_comparison: structured JSON report for automated gas planning pipelines
- regression_is_paused_cold_threshold: hard budget gate for cold path
- regression_is_paused_hot_threshold: hard budget gate for hot path
- Both paths emit CSV rows via append_to_csv to target/gas_benchmarks.csv

Fast-path budget: < 80 000 CPU instructions / < 2 000 memory bytes (same ceiling as has_role; both are single instance-storage boolean reads). Assertion uses the standard 150% ceiling enforced across all benchmarks.

Docs: updated docs/contract-gas-benchmarks.md with is_paused rows in the target ranges table, a dedicated Cold vs Hot Storage section, updated regression test coverage table, and 2026-07-28 changelog entry.
closes #535