### PR TITLE
test: restore idempotency rejects double-apply

### DIFF
--- a/contracts/attestation-snapshot/src/lib.rs
+++ b/contracts/attestation-snapshot/src/lib.rs
@@ -44,7 +44,10 @@
 //!   stale authorisations from being replayed.
 //! - Only the admin who called `restore_dry_run` can call `restore_commit`.
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String, Symbol, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address,
+    xdr::ToXdr, BytesN, Env, String, Symbol, Vec,
+};
 
 /// Maximum UTF-8 byte length for period/epoch identifiers.
 pub const MAX_PERIOD_BYTES: u32 = 128;
@@ -54,6 +57,12 @@ pub const MAX_BUSINESS_PERIODS: u32 = 512;
 
 /// Maximum indexed businesses per epoch.
 pub const MAX_EPOCH_BUSINESSES: u32 = 512;
+
+/// Maximum number of records accepted in a restore batch.
+pub const MAX_RESTORE_BATCH: u32 = 512;
+
+/// Ledgers after dry-run during which its restore token remains valid.
+pub const RESTORE_COMMIT_WINDOW_LEDGERS: u32 = 600;
 
 // ════════════════════════════════════════════════════════════════════
 //  TTL constants
@@ -149,6 +158,17 @@ pub enum DataKey {
     Writer(Address),
     /// Pending restore token for a given admin (set by dry-run, consumed by commit).
     PendingRestore(Address),
+    /// Fingerprint of the most recently committed restore batch.
+    LastRestoreId,
+}
+
+/// Typed restore errors exposed to callers and automation.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum SnapshotError {
+    /// The restore batch fingerprint matches the last successfully applied batch.
+    AlreadyRestored = 1,
 }
 
 /// A single snapshot record for (business, period).
@@ -604,6 +624,8 @@ impl AttestationSnapshotContract {
     ///   and commit.
     /// - Token expiry prevents indefinitely-pending authorisations.
     /// - Token is deleted before writes begin (re-entrancy guard).
+    /// - The last committed batch fingerprint rejects sequential replay, even
+    ///   when the caller performs a new dry-run first.
     pub fn restore_commit(env: Env, caller: Address, entries: Vec<RestoreEntry>) {
         Self::require_admin(&env, &caller);
 
@@ -629,6 +651,15 @@ impl AttestationSnapshotContract {
             "snapshot_bytes hash mismatch; batch was altered since dry-run"
         );
 
+        if env
+            .storage()
+            .instance()
+            .get::<_, BytesN<32>>(&DataKey::LastRestoreId)
+            == Some(incoming_hash.clone())
+        {
+            panic_with_error!(&env, SnapshotError::AlreadyRestored);
+        }
+
         for i in 0..entries.len() {
             let entry = entries.get(i).unwrap();
 
@@ -644,6 +675,12 @@ impl AttestationSnapshotContract {
             Self::index_period_for_business(&env, &entry.business, &entry.period);
             Self::index_business_for_epoch(&env, &entry.period, &entry.business);
         }
+
+        // Soroban invocations are atomic: this marker and all restored records
+        // commit together, or neither does.
+        env.storage()
+            .instance()
+            .set(&DataKey::LastRestoreId, &incoming_hash);
     }
 
     /// Return the pending restore token for an admin, if any.
@@ -653,6 +690,11 @@ impl AttestationSnapshotContract {
         env.storage()
             .instance()
             .get(&DataKey::PendingRestore(admin))
+    }
+
+    /// Return the fingerprint of the most recently committed restore batch.
+    pub fn get_last_restore_id(env: Env) -> Option<BytesN<32>> {
+        env.storage().instance().get(&DataKey::LastRestoreId)
     }
 
     // ── Read-only queries ────────────────────────────────────────────
@@ -896,7 +938,15 @@ impl AttestationSnapshotContract {
         epochs.push_back(epoch.clone());
         env.storage().instance().set(&key, &epochs);
     }
-}
 
+    /// Compute a deterministic identifier that binds every restore field.
+    ///
+    /// Contract-value serialization is length-delimited and avoids ambiguous
+    /// concatenation. Changing a business, period, metric, count, or timestamp
+    /// therefore produces a different restore identifier.
+    fn compute_batch_hash(env: &Env, entries: &Vec<RestoreEntry>) -> BytesN<32> {
+        env.crypto().sha256(&entries.clone().to_xdr(env)).into()
+    }
+}
 #[cfg(test)]
 mod snapshot_ttl_test;

--- a/contracts/attestation-snapshot/src/test.rs
+++ b/contracts/attestation-snapshot/src/test.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 use soroban_sdk::testutils::Address as _;
-use soroban_sdk::{Address, Env, String};
+use soroban_sdk::{Address, Env, String, Vec};
 
 fn setup_snapshot_only() -> (Env, AttestationSnapshotContractClient<'static>, Address) {
     let env = Env::default();
@@ -421,4 +421,111 @@ fn test_set_attestation_contract_non_admin_panics() {
     let (_env, client, _admin) = setup_snapshot_only();
     let other = Address::generate(&_env);
     client.set_attestation_contract(&other, &None::<Address>);
+}
+
+// ── Restore idempotency ──────────────────────────────────────────────
+
+fn restore_entry(env: &Env, business: &Address, period: &str, revenue: i128) -> RestoreEntry {
+    let period = String::from_str(env, period);
+    RestoreEntry {
+        business: business.clone(),
+        period: period.clone(),
+        record: SnapshotRecord {
+            period,
+            trailing_revenue: revenue,
+            anomaly_count: 0,
+            attestation_count: 1,
+            recorded_at: env.ledger().timestamp(),
+        },
+    }
+}
+
+fn restore_batch(env: &Env, entry: RestoreEntry) -> Vec<RestoreEntry> {
+    let mut entries = Vec::new(env);
+    entries.push_back(entry);
+    entries
+}
+
+#[test]
+fn restore_idempotency_rejects_double_restore_with_specific_code() {
+    let (env, client, admin) = setup_snapshot_only();
+    let business = Address::generate(&env);
+    let entries = restore_batch(
+        &env,
+        restore_entry(&env, &business, "2026-08", 100_000),
+    );
+
+    assert!(client.restore_dry_run(&admin, &entries).ready_to_commit);
+    client.restore_commit(&admin, &entries);
+    let first_id = client.get_last_restore_id().unwrap();
+
+    // A fresh dry-run must not make an already-applied batch replayable.
+    assert!(client.restore_dry_run(&admin, &entries).ready_to_commit);
+    let second = client.try_restore_commit(&admin, &entries);
+    assert_eq!(
+        second,
+        Err(Ok(soroban_sdk::Error::from_contract_error(
+            SnapshotError::AlreadyRestored as u32,
+        )))
+    );
+    assert_eq!(client.get_last_restore_id(), Some(first_id));
+    assert_eq!(
+        client
+            .get_snapshot(&business, &String::from_str(&env, "2026-08"))
+            .unwrap()
+            .trailing_revenue,
+        100_000
+    );
+}
+
+#[test]
+fn restore_changed_payload_cannot_reuse_validated_restore_id() {
+    let (env, client, admin) = setup_snapshot_only();
+    let business = Address::generate(&env);
+    let validated = restore_batch(
+        &env,
+        restore_entry(&env, &business, "2026-09", 100_000),
+    );
+    let changed = restore_batch(
+        &env,
+        restore_entry(&env, &business, "2026-09", 999_999),
+    );
+
+    assert!(client.restore_dry_run(&admin, &validated).ready_to_commit);
+    assert!(client.try_restore_commit(&admin, &changed).is_err());
+    assert!(client.get_last_restore_id().is_none());
+    assert!(client
+        .get_snapshot(&business, &String::from_str(&env, "2026-09"))
+        .is_none());
+}
+
+#[test]
+fn restore_different_batch_after_first_restore_is_allowed() {
+    let (env, client, admin) = setup_snapshot_only();
+    let first_business = Address::generate(&env);
+    let second_business = Address::generate(&env);
+    let first = restore_batch(
+        &env,
+        restore_entry(&env, &first_business, "2026-10", 100_000),
+    );
+    let second = restore_batch(
+        &env,
+        restore_entry(&env, &second_business, "2026-11", 200_000),
+    );
+
+    client.restore_dry_run(&admin, &first);
+    client.restore_commit(&admin, &first);
+    let first_id = client.get_last_restore_id().unwrap();
+
+    client.restore_dry_run(&admin, &second);
+    client.restore_commit(&admin, &second);
+    let second_id = client.get_last_restore_id().unwrap();
+
+    assert_ne!(first_id, second_id);
+    assert!(client
+        .get_snapshot(&first_business, &String::from_str(&env, "2026-10"))
+        .is_some());
+    assert!(client
+        .get_snapshot(&second_business, &String::from_str(&env, "2026-11"))
+        .is_some());
 }

--- a/docs/attestation-snapshot-operations.md
+++ b/docs/attestation-snapshot-operations.md
@@ -218,3 +218,22 @@ cargo test -p veritasor-attestation-snapshot -- --nocapture
 ```
 
 If the coverage tool is unavailable in a given CI environment, document explicit risk acceptance and list untested branches in the PR.
+
+## Restore replay protection
+
+Every successful `restore_commit` stores the exact batch fingerprint as
+`LastRestoreId`. A later attempt to commit that same batch is rejected with the
+typed contract error `SnapshotError::AlreadyRestored` (code `1`), even if the
+administrator obtains a fresh dry-run token. Operators should treat that error
+as confirmation that the restore was already applied and must not retry it.
+
+The identifier hashes the contract-value serialization of every restore entry,
+including the business, period, revenue, anomaly count, attestation count, and
+recorded timestamp. Consequently, changing any restored value invalidates the
+dry-run token rather than silently reusing its identifier. A genuinely different
+validated batch receives a different identifier and may be committed normally.
+
+The marker is written in the same atomic Soroban invocation as the restored
+records. A failed invocation changes neither snapshot state nor `LastRestoreId`.
+Use `get_last_restore_id()` to reconcile an operator job after an uncertain RPC
+response before deciding whether another restore should be attempted.

--- a/docs/attestation-snapshots.md
+++ b/docs/attestation-snapshots.md
@@ -109,3 +109,12 @@ The primary contract tests cover:
 - overwrite behavior before finalization,
 - write rejection after finalization,
 - unique business counting and ordering behavior.
+
+## Restore idempotency
+
+`restore_commit` records a SHA-256 identifier for the exact committed batch and
+rejects a sequential replay with `AlreadyRestored` (contract error code `1`).
+The identifier covers every `RestoreEntry` field, so payload substitution after
+dry-run validation fails the hash check. `get_last_restore_id()` exposes the
+last successful identifier for operator reconciliation without exposing private
+data.


### PR DESCRIPTION
Persist the exact fingerprint of the last committed restore batch and reject a sequential replay with the typed AlreadyRestored contract error.

Bind restore identifiers to every RestoreEntry field, restore the missing batch limits and hash helper, cover altered-payload and distinct-batch edge cases, and document operator reconciliation and security assumptions.

Closes #523