### PR TITLE
test: add proptest for rate limit under clock skew

### DIFF
--- a/contracts/attestation/src/dynamic_fees.rs
+++ b/contracts/attestation/src/dynamic_fees.rs
@@ -152,6 +152,9 @@ pub enum DataKey {
     EpochFees(soroban_sdk::String),
     /// Global running submission count for backfill checkpointing.
     BackfillSubmissionCount,
+    /// Highest ledger timestamp observed for a successful rate-limited
+    /// submission, keyed per business. Appended for storage compatibility.
+    RateLimitHighWaterTimestamp(Address),
 }
 
 // ════════════════════════════════════════════════════════════════════

--- a/contracts/attestation/src/rate_limit.rs
+++ b/contracts/attestation/src/rate_limit.rs
@@ -35,10 +35,12 @@
 //!
 //! ## Clock Skew
 //!
-//! Soroban ledger timestamps are set by validators and advance
-//! monotonically within a single ledger sequence. The sliding-window
-//! cutoff uses `saturating_sub` so a zero-valued timestamp (e.g. in
-//! tests) never underflows. Callers must not assume sub-second precision.
+//! Soroban ledger timestamps are set by validators, but defensive handling
+//! is required for rollback or malformed test sequences. Each business keeps
+//! a timestamp high-water mark. Window calculations and newly recorded
+//! submissions use `max(ledger_timestamp, high_water_mark)`, so a forward
+//! jump followed by a backward jump cannot reopen capacity that was already
+//! consumed. Cutoffs use `saturating_sub` to avoid underflow at timestamp zero.
 //!
 //! ## Backward Compatibility
 //!
@@ -183,6 +185,20 @@ fn set_timestamps(env: &Env, business: &Address, timestamps: &Vec<u64>) {
         .set(&DataKey::SubmissionTimestamps(business.clone()), timestamps);
 }
 
+/// Return a non-decreasing clock for this business.
+///
+/// The high-water mark is written only after a successful submission, keeping
+/// failed attempts from advancing the limiter clock or consuming capacity.
+fn effective_timestamp(env: &Env, business: &Address) -> u64 {
+    let ledger_timestamp = env.ledger().timestamp();
+    let high_water: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::RateLimitHighWaterTimestamp(business.clone()))
+        .unwrap_or(ledger_timestamp);
+    ledger_timestamp.max(high_water)
+}
+
 /// Analyze the current submission history for the configured windows.
 ///
 /// Prunes timestamps that have fallen outside the full window and counts
@@ -192,15 +208,15 @@ fn set_timestamps(env: &Env, business: &Address, timestamps: &Vec<u64>) {
 ///
 /// # Clock Skew
 ///
-/// `now` is taken from `env.ledger().timestamp()`. The cutoffs use
-/// `saturating_sub` so a ledger timestamp of `0` (common in unit tests)
-/// never underflows to `u64::MAX`.
+/// `now` is the greater of the current ledger timestamp and the business's
+/// successful-submission high-water mark. The cutoffs use `saturating_sub`,
+/// so timestamp `0` never underflows to `u64::MAX`.
 fn analyze_submission_windows(
     env: &Env,
     config: &RateLimitConfig,
     business: &Address,
 ) -> (Vec<u64>, u32, u32, u32) {
-    let now = env.ledger().timestamp();
+    let now = effective_timestamp(env, business);
     let cutoff = now.saturating_sub(config.window_seconds);
     let burst_cutoff = now.saturating_sub(config.burst_window_seconds);
 
@@ -278,11 +294,15 @@ pub fn record_submission(env: &Env, business: &Address) {
         _ => return,
     };
 
-    let now = env.ledger().timestamp();
+    let now = effective_timestamp(env, business);
     let (mut active, _, _, _) = analyze_submission_windows(env, &config, business);
     active.push_back(now);
 
     set_timestamps(env, business, &active);
+    env.storage().instance().set(
+        &DataKey::RateLimitHighWaterTimestamp(business.clone()),
+        &now,
+    );
 }
 
 /// Count active submissions for `business` in the full sliding window.

--- a/contracts/attestation/src/rate_limit_test.rs
+++ b/contracts/attestation/src/rate_limit_test.rs
@@ -3,6 +3,7 @@
 extern crate std;
 
 use super::*;
+use proptest::prelude::*;
 use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
 use soroban_sdk::{Address, BytesN, Env, String};
 
@@ -593,4 +594,121 @@ fn test_disabled_config_enforces_nothing() {
     assert_eq!(client.get_submission_window_count(&business), 0);
     assert_eq!(client.get_submission_burst_count(&business), 0);
     assert_eq!(client.get_business_count(&business), 3);
+}
+
+/// A forward jump must not erase quota history that a later rollback could
+/// exploit. With a budget of one, the rollback attempt remains rejected.
+#[test]
+#[should_panic(expected = "rate limit exceeded")]
+fn test_forward_jump_then_backward_jump_does_not_reopen_capacity() {
+    let (env, client, _admin) = setup();
+    let business = Address::generate(&env);
+    configure_rate_limit(&client, 1, 100, 1, 100, true, 1);
+
+    set_ledger_timestamp(&env, 1_000);
+    submit(&client, &env, &business, 1);
+
+    set_ledger_timestamp(&env, 1_200);
+    submit(&client, &env, &business, 2);
+
+    set_ledger_timestamp(&env, 1_001);
+    submit(&client, &env, &business, 3);
+}
+prop_compose! {
+    /// Generates clock movement biased toward the exact expiry boundary and
+    /// its two adjacent seconds, plus larger forward/backward jumps.
+    fn skewed_rate_limit_sequence()
+        (window_seconds in 2u64..120, max_per_window in 1u32..8)
+        (
+            movements in prop::collection::vec(
+                prop_oneof![
+                    4 => Just(window_seconds as i64),
+                    4 => Just(window_seconds as i64 - 1),
+                    4 => Just(window_seconds as i64 + 1),
+                    3 => Just(-(window_seconds as i64)),
+                    3 => Just(-(window_seconds as i64 - 1)),
+                    3 => Just(-(window_seconds as i64 + 1)),
+                    2 => -240i64..=240,
+                ],
+                1..48,
+            ),
+            window_seconds in Just(window_seconds),
+            max_per_window in Just(max_per_window),
+        ) -> (u64, u32, std::vec::Vec<i64>) {
+            (window_seconds, max_per_window, movements)
+        }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 64,
+        max_shrink_iters: 2_048,
+        ..ProptestConfig::default()
+    })]
+
+    /// Replays randomized ledger skew against the contract. The oracle uses
+    /// the same non-decreasing effective clock required by the security model
+    /// and verifies that every admitted submission fits the configured budget.
+    #[test]
+    fn check_rate_limit_never_exceeds_window_budget_under_clock_skew(
+        (window_seconds, max_per_window, movements) in skewed_rate_limit_sequence()
+    ) {
+        let (env, client, _admin) = setup();
+        let business = Address::generate(&env);
+        configure_rate_limit(
+            &client,
+            max_per_window,
+            window_seconds,
+            max_per_window,
+            window_seconds,
+            true,
+            1,
+        );
+
+        let mut ledger_now = 10_000u64;
+        let mut effective_now = ledger_now;
+        let mut admitted_at = std::vec::Vec::<u64>::new();
+
+        for (index, movement) in movements.into_iter().enumerate() {
+            ledger_now = if movement < 0 {
+                ledger_now.saturating_sub(movement.unsigned_abs())
+            } else {
+                ledger_now.saturating_add(movement as u64)
+            };
+            set_ledger_timestamp(&env, ledger_now);
+
+            let period = String::from_str(&env, &std::format!("skew-{index}"));
+            let root = BytesN::from_array(&env, &[index as u8; 32]);
+            let admitted = client
+                .try_submit_attestation(
+                    &business,
+                    &period,
+                    &root,
+                    &1_700_000_000u64,
+                    &1u32,
+                    &0i128,
+                    &None,
+                    &None,
+                )
+                .is_ok();
+
+            if admitted {
+                effective_now = effective_now.max(ledger_now);
+                admitted_at.retain(|timestamp| {
+                    *timestamp > effective_now.saturating_sub(window_seconds)
+                });
+                admitted_at.push(effective_now);
+
+                prop_assert!(
+                    admitted_at.len() <= max_per_window as usize,
+                    "{} admits in a {}-second window with budget {}; ledger_now={}, effective_now={}",
+                    admitted_at.len(),
+                    window_seconds,
+                    max_per_window,
+                    ledger_now,
+                    effective_now,
+                );
+            }
+        }
+    }
 }

--- a/docs/attestation-rate-limits.md
+++ b/docs/attestation-rate-limits.md
@@ -30,12 +30,15 @@ time source.
 On each submission:
 
 1. Load the business's recorded timestamps.
-2. Prune entries older than `now - window_seconds`.
-3. Count remaining timestamps in the full window.
-4. Count remaining timestamps in the burst window.
-5. Reject with `rate limit exceeded` if the full-window count is already at capacity.
-6. Reject with `burst rate limit exceeded` if the burst-window count is already at capacity.
-7. Record the current timestamp only after the attestation is successfully stored.
+2. Derive a per-business effective time as the maximum of the current ledger
+   timestamp and the last successful submission timestamp.
+3. Prune entries older than `effective_now - window_seconds`.
+4. Count remaining timestamps in the full window.
+5. Count remaining timestamps in the burst window.
+6. Reject with `rate limit exceeded` if the full-window count is already at capacity.
+7. Reject with `burst rate limit exceeded` if the burst-window count is already at capacity.
+8. Record the effective timestamp and advance the high-water mark only after
+   the attestation is successfully stored.
 
 The implementation uses strict `>` cutoff checks. A timestamp exactly equal to
 the computed cutoff is treated as expired.
@@ -73,6 +76,8 @@ This means:
 - Timestamp history is pruned lazily, which keeps state bounded by the configured window.
 - Counts are isolated per business address.
 - Rejected submissions do not record timestamps, so failed attempts cannot consume future quota.
+- A per-business high-water timestamp prevents a forward clock jump followed
+  by rollback from pruning history and reopening previously consumed capacity.
 
 ## Performance Notes
 
@@ -93,3 +98,4 @@ The contract test target covers:
 - per-business isolation
 - disabled and unconfigured backward-compatible behavior
 - replay nonce ordering for admin configuration
+- randomized forward and backward clock jumps, including exact window edges


### PR DESCRIPTION
Add a skew-biased proptest state machine that replays forward and backward ledger timestamp jumps against the attestation rate limiter and checks every admitted submission against a sliding-window budget oracle.

Persist a per-business timestamp high-water mark so a forward jump followed by rollback cannot prune quota history and reopen capacity. Add a deterministic regression for that sequence and document the security and performance behavior.

Closes #451