### PR TITLE
test(dynamic-fees): add single-bracket volume edge case tests

### DIFF
--- a/contracts/attestation/src/dynamic_fees_test.rs
+++ b/contracts/attestation/src/dynamic_fees_test.rs
@@ -816,6 +816,123 @@ fn test_volume_brackets_descending_thresholds_rejected() {
 }
 
 
+// ════════════════════════════════════════════════════════════════════
+//  Single-bracket volume edge cases
+// ════════════════════════════════════════════════════════════════════
+
+/// Helper: set a single volume bracket and return a fresh business address
+/// with enough tokens to make submissions.
+fn setup_single_bracket(t: &TestSetup, threshold: u64, discount_bps: u32) {
+    let thresholds = vec![&t.env, threshold];
+    let discounts = vec![&t.env, discount_bps];
+    t.client.set_volume_brackets(&thresholds, &discounts);
+}
+
+/// volume = 0 (fresh business, no submissions yet):
+/// count = 0, threshold = 5 → 0 < 5, bracket NOT matched, discount = 0.
+#[test]
+fn test_single_bracket_volume_zero() {
+    let t = setup_with_fees(1_000_000);
+    setup_single_bracket(&t, 5, 1_000);
+
+    let business = Address::generate(&t.env);
+    // count is 0 (no submissions)
+    assert_eq!(t.client.get_business_count(&business), 0);
+    assert_eq!(t.client.get_volume_discount(&business), 0);
+    assert_eq!(t.client.get_fee_quote(&business), 1_000_000);
+}
+
+/// volume = threshold - 1:
+/// count = 4, threshold = 5 → 4 < 5, bracket NOT matched, discount = 0.
+#[test]
+fn test_single_bracket_volume_below_threshold() {
+    let t = setup_with_fees(1_000_000);
+    setup_single_bracket(&t, 5, 1_000);
+
+    let business = Address::generate(&t.env);
+    mint(&t.env, &t.token_addr, &business, 100_000_000);
+
+    // submit 4 times → count = 4 = threshold - 1
+    for i in 1..=4 {
+        submit(&t.client, &t.env, &business, i);
+    }
+    assert_eq!(t.client.get_business_count(&business), 4);
+    assert_eq!(t.client.get_volume_discount(&business), 0);
+    assert_eq!(t.client.get_fee_quote(&business), 1_000_000);
+}
+
+/// volume = threshold (exact boundary):
+/// count = 5, threshold = 5 → 5 >= 5, bracket matched, discount applies.
+#[test]
+fn test_single_bracket_volume_at_threshold() {
+    let t = setup_with_fees(1_000_000);
+    setup_single_bracket(&t, 5, 1_000);
+
+    let business = Address::generate(&t.env);
+    mint(&t.env, &t.token_addr, &business, 100_000_000);
+
+    // submit 5 times → count = 5 = threshold
+    for i in 1..=5 {
+        submit(&t.client, &t.env, &business, i);
+    }
+    assert_eq!(t.client.get_business_count(&business), 5);
+    assert_eq!(t.client.get_volume_discount(&business), 1_000);
+    // 1_000_000 * (10_000 - 1_000) / 10_000 = 900_000
+    assert_eq!(t.client.get_fee_quote(&business), 900_000);
+}
+
+/// volume = threshold + 1 (one past the boundary):
+/// count = 6, threshold = 5 → bracket remains matched, same discount.
+#[test]
+fn test_single_bracket_volume_above_threshold() {
+    let t = setup_with_fees(1_000_000);
+    setup_single_bracket(&t, 5, 1_000);
+
+    let business = Address::generate(&t.env);
+    mint(&t.env, &t.token_addr, &business, 100_000_000);
+
+    // submit 6 times → count = 6 = threshold + 1
+    for i in 1..=6 {
+        submit(&t.client, &t.env, &business, i);
+    }
+    assert_eq!(t.client.get_business_count(&business), 6);
+    assert_eq!(t.client.get_volume_discount(&business), 1_000);
+    assert_eq!(t.client.get_fee_quote(&business), 900_000);
+}
+
+/// Single bracket with threshold = 0:
+/// Any volume (including 0) satisfies count >= 0, so the bracket
+/// matches immediately and the discount applies from the very first check.
+#[test]
+fn test_single_bracket_threshold_zero_matches_any_volume() {
+    let t = setup_with_fees(1_000_000);
+    // threshold = 0 means every count qualifies
+    setup_single_bracket(&t, 0, 2_000);
+
+    let business = Address::generate(&t.env);
+    mint(&t.env, &t.token_addr, &business, 100_000_000);
+
+    // count = 0: even before any submission the discount should apply
+    assert_eq!(t.client.get_business_count(&business), 0);
+    assert_eq!(t.client.get_volume_discount(&business), 2_000);
+    // 1_000_000 * (10_000 - 2_000) / 10_000 = 800_000
+    assert_eq!(t.client.get_fee_quote(&business), 800_000);
+
+    // count = 1 (threshold + 1): discount still applies
+    submit(&t.client, &t.env, &business, 1);
+    assert_eq!(t.client.get_business_count(&business), 1);
+    assert_eq!(t.client.get_volume_discount(&business), 2_000);
+    assert_eq!(t.client.get_fee_quote(&business), 800_000);
+
+    // count = 100: discount still applies
+    for i in 2..=100 {
+        submit(&t.client, &t.env, &business, i);
+    }
+    assert_eq!(t.client.get_business_count(&business), 100);
+    assert_eq!(t.client.get_volume_discount(&business), 2_000);
+    assert_eq!(t.client.get_fee_quote(&business), 800_000);
+}
+
 #[test]
 fn discount_stacking_no_underflow() {
     let e = soroban_sdk::Env::default();


### PR DESCRIPTION
Cover the following scenarios in dynamic_fees_test.rs:
- volume = 0 (fresh business, no submissions)
- volume = threshold - 1 (just below, no bracket match)
- volume = threshold (exact boundary, bracket matches)
- volume = threshold + 1 (above boundary, bracket still matches)
- single bracket with threshold = 0 (any volume qualifies immediately)

Each test asserts correct bracket selection, get_volume_discount consistency, and that volumes below a non-zero threshold are rejected (discount = 0, full fee).
Closes #499 