### PR TITLE
Title: feat: revoke_approval before quorum reached

### DIFF
--- a/contracts/attestation/src/events.rs
+++ b/contracts/attestation/src/events.rs
@@ -1653,3 +1653,12 @@ pub fn emit_revocation_committed(
     env.events()
         .publish((TOPIC_REVOCATION_COMMITTED, business.clone()), event);
 }
+
+pub fn emit_approval_revoked(env: &Env, proposal_id: u64, approver: &Address) {
+    let mut topics = Vec::new(env);
+    topics.push_back(Symbol::new(env, "approval_revoked").to_val());
+    topics.push_back(proposal_id.into_val(env));
+    let mut data = Vec::new(env);
+    data.push_back(approver.to_val());
+    env.events().publish(topics, data);
+}

--- a/contracts/attestation/src/multisig.rs
+++ b/contracts/attestation/src/multisig.rs
@@ -579,3 +579,19 @@ pub fn cleanup_expired_proposals(env: &Env, limit: u32) -> u32 {
     }
     cleaned
 }
+
+pub fn revoke_approval(env: &Env, approver: &Address, id: u64) {
+    approver.require_auth();
+    let proposal = get_proposal(env, id).expect("proposal not found");
+    if is_proposal_expired(env, id) { panic!("proposal has expired"); }
+    assert!(proposal.status == ProposalStatus::Pending, "cannot revoke approval: proposal already executed or rejected");
+    let mut approvals = get_approvals(env, id);
+    let pos = approvals.iter().position(|a| a == approver);
+    if let Some(idx) = pos {
+        let last = approvals.len() - 1;
+        if idx != last { let last_addr = approvals.get(last).unwrap(); approvals.set(idx, last_addr); }
+        approvals.pop_back();
+        env.storage().instance().set(&MultisigKey::Approvals(id), &approvals);
+        events::emit_approval_revoked(env, id, approver);
+    }
+}


### PR DESCRIPTION
- Added revoke_approval(proposal_id) allowing approver to withdraw vote before execution
- Refuses revocation if proposal expired, already executed, or rejected
- Removes approval by swap-and-pop (O(1)) and decrements approval count
- Emits ApprovalRevoked event
- Idempotent: revoking a non-existent approval is a no-op
- Closes #513