### PR TITLE
feat: version-checked snapshot restore

### DIFF
--- a/contracts/attestation-snapshot/src/lib.rs
+++ b/contracts/attestation-snapshot/src/lib.rs
@@ -29,6 +29,9 @@
 //! ## Restore dry-run invariants
 //!
 //! `restore_dry_run` checks and reports:
+//! - **Schema version**: all entries must declare `schema_version == SNAPSHOT_SCHEMA_VERSION`.
+//!   Batches with an incompatible version are rejected immediately with a
+//!   `RestoreVersionMismatch` event.
 //! - **No duplicate keys**: each (business, period) pair must be unique in the batch.
 //! - **Expiries in the future**: any `recorded_at` must not exceed the current ledger timestamp
 //!   (records from the future are rejected).
@@ -54,6 +57,35 @@ pub const MAX_BUSINESS_PERIODS: u32 = 512;
 
 /// Maximum indexed businesses per epoch.
 pub const MAX_EPOCH_BUSINESSES: u32 = 512;
+
+// ════════════════════════════════════════════════════════════════════
+//  Snapshot schema versioning
+//
+//  When restoring a snapshot batch, the contract must verify that the
+//  payload was encoded with a compatible schema version.  This prevents
+//  silent data corruption when restoring older snapshots after a schema
+//  evolution.
+// ════════════════════════════════════════════════════════════════════
+
+/// Current schema version for snapshot restore batches.
+///
+/// Increment this constant whenever the on-chain layout of `RestoreEntry`
+/// or `SnapshotRecord` changes in a way that would cause older encoded
+/// payloads to be misinterpreted.  Restore batches encoded with a different
+/// version are rejected during `restore_dry_run` with a `RestoreVersionMismatch`
+/// event.
+pub const SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+/// Maximum number of entries allowed in a single restore batch.
+///
+/// Limits the computational cost of the dry-run validation and the commit
+/// operation to keep them within gas bounds.
+pub const MAX_RESTORE_BATCH: u32 = 1024;
+
+/// Number of ledgers after which a pending restore token expires.
+///
+/// Approximately ~2 hours at 5-second ledger close time.
+pub const RESTORE_COMMIT_WINDOW_LEDGERS: u32 = 1_440;
 
 // ════════════════════════════════════════════════════════════════════
 //  TTL constants
@@ -95,6 +127,35 @@ pub struct PointerTtlBumpedEvent {
     pub bumped_at: u64,
     /// The TTL amount added (in ledger sequences).
     pub ttl_bump: u32,
+}
+
+/// Topic: snapshot restore version mismatch.
+pub const TOPIC_RESTORE_VERSION_MISMATCH: Symbol = symbol_short!("rst_ver");
+
+/// Payload emitted when `restore_dry_run` or `restore_commit` detects a
+/// snapshot schema version mismatch between the incoming batch and the
+/// contract's expected `SNAPSHOT_SCHEMA_VERSION`.
+///
+/// The event is emitted **before** the function panics, allowing off-chain
+/// tooling to detect the version incompatibility without relying on panic
+/// messages.
+///
+/// ## Security Notes
+///
+/// - Emitted only when a version mismatch is detected; no event for matching
+///   versions.
+/// - The `batch_version` field allows off-chain tooling to distinguish between
+///   older and newer snapshot payloads.
+/// - No sensitive data is included.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct RestoreVersionMismatchEvent {
+    /// The schema version declared in the incoming restore batch.
+    pub batch_version: u32,
+    /// The contract's expected schema version (`SNAPSHOT_SCHEMA_VERSION`).
+    pub expected_version: u32,
+    /// Ledger timestamp when the mismatch was detected.
+    pub detected_at: u64,
 }
 
 /// Attestation contract client: WASM import for wasm32 (avoids duplicate symbols), crate for tests.
@@ -193,6 +254,8 @@ pub struct RestoreEntry {
     pub period: String,
     /// Full snapshot record to restore.
     pub record: SnapshotRecord,
+    /// Schema version of this entry's encoding. Must match `SNAPSHOT_SCHEMA_VERSION`.
+    pub schema_version: u32,
 }
 
 /// Outcome of a single-entry invariant check.
@@ -446,10 +509,13 @@ impl AttestationSnapshotContract {
     /// Validate a restore batch without writing any business state.
     ///
     /// Invariants checked per entry:
-    /// 1. `period` length within `MAX_PERIOD_BYTES`.
-    /// 2. `recorded_at` must not be in the future (> current ledger timestamp).
-    /// 3. No duplicate `(business, period)` keys within the batch.
-    /// 4. For each business, `recorded_at` values must be non-decreasing across
+    /// 1. **Schema version** matches `SNAPSHOT_SCHEMA_VERSION` — batches encoded
+    ///    with an incompatible version are rejected with a `RestoreVersionMismatch`
+    ///    event.
+    /// 2. `period` length within `MAX_PERIOD_BYTES`.
+    /// 3. `recorded_at` must not be in the future (> current ledger timestamp).
+    /// 4. No duplicate `(business, period)` keys within the batch.
+    /// 5. For each business, `recorded_at` values must be non-decreasing across
     ///    entries as they appear in the batch (monotonic nonces).
     ///
     /// If all checks pass a `PendingRestoreToken` is stored keyed to `caller`.
@@ -486,6 +552,22 @@ impl AttestationSnapshotContract {
 
         for i in 0..batch_len {
             let entry = entries.get(i).unwrap();
+
+            // ── Invariant 0: schema version check ────────────────────
+            if entry.schema_version != SNAPSHOT_SCHEMA_VERSION {
+                // Emit version mismatch event before panicking
+                let event = RestoreVersionMismatchEvent {
+                    batch_version: entry.schema_version,
+                    expected_version: SNAPSHOT_SCHEMA_VERSION,
+                    detected_at: now_ts,
+                };
+                env.events().publish(
+                    (TOPIC_RESTORE_VERSION_MISMATCH, caller.clone()),
+                    event,
+                );
+                panic!("snapshot schema version mismatch: expected {}, got {}",
+                       SNAPSHOT_SCHEMA_VERSION, entry.schema_version);
+            }
 
             // ── Invariant 1: period length ──────────────────────────
             if entry.period.len() > MAX_PERIOD_BYTES {
@@ -594,6 +676,7 @@ impl AttestationSnapshotContract {
     /// - A pending token exists for the caller (set by `restore_dry_run`).
     /// - The token has not expired.
     /// - The `entries` batch hash matches the token exactly.
+    /// - All entries declare `schema_version == SNAPSHOT_SCHEMA_VERSION`.
     ///
     /// On success all entries are written to storage and the pending token is
     /// consumed (one-shot). Entries whose epoch is already finalized are skipped
@@ -604,6 +687,8 @@ impl AttestationSnapshotContract {
     ///   and commit.
     /// - Token expiry prevents indefinitely-pending authorisations.
     /// - Token is deleted before writes begin (re-entrancy guard).
+    /// - Schema version re-check at commit time provides defence-in-depth against
+    ///   direct commit calls that bypass dry-run.
     pub fn restore_commit(env: Env, caller: Address, entries: Vec<RestoreEntry>) {
         Self::require_admin(&env, &caller);
 
@@ -628,6 +713,26 @@ impl AttestationSnapshotContract {
             incoming_hash == token.batch_hash,
             "snapshot_bytes hash mismatch; batch was altered since dry-run"
         );
+
+        // Defence-in-depth: re-validate schema version at commit time
+        // (should never fail if dry-run passed, but guards against direct commit calls).
+        let now_ts = env.ledger().timestamp();
+        for i in 0..entries.len() {
+            let entry = entries.get(i).unwrap();
+            if entry.schema_version != SNAPSHOT_SCHEMA_VERSION {
+                let event = RestoreVersionMismatchEvent {
+                    batch_version: entry.schema_version,
+                    expected_version: SNAPSHOT_SCHEMA_VERSION,
+                    detected_at: now_ts,
+                };
+                env.events().publish(
+                    (TOPIC_RESTORE_VERSION_MISMATCH, caller.clone()),
+                    event,
+                );
+                panic!("snapshot schema version mismatch: expected {}, got {}",
+                       SNAPSHOT_SCHEMA_VERSION, entry.schema_version);
+            }
+        }
 
         for i in 0..entries.len() {
             let entry = entries.get(i).unwrap();
@@ -895,6 +1000,22 @@ impl AttestationSnapshotContract {
 
         epochs.push_back(epoch.clone());
         env.storage().instance().set(&key, &epochs);
+    }
+
+    /// Compute a SHA-256 hash of the canonical restore batch data.
+    ///
+    /// The hash covers the ordered sequence of (business, period, schema_version)
+    /// tuples to bind the commit to the exact entries validated by dry-run.
+    fn compute_batch_hash(env: &Env, entries: &Vec<RestoreEntry>) -> soroban_sdk::BytesN<32> {
+        let mut buffer = Vec::new(env);
+        for i in 0..entries.len() {
+            let entry = entries.get(i).unwrap();
+            buffer.push_back(entry.business.clone());
+            buffer.push_back(entry.period.clone());
+            buffer.push_back(entry.schema_version);
+        }
+        let encoded = buffer.to_xdr(env);
+        env.crypto().sha256(&encoded).into()
     }
 }
 

--- a/contracts/attestation-snapshot/src/test.rs
+++ b/contracts/attestation-snapshot/src/test.rs
@@ -6,8 +6,8 @@
 //! off-chain verifier CLI.
 
 use super::*;
-use soroban_sdk::testutils::Address as _;
-use soroban_sdk::{Address, Env, String};
+use soroban_sdk::testutils::{Address as _, Events as _, Ledger as _};
+use soroban_sdk::{Address, Env, String, Symbol, TryFromVal, Vec};
 
 fn setup_snapshot_only() -> (Env, AttestationSnapshotContractClient<'static>, Address) {
     let env = Env::default();
@@ -17,6 +17,30 @@ fn setup_snapshot_only() -> (Env, AttestationSnapshotContractClient<'static>, Ad
     let admin = Address::generate(&env);
     client.initialize(&admin, &None::<Address>);
     (env, client, admin)
+}
+
+/// Helper to create a valid RestoreEntry with the current schema version.
+fn make_entry(
+    env: &Env,
+    business: &Address,
+    period: &str,
+    trailing_revenue: i128,
+    anomaly_count: u32,
+    attestation_count: u64,
+    recorded_at: u64,
+) -> RestoreEntry {
+    RestoreEntry {
+        business: business.clone(),
+        period: String::from_str(env, period),
+        record: SnapshotRecord {
+            period: String::from_str(env, period),
+            trailing_revenue,
+            anomaly_count,
+            attestation_count,
+            recorded_at,
+        },
+        schema_version: SNAPSHOT_SCHEMA_VERSION,
+    }
 }
 
 // ── Initialization ───────────────────────────────────────────────────
@@ -421,4 +445,160 @@ fn test_set_attestation_contract_non_admin_panics() {
     let (_env, client, _admin) = setup_snapshot_only();
     let other = Address::generate(&_env);
     client.set_attestation_contract(&other, &None::<Address>);
+}
+
+// ── Restore version checking ───────────────────────────────────────────
+
+#[test]
+fn test_restore_dry_run_with_matching_version_succeeds() {
+    let (env, client, admin) = setup_snapshot_only();
+    let business = Address::generate(&env);
+
+    let entries = vec![
+        &env,
+        make_entry(&env, &business, "2026-01", 100_000i128, 0u32, 1u64, 1_000_000),
+    ];
+
+    let report = client.restore_dry_run(&admin, &entries);
+    assert!(report.ready_to_commit);
+    assert_eq!(report.entries_checked, 1);
+    assert_eq!(report.entries_valid, 1);
+    assert!(report.violations.is_empty());
+}
+
+#[test]
+#[should_panic(expected = "snapshot schema version mismatch")]
+fn test_restore_dry_run_with_older_version_fails() {
+    let (env, client, admin) = setup_snapshot_only();
+    let business = Address::generate(&env);
+
+    // Create an entry with an older schema version (0)
+    let mut entry = make_entry(&env, &business, "2026-01", 100_000i128, 0u32, 1u64, 1_000_000);
+    entry.schema_version = 0; // Older version
+
+    let entries = vec![&env, entry];
+    client.restore_dry_run(&admin, &entries);
+}
+
+#[test]
+#[should_panic(expected = "snapshot schema version mismatch")]
+fn test_restore_dry_run_with_newer_version_fails() {
+    let (env, client, admin) = setup_snapshot_only();
+    let business = Address::generate(&env);
+
+    // Create an entry with a newer schema version (999)
+    let mut entry = make_entry(&env, &business, "2026-01", 100_000i128, 0u32, 1u64, 1_000_000);
+    entry.schema_version = 999; // Newer version
+
+    let entries = vec![&env, entry];
+    client.restore_dry_run(&admin, &entries);
+}
+
+#[test]
+#[should_panic(expected = "snapshot schema version mismatch")]
+fn test_restore_commit_with_mismatched_version_fails() {
+    let (env, client, admin) = setup_snapshot_only();
+    let business = Address::generate(&env);
+
+    // First do a valid dry-run
+    let valid_entries = vec![
+        &env,
+        make_entry(&env, &business, "2026-01", 100_000i128, 0u32, 1u64, 1_000_000),
+    ];
+    client.restore_dry_run(&admin, &valid_entries);
+
+    // Now try to commit with a mismatched version (should fail even though dry-run passed)
+    let mut bad_entry = make_entry(&env, &business, "2026-01", 100_000i128, 0u32, 1u64, 1_000_000);
+    bad_entry.schema_version = 999;
+    let bad_entries = vec![&env, bad_entry];
+
+    client.restore_commit(&admin, &bad_entries);
+}
+
+#[test]
+#[should_panic(expected = "snapshot schema version mismatch")]
+fn test_restore_dry_run_multiple_entries_all_must_match_version() {
+    let (env, client, admin) = setup_snapshot_only();
+    let business1 = Address::generate(&env);
+    let business2 = Address::generate(&env);
+
+    // One valid, one invalid version
+    let mut entry1 = make_entry(&env, &business1, "2026-01", 100_000i128, 0u32, 1u64, 1_000_000);
+    let mut entry2 = make_entry(&env, &business2, "2026-01", 200_000i128, 1u32, 2u64, 2_000_000);
+    entry2.schema_version = 0; // Invalid version
+
+    let entries = vec![&env, entry1, entry2];
+    client.restore_dry_run(&admin, &entries);
+}
+
+#[test]
+#[should_panic(expected = "snapshot schema version mismatch")]
+fn test_restore_dry_run_missing_version_field_panics() {
+    // Test that entries without schema_version (default 0) are rejected
+    let (env, client, admin) = setup_snapshot_only();
+    let business = Address::generate(&env);
+
+    // Construct an entry with schema_version = 0 (simulating missing field)
+    let entry = RestoreEntry {
+        business: business.clone(),
+        period: String::from_str(&env, "2026-01"),
+        record: SnapshotRecord {
+            period: String::from_str(&env, "2026-01"),
+            trailing_revenue: 100_000i128,
+            anomaly_count: 0u32,
+            attestation_count: 1u64,
+            recorded_at: 1_000_000,
+        },
+        schema_version: 0, // Missing/zero version
+    };
+
+    let entries = vec![&env, entry];
+    client.restore_dry_run(&admin, &entries);
+}
+
+/// Test that RestoreVersionMismatchEvent is emitted with correct fields
+/// when a version mismatch is detected.
+#[test]
+fn test_restore_version_mismatch_event_emitted() {
+    let (env, client, admin) = setup_snapshot_only();
+    let business = Address::generate(&env);
+    env.ledger().with_mut(|l| l.timestamp = 5_000_000);
+
+    // Create an entry with wrong version
+    let mut entry = make_entry(&env, &business, "2026-01", 100_000i128, 0u32, 1u64, 1_000_000);
+    entry.schema_version = 999; // Wrong version
+
+    let entries = vec![&env, entry];
+
+    // Expect panic with version mismatch
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.restore_dry_run(&admin, &entries);
+    }));
+
+    assert!(result.is_err(), "Expected panic for version mismatch");
+
+    // Verify event was emitted
+    let events = env.events().all();
+    let mismatch_events: Vec<_> = events
+        .iter()
+        .filter_map(|(cid, topics, data)| {
+            if cid != client.address {
+                return None;
+            }
+            if topics.len() != 2 {
+                return None;
+            }
+            let sym = Symbol::try_from_val(&env, &topics.get(0).unwrap()).ok()?;
+            if sym != TOPIC_RESTORE_VERSION_MISMATCH {
+                return None;
+            }
+            RestoreVersionMismatchEvent::try_from_val(&env, &data).ok()
+        })
+        .collect();
+
+    assert_eq!(mismatch_events.len(), 1, "Expected exactly one RestoreVersionMismatchEvent");
+    let evt = &mismatch_events[0];
+    assert_eq!(evt.batch_version, 999);
+    assert_eq!(evt.expected_version, SNAPSHOT_SCHEMA_VERSION);
+    assert_eq!(evt.detected_at, 5_000_000);
 }


### PR DESCRIPTION

- Add SNAPSHOT_SCHEMA_VERSION constant (v1) for restore batch versioning
- Add schema_version field to RestoreEntry struct
- Add RestoreVersionMismatchEvent emitted before panic on version mismatch
- Add version validation in restore_dry_run (primary check)
- Add defence-in-depth version re-check in restore_commit
- Include schema_version in compute_batch_hash for tamper-proof binding
- Add MAX_RESTORE_BATCH and RESTORE_COMMIT_WINDOW_LEDGERS constants
- Comprehensive test coverage for version mismatch scenarios
- Updated documentation in module docs and function docstrings
closes #524 