### PR TITLE
feat: time-lock set_attestor_staking_contract with 24h delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Attestations can optionally include a SHA-256 hash pointing to a full off-chain 
 
 See [docs/offchain-proof-hash.md](docs/offchain-proof-hash.md) for the full specification, security assumptions, and usage guide.
 
+### Staking Contract Time-Lock
+
+Rebinding the attestor staking contract is a high-blast-radius operation. A 24-hour mandatory delay is enforced between proposing and committing a new staking contract address, giving monitoring systems and stakeholders time to detect and react to an unintended or hostile change.
+
+See [docs/timelock-staking-binding.md](docs/timelock-staking-binding.md) for the full specification, event catalog, security invariants, and operational runbook.
+
 ### Methods
 
 | Method                                                                                                | Description                                                                                                                    |

--- a/contracts/attestation/src/dynamic_fees.rs
+++ b/contracts/attestation/src/dynamic_fees.rs
@@ -99,6 +99,12 @@ pub enum DataKey {
     AttestorStakingContract,
     /// Address of the audit log contract for slash events.
     AuditLogContract,
+    /// Pending staking contract rebinding with activation timestamp.
+    ///
+    /// Written by `propose_staking_contract`; consumed by
+    /// `commit_staking_contract` or removed by
+    /// `cancel_pending_staking_contract`.
+    PendingStakingContract,
 
     // ── Fee system ──────────────────────────────────────────────
     /// Contract administrator address.
@@ -740,4 +746,52 @@ pub fn add_relayer_gas(env: &Env, relayer: &Address, gas: u64) {
     env.storage()
         .instance()
         .set(&DataKey::RelayerGasAccumulator(relayer.clone()), &new_total);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Pending Staking Contract (time-locked rebinding)
+// ════════════════════════════════════════════════════════════════════
+
+/// A pending staking-contract rebinding waiting for the timelock to expire.
+///
+/// Stored under [`DataKey::PendingStakingContract`].
+///
+/// The rebinding of the attestor staking contract is a high-blast-radius
+/// operation: pointing the contract at a malicious or misconfigured address
+/// could instantly break attestor eligibility checks for all businesses.
+/// Requiring a 24-hour delay gives monitoring systems and stakeholders time
+/// to detect and react to a hostile or accidental change before it takes
+/// effect.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct PendingStakingContract {
+    /// The staking contract address that will become active after `effective_at`.
+    pub new_contract: Address,
+    /// Ledger timestamp (Unix seconds) after which the rebinding may be committed.
+    ///
+    /// Set to `env.ledger().timestamp() + FEE_TIMELOCK_SECONDS` at proposal time.
+    pub effective_at: u64,
+    /// Address that proposed this rebinding.
+    pub proposed_by: Address,
+}
+
+/// Read the pending staking-contract proposal, if one exists.
+pub fn get_pending_staking_contract(env: &Env) -> Option<PendingStakingContract> {
+    env.storage()
+        .instance()
+        .get(&DataKey::PendingStakingContract)
+}
+
+/// Store a pending staking-contract proposal.
+pub fn set_pending_staking_contract(env: &Env, pending: &PendingStakingContract) {
+    env.storage()
+        .instance()
+        .set(&DataKey::PendingStakingContract, pending);
+}
+
+/// Remove any pending staking-contract proposal (after commit or cancel).
+pub fn clear_pending_staking_contract(env: &Env) {
+    env.storage()
+        .instance()
+        .remove(&DataKey::PendingStakingContract);
 }

--- a/contracts/attestation/src/events.rs
+++ b/contracts/attestation/src/events.rs
@@ -46,6 +46,9 @@
 //! | `EpochCheckpoint`           | `ep_ckpt`      | *(none)*          |
 //! | `EpochAdvanced`             | `ep_adv`       | *(none)*          |
 //! | `BackfillCheckpoint`        | `bkf_chk`      | *(none)*          |
+//! | `StakingContractProposed`   | `sk_prop`      | *(none)*          |
+//! | `StakingContractCommitted`  | `sk_com`       | *(none)*          |
+//! | `StakingContractCancelled`  | `sk_canc`      | *(none)*          |
 //!
 //! ## Indexer Compatibility Contract
 //!
@@ -164,6 +167,12 @@ pub const TOPIC_EPOCH_CHECKPOINT: Symbol = symbol_short!("ep_ckpt");
 pub const TOPIC_EPOCH_ADVANCED: Symbol = symbol_short!("ep_adv");
 /// Topic: backfill checkpoint emitted every N submissions (global counter)
 pub const TOPIC_BACKFILL_CHECKPOINT: Symbol = symbol_short!("bkf_chk");
+/// Topic: attestor staking contract rebinding proposed (24 h time-locked)
+pub const TOPIC_STAKING_CONTRACT_PROPOSED: Symbol = symbol_short!("sk_prop");
+/// Topic: attestor staking contract rebinding committed after timelock
+pub const TOPIC_STAKING_CONTRACT_COMMITTED: Symbol = symbol_short!("sk_com");
+/// Topic: attestor staking contract rebinding proposal cancelled
+pub const TOPIC_STAKING_CONTRACT_CANCELLED: Symbol = symbol_short!("sk_canc");
 
 // ════════════════════════════════════════════════════════════════════
 //  Normalized Event Data Structures
@@ -1980,4 +1989,122 @@ pub fn emit_backfill_checkpoint(
         state_commitment: state_commitment.clone(),
     };
     env.events().publish((TOPIC_BACKFILL_CHECKPOINT,), event);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Attestor Staking Contract Time-Lock Events
+// ════════════════════════════════════════════════════════════════════
+
+/// Normalized payload for `StakingContractProposed` events.
+///
+/// Emitted when an admin proposes a new attestor staking contract address.
+/// The change does not take effect until `commit_staking_contract` is
+/// called at least `FEE_TIMELOCK_SECONDS` (86 400 s / 24 h) later.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct StakingContractProposedEvent {
+    /// Proposed new staking contract address.
+    pub new_contract: Address,
+    /// Address that proposed the change.
+    pub proposed_by: Address,
+    /// Ledger timestamp (Unix seconds) after which the change may be committed.
+    pub effective_at: u64,
+}
+
+/// Normalized payload for `StakingContractCommitted` events.
+///
+/// Emitted when the proposed staking contract address is applied after the
+/// 24-hour timelock has elapsed.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct StakingContractCommittedEvent {
+    /// Staking contract address now in effect.
+    pub new_contract: Address,
+    /// Address that committed the change.
+    pub committed_by: Address,
+}
+
+/// Normalized payload for `StakingContractCancelled` events.
+///
+/// Emitted when a pending staking-contract proposal is cancelled before
+/// the timelock expires.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct StakingContractCancelledEvent {
+    /// Proposed address that was cancelled.
+    pub cancelled_contract: Address,
+    /// Address that cancelled the proposal.
+    pub cancelled_by: Address,
+}
+
+/// Emit a `StakingContractProposed` event.
+///
+/// # Arguments
+///
+/// * `env`          – Soroban execution environment.
+/// * `new_contract` – Proposed staking contract address.
+/// * `proposed_by`  – Admin that created the proposal.
+/// * `effective_at` – Earliest timestamp at which `commit_staking_contract` may be called.
+///
+/// # Events
+///
+/// Publishes `(sk_prop,)` → `StakingContractProposedEvent`.
+pub fn emit_staking_contract_proposed(
+    env: &Env,
+    new_contract: &Address,
+    proposed_by: &Address,
+    effective_at: u64,
+) {
+    let event = StakingContractProposedEvent {
+        new_contract: new_contract.clone(),
+        proposed_by: proposed_by.clone(),
+        effective_at,
+    };
+    env.events().publish((TOPIC_STAKING_CONTRACT_PROPOSED,), event);
+}
+
+/// Emit a `StakingContractCommitted` event.
+///
+/// # Arguments
+///
+/// * `env`          – Soroban execution environment.
+/// * `new_contract` – Staking contract address now in effect.
+/// * `committed_by` – Admin that committed the change.
+///
+/// # Events
+///
+/// Publishes `(sk_com,)` → `StakingContractCommittedEvent`.
+pub fn emit_staking_contract_committed(
+    env: &Env,
+    new_contract: &Address,
+    committed_by: &Address,
+) {
+    let event = StakingContractCommittedEvent {
+        new_contract: new_contract.clone(),
+        committed_by: committed_by.clone(),
+    };
+    env.events().publish((TOPIC_STAKING_CONTRACT_COMMITTED,), event);
+}
+
+/// Emit a `StakingContractCancelled` event.
+///
+/// # Arguments
+///
+/// * `env`               – Soroban execution environment.
+/// * `cancelled_contract` – The proposed address that was cancelled.
+/// * `cancelled_by`      – Admin that cancelled the proposal.
+///
+/// # Events
+///
+/// Publishes `(sk_canc,)` → `StakingContractCancelledEvent`.
+pub fn emit_staking_contract_cancelled(
+    env: &Env,
+    cancelled_contract: &Address,
+    cancelled_by: &Address,
+) {
+    let event = StakingContractCancelledEvent {
+        cancelled_contract: cancelled_contract.clone(),
+        cancelled_by: cancelled_by.clone(),
+    };
+    env.events().publish((TOPIC_STAKING_CONTRACT_CANCELLED,), event);
 }

--- a/contracts/attestation/src/lib.rs
+++ b/contracts/attestation/src/lib.rs
@@ -61,11 +61,14 @@ pub use dispute::{
 };
 pub use dynamic_fees::{add_relayer_gas, compute_fee, DataKey, FeeConfig, get_relayer_gas};
 pub use dynamic_fees::{RevokeProposal, DEFAULT_REVOKE_GRACE_SECONDS};
+pub use dynamic_fees::{PendingStakingContract};
 pub use events::{
     AttestationCleanedUpEvent, AttestationMigratedEvent, AttestationRevokedEvent,
     AttestationSubmittedEvent, ProofHashUpdatedEvent,
     RelayerGasReportedEvent,
     RevocationCancelledEvent, RevocationCommittedEvent, RevocationProposedEvent,
+    StakingContractProposedEvent, StakingContractCommittedEvent, StakingContractCancelledEvent,
+    TOPIC_STAKING_CONTRACT_PROPOSED, TOPIC_STAKING_CONTRACT_COMMITTED, TOPIC_STAKING_CONTRACT_CANCELLED,
 };
 pub use fees::{collect_flat_fee, CollectorRotationProposal, FlatFeeConfig};
 pub use multisig::{Proposal, ProposalAction, ProposalStatus};
@@ -170,6 +173,11 @@ mod backfill_checkpoint_test;
 /// reproduce without these tests).
 #[cfg(test)]
 mod vote_weight_snapshot_test;
+
+/// Staking contract time-lock tests. Covers propose → commit → apply flow,
+/// cancel, edge cases, authorization, and event emission.
+#[cfg(test)]
+mod timelock_staking_test;
 
 #[contractimpl]
 impl AttestationContract {
@@ -429,10 +437,106 @@ impl AttestationContract {
     }
 
     pub fn set_attestor_staking_contract(env: Env, caller: Address, staking_contract: Address) {
+        // This function is superseded by the time-locked rebinding flow.
+        // Use `propose_staking_contract` followed by `commit_staking_contract`
+        // (after at least 86 400 s / 24 h) instead.
+        panic!(
+            "set_attestor_staking_contract is disabled: \
+             use propose_staking_contract + commit_staking_contract (24 h timelock)"
+        );
+    }
+
+    /// Propose a new attestor staking contract address.
+    ///
+    /// The change enters a 24-hour time-lock (86 400 seconds) before it can be
+    /// committed.  Only one proposal may be pending at a time; cancel the
+    /// existing one with `cancel_pending_staking_contract` before creating a
+    /// new proposal.
+    ///
+    /// Rebinding the staking contract is a **high-blast-radius** operation.
+    /// Pointing the contract at a malicious or misconfigured address would
+    /// instantly break attestor eligibility checks for every business.  The
+    /// mandatory delay gives monitoring systems and stakeholders time to detect
+    /// and react to an unintended or hostile change.
+    ///
+    /// # Panics
+    /// - Caller does not have ADMIN role
+    /// - A pending staking contract proposal already exists (cancel it first)
+    pub fn propose_staking_contract(
+        env: Env,
+        caller: Address,
+        new_contract: Address,
+        nonce: u64,
+    ) {
         access_control::require_admin(&env, &caller);
+        let admin = dynamic_fees::require_admin(&env);
+        replay_protection::verify_and_increment_nonce(&env, &admin, NONCE_CHANNEL_ADMIN, nonce);
+        assert!(
+            dynamic_fees::get_pending_staking_contract(&env).is_none(),
+            "pending staking contract already scheduled"
+        );
+        let effective_at = env.ledger().timestamp() + dynamic_fees::FEE_TIMELOCK_SECONDS;
+        let pending = dynamic_fees::PendingStakingContract {
+            new_contract: new_contract.clone(),
+            effective_at,
+            proposed_by: admin.clone(),
+        };
+        dynamic_fees::set_pending_staking_contract(&env, &pending);
+        events::emit_staking_contract_proposed(&env, &new_contract, &admin, effective_at);
+    }
+
+    /// Commit a previously proposed staking contract address after its 24-hour
+    /// timelock has elapsed.
+    ///
+    /// Applies the pending address to the live staking contract slot and clears
+    /// the pending state.
+    ///
+    /// # Panics
+    /// - Caller does not have ADMIN role
+    /// - No pending staking contract proposal exists
+    /// - Timelock has not yet expired
+    pub fn commit_staking_contract(env: Env, caller: Address, nonce: u64) {
+        access_control::require_admin(&env, &caller);
+        let admin = dynamic_fees::require_admin(&env);
+        replay_protection::verify_and_increment_nonce(&env, &admin, NONCE_CHANNEL_ADMIN, nonce);
+        let pending = dynamic_fees::get_pending_staking_contract(&env)
+            .expect("no pending staking contract to commit");
+        assert!(
+            env.ledger().timestamp() >= pending.effective_at,
+            "timelock not yet expired"
+        );
         env.storage()
             .instance()
-            .set(&DataKey::AttestorStakingContract, &staking_contract);
+            .set(&DataKey::AttestorStakingContract, &pending.new_contract);
+        dynamic_fees::clear_pending_staking_contract(&env);
+        events::emit_staking_contract_committed(&env, &pending.new_contract, &admin);
+    }
+
+    /// Cancel a pending staking contract proposal.
+    ///
+    /// The live staking contract address is not affected.
+    ///
+    /// # Panics
+    /// - Caller does not have ADMIN role
+    /// - No pending staking contract proposal exists
+    pub fn cancel_pending_staking_contract(env: Env, caller: Address, nonce: u64) {
+        access_control::require_admin(&env, &caller);
+        let admin = dynamic_fees::require_admin(&env);
+        replay_protection::verify_and_increment_nonce(&env, &admin, NONCE_CHANNEL_ADMIN, nonce);
+        let pending = dynamic_fees::get_pending_staking_contract(&env)
+            .expect("no pending staking contract to cancel");
+        dynamic_fees::clear_pending_staking_contract(&env);
+        events::emit_staking_contract_cancelled(&env, &pending.new_contract, &admin);
+    }
+
+    /// Returns the pending staking contract proposal, if any.
+    ///
+    /// Observers (monitoring systems, DAO, community) can call this to detect
+    /// a pending rebinding before the timelock expires.
+    pub fn get_pending_staking_contract(
+        env: Env,
+    ) -> Option<dynamic_fees::PendingStakingContract> {
+        dynamic_fees::get_pending_staking_contract(&env)
     }
 
     pub fn get_attestor_staking_contract(env: Env) -> Option<Address> {

--- a/contracts/attestation/src/timelock_staking_test.rs
+++ b/contracts/attestation/src/timelock_staking_test.rs
@@ -1,0 +1,566 @@
+//! # Time-Locked Staking Contract Rebinding Tests
+//!
+//! Tests for the `propose_staking_contract` → `commit_staking_contract`
+//! flow that enforces a mandatory 24-hour delay before a staking contract
+//! rebinding takes effect.
+//!
+//! ## Coverage areas
+//!
+//! - **Happy path**: propose → advance past timelock → commit → verify live
+//! - **Accessor**: `get_pending_staking_contract` returns correct pending state
+//! - **Cancel**: pending proposal is removed without touching live address
+//! - **Timelock enforcement**: commit before delay panics with clear message
+//! - **Exact boundary**: commit at exactly `effective_at` succeeds
+//! - **Double-proposal guard**: second proposal without cancel panics
+//! - **Authorization**: non-admin cannot propose, commit, or cancel
+//! - **No-pending guards**: commit/cancel without a proposal panic
+//! - **Event emission**: all three events have correct topics and fields
+//! - **Live address unchanged until commit**: propose does not alter live slot
+//! - **Overwrite existing**: commit replaces a previously live address
+//! - **Re-propose after cancel**: can open a new proposal after cancelling
+//! - **Re-propose after commit**: can open a new proposal after committing
+//! - **Legacy entrypoint disabled**: `set_attestor_staking_contract` panics
+//! - **Long delay commit**: commit succeeds after much more than 24 h
+
+use super::*;
+use crate::dynamic_fees::FEE_TIMELOCK_SECONDS;
+use crate::events::{
+    StakingContractCancelledEvent, StakingContractCommittedEvent, StakingContractProposedEvent,
+    TOPIC_STAKING_CONTRACT_CANCELLED, TOPIC_STAKING_CONTRACT_COMMITTED,
+    TOPIC_STAKING_CONTRACT_PROPOSED,
+};
+use soroban_sdk::testutils::{Address as _, Events as _, Ledger as _};
+use soroban_sdk::{Address, Env, Symbol, TryFromVal};
+
+// ════════════════════════════════════════════════════════════════════
+//  Helpers
+// ════════════════════════════════════════════════════════════════════
+
+/// Bootstrap a fresh contract. Returns `(env, client, admin)`.
+fn setup() -> (Env, AttestationContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AttestationContract, ());
+    let client = AttestationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &0u64);
+    (env, client, admin)
+}
+
+/// Advance ledger timestamp by `seconds`.
+fn advance_time(env: &Env, seconds: u64) {
+    let now = env.ledger().timestamp();
+    env.ledger().set_timestamp(now + seconds);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Happy Path Tests
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_propose_and_commit_staking_contract() {
+    let (env, client, admin) = setup();
+    let staking_addr = Address::generate(&env);
+
+    // Initially no staking contract set
+    assert!(client.get_attestor_staking_contract().is_none());
+
+    client.propose_staking_contract(&admin, &staking_addr, &1u64);
+
+    // Live slot unchanged after proposal
+    assert!(client.get_attestor_staking_contract().is_none());
+
+    // Advance past timelock
+    advance_time(&env, FEE_TIMELOCK_SECONDS + 1);
+
+    client.commit_staking_contract(&admin, &2u64);
+
+    // Now the live address must match
+    assert_eq!(
+        client.get_attestor_staking_contract().unwrap(),
+        staking_addr
+    );
+    // Pending slot cleared
+    assert!(client.get_pending_staking_contract().is_none());
+}
+
+#[test]
+fn test_commit_at_exact_timelock_boundary_succeeds() {
+    let (env, client, admin) = setup();
+    let staking_addr = Address::generate(&env);
+
+    client.propose_staking_contract(&admin, &staking_addr, &1u64);
+    advance_time(&env, FEE_TIMELOCK_SECONDS); // exactly at effective_at
+
+    client.commit_staking_contract(&admin, &2u64);
+
+    assert_eq!(
+        client.get_attestor_staking_contract().unwrap(),
+        staking_addr
+    );
+}
+
+#[test]
+fn test_commit_long_after_timelock_succeeds() {
+    let (env, client, admin) = setup();
+    let staking_addr = Address::generate(&env);
+
+    client.propose_staking_contract(&admin, &staking_addr, &1u64);
+    // Advance one full year past the timelock
+    advance_time(&env, 365 * 86_400);
+
+    client.commit_staking_contract(&admin, &2u64);
+
+    assert_eq!(
+        client.get_attestor_staking_contract().unwrap(),
+        staking_addr
+    );
+}
+
+#[test]
+fn test_commit_overwrites_previously_live_address() {
+    let (env, client, admin) = setup();
+
+    // Arrange: manually put a live address in place via a prior propose+commit
+    let first = Address::generate(&env);
+    client.propose_staking_contract(&admin, &first, &1u64);
+    advance_time(&env, FEE_TIMELOCK_SECONDS + 1);
+    client.commit_staking_contract(&admin, &2u64);
+    assert_eq!(client.get_attestor_staking_contract().unwrap(), first);
+
+    // Now propose and commit a second address
+    let second = Address::generate(&env);
+    client.propose_staking_contract(&admin, &second, &3u64);
+    advance_time(&env, FEE_TIMELOCK_SECONDS + 1);
+    client.commit_staking_contract(&admin, &4u64);
+
+    assert_eq!(
+        client.get_attestor_staking_contract().unwrap(),
+        second
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Accessor Tests
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_get_pending_staking_contract_none_initially() {
+    let (_env, client, _admin) = setup();
+    assert!(client.get_pending_staking_contract().is_none());
+}
+
+#[test]
+fn test_get_pending_staking_contract_after_propose() {
+    let (env, client, admin) = setup();
+    let staking_addr = Address::generate(&env);
+
+    let before_ts = env.ledger().timestamp();
+    client.propose_staking_contract(&admin, &staking_addr, &1u64);
+
+    let pending = client.get_pending_staking_contract().unwrap();
+    assert_eq!(pending.new_contract, staking_addr);
+    assert_eq!(pending.proposed_by, admin);
+    assert_eq!(pending.effective_at, before_ts + FEE_TIMELOCK_SECONDS);
+}
+
+#[test]
+fn test_get_pending_staking_contract_cleared_after_commit() {
+    let (env, client, admin) = setup();
+    let staking_addr = Address::generate(&env);
+
+    client.propose_staking_contract(&admin, &staking_addr, &1u64);
+    advance_time(&env, FEE_TIMELOCK_SECONDS + 1);
+    client.commit_staking_contract(&admin, &2u64);
+
+    assert!(client.get_pending_staking_contract().is_none());
+}
+
+#[test]
+fn test_get_pending_staking_contract_cleared_after_cancel() {
+    let (env, client, admin) = setup();
+    let staking_addr = Address::generate(&env);
+
+    client.propose_staking_contract(&admin, &staking_addr, &1u64);
+    client.cancel_pending_staking_contract(&admin, &2u64);
+
+    assert!(client.get_pending_staking_contract().is_none());
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Cancel Tests
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_cancel_pending_staking_contract() {
+    let (env, client, admin) = setup();
+    let staking_addr = Address::generate(&env);
+
+    client.propose_staking_contract(&admin, &staking_addr, &1u64);
+    assert!(client.get_pending_staking_contract().is_some());
+
+    client.cancel_pending_staking_contract(&admin, &2u64);
+
+    assert!(client.get_pending_staking_contract().is_none());
+    // Live slot unaffected
+    assert!(client.get_attestor_staking_contract().is_none());
+}
+
+#[test]
+fn test_cancel_does_not_affect_live_address() {
+    let (env, client, admin) = setup();
+
+    // Put a live address in place
+    let live = Address::generate(&env);
+    client.propose_staking_contract(&admin, &live, &1u64);
+    advance_time(&env, FEE_TIMELOCK_SECONDS + 1);
+    client.commit_staking_contract(&admin, &2u64);
+    assert_eq!(client.get_attestor_staking_contract().unwrap(), live);
+
+    // Now propose a different address and cancel it
+    let new_addr = Address::generate(&env);
+    client.propose_staking_contract(&admin, &new_addr, &3u64);
+    client.cancel_pending_staking_contract(&admin, &4u64);
+
+    // Live address still points to `live`
+    assert_eq!(client.get_attestor_staking_contract().unwrap(), live);
+}
+
+#[test]
+fn test_can_re_propose_after_cancel() {
+    let (env, client, admin) = setup();
+    let addr_a = Address::generate(&env);
+    let addr_b = Address::generate(&env);
+
+    client.propose_staking_contract(&admin, &addr_a, &1u64);
+    client.cancel_pending_staking_contract(&admin, &2u64);
+
+    // A fresh proposal should succeed
+    client.propose_staking_contract(&admin, &addr_b, &3u64);
+
+    let pending = client.get_pending_staking_contract().unwrap();
+    assert_eq!(pending.new_contract, addr_b);
+}
+
+#[test]
+fn test_can_re_propose_after_commit() {
+    let (env, client, admin) = setup();
+    let addr_a = Address::generate(&env);
+    let addr_b = Address::generate(&env);
+
+    client.propose_staking_contract(&admin, &addr_a, &1u64);
+    advance_time(&env, FEE_TIMELOCK_SECONDS + 1);
+    client.commit_staking_contract(&admin, &2u64);
+
+    // A fresh proposal should succeed after commit
+    client.propose_staking_contract(&admin, &addr_b, &3u64);
+
+    let pending = client.get_pending_staking_contract().unwrap();
+    assert_eq!(pending.new_contract, addr_b);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Timelock Enforcement Tests
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+#[should_panic(expected = "timelock not yet expired")]
+fn test_commit_before_timelock_panics() {
+    let (env, client, admin) = setup();
+    let staking_addr = Address::generate(&env);
+
+    client.propose_staking_contract(&admin, &staking_addr, &1u64);
+    // Advance only half the required delay
+    advance_time(&env, FEE_TIMELOCK_SECONDS / 2);
+
+    client.commit_staking_contract(&admin, &2u64);
+}
+
+#[test]
+#[should_panic(expected = "timelock not yet expired")]
+fn test_commit_one_second_before_timelock_panics() {
+    let (env, client, admin) = setup();
+    let staking_addr = Address::generate(&env);
+
+    client.propose_staking_contract(&admin, &staking_addr, &1u64);
+    // One second short of the boundary
+    advance_time(&env, FEE_TIMELOCK_SECONDS - 1);
+
+    client.commit_staking_contract(&admin, &2u64);
+}
+
+#[test]
+#[should_panic(expected = "timelock not yet expired")]
+fn test_commit_immediately_after_proposal_panics() {
+    let (env, client, admin) = setup();
+    let staking_addr = Address::generate(&env);
+
+    client.propose_staking_contract(&admin, &staking_addr, &1u64);
+    // No time advance — try to commit immediately
+    client.commit_staking_contract(&admin, &2u64);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Double-Proposal Guard Tests
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+#[should_panic(expected = "pending staking contract already scheduled")]
+fn test_propose_twice_without_cancel_panics() {
+    let (env, client, admin) = setup();
+    let addr_a = Address::generate(&env);
+    let addr_b = Address::generate(&env);
+
+    client.propose_staking_contract(&admin, &addr_a, &1u64);
+    client.propose_staking_contract(&admin, &addr_b, &2u64);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  No-Pending Guard Tests
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+#[should_panic(expected = "no pending staking contract to commit")]
+fn test_commit_without_pending_panics() {
+    let (_env, client, admin) = setup();
+    client.commit_staking_contract(&admin, &1u64);
+}
+
+#[test]
+#[should_panic(expected = "no pending staking contract to cancel")]
+fn test_cancel_without_pending_panics() {
+    let (_env, client, admin) = setup();
+    client.cancel_pending_staking_contract(&admin, &1u64);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Authorization Tests
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+#[should_panic(expected = "caller does not have ADMIN role")]
+fn test_non_admin_cannot_propose() {
+    let (env, client, _admin) = setup();
+    let non_admin = Address::generate(&env);
+    let staking_addr = Address::generate(&env);
+
+    client.propose_staking_contract(&non_admin, &staking_addr, &0u64);
+}
+
+#[test]
+#[should_panic(expected = "caller does not have ADMIN role")]
+fn test_non_admin_cannot_commit() {
+    let (env, client, admin) = setup();
+    let non_admin = Address::generate(&env);
+    let staking_addr = Address::generate(&env);
+
+    client.propose_staking_contract(&admin, &staking_addr, &1u64);
+    advance_time(&env, FEE_TIMELOCK_SECONDS + 1);
+
+    client.commit_staking_contract(&non_admin, &0u64);
+}
+
+#[test]
+#[should_panic(expected = "caller does not have ADMIN role")]
+fn test_non_admin_cannot_cancel() {
+    let (env, client, admin) = setup();
+    let non_admin = Address::generate(&env);
+    let staking_addr = Address::generate(&env);
+
+    client.propose_staking_contract(&admin, &staking_addr, &1u64);
+
+    client.cancel_pending_staking_contract(&non_admin, &0u64);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Event Emission Tests
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_propose_emits_staking_contract_proposed_event() {
+    let (env, client, admin) = setup();
+    let staking_addr = Address::generate(&env);
+
+    let before_ts = env.ledger().timestamp();
+    client.propose_staking_contract(&admin, &staking_addr, &1u64);
+
+    let expected_effective_at = before_ts + FEE_TIMELOCK_SECONDS;
+
+    let events = env.events().all();
+    let last = events.last().unwrap();
+    let topics = last.1.clone();
+
+    // Exactly one topic
+    assert_eq!(topics.len(), 1);
+    assert_eq!(
+        Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap(),
+        TOPIC_STAKING_CONTRACT_PROPOSED
+    );
+
+    let ev = StakingContractProposedEvent::try_from_val(&env, &last.2).unwrap();
+    assert_eq!(ev.new_contract, staking_addr);
+    assert_eq!(ev.proposed_by, admin);
+    assert_eq!(ev.effective_at, expected_effective_at);
+}
+
+#[test]
+fn test_commit_emits_staking_contract_committed_event() {
+    let (env, client, admin) = setup();
+    let staking_addr = Address::generate(&env);
+
+    client.propose_staking_contract(&admin, &staking_addr, &1u64);
+    advance_time(&env, FEE_TIMELOCK_SECONDS + 1);
+    client.commit_staking_contract(&admin, &2u64);
+
+    let events = env.events().all();
+    let last = events.last().unwrap();
+    let topics = last.1.clone();
+
+    assert_eq!(topics.len(), 1);
+    assert_eq!(
+        Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap(),
+        TOPIC_STAKING_CONTRACT_COMMITTED
+    );
+
+    let ev = StakingContractCommittedEvent::try_from_val(&env, &last.2).unwrap();
+    assert_eq!(ev.new_contract, staking_addr);
+    assert_eq!(ev.committed_by, admin);
+}
+
+#[test]
+fn test_cancel_emits_staking_contract_cancelled_event() {
+    let (env, client, admin) = setup();
+    let staking_addr = Address::generate(&env);
+
+    client.propose_staking_contract(&admin, &staking_addr, &1u64);
+    client.cancel_pending_staking_contract(&admin, &2u64);
+
+    let events = env.events().all();
+    let last = events.last().unwrap();
+    let topics = last.1.clone();
+
+    assert_eq!(topics.len(), 1);
+    assert_eq!(
+        Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap(),
+        TOPIC_STAKING_CONTRACT_CANCELLED
+    );
+
+    let ev = StakingContractCancelledEvent::try_from_val(&env, &last.2).unwrap();
+    assert_eq!(ev.cancelled_contract, staking_addr);
+    assert_eq!(ev.cancelled_by, admin);
+}
+
+#[test]
+fn test_propose_does_not_emit_commit_event() {
+    let (env, client, admin) = setup();
+    let staking_addr = Address::generate(&env);
+
+    client.propose_staking_contract(&admin, &staking_addr, &1u64);
+
+    // No COMMITTED event should exist in the event log
+    let events = env.events().all();
+    let has_committed = events.iter().any(|(_, topics, _)| {
+        topics.len() == 1
+            && Symbol::try_from_val(&env, &topics.get(0).unwrap())
+                .map(|s: Symbol| s == TOPIC_STAKING_CONTRACT_COMMITTED)
+                .unwrap_or(false)
+    });
+    assert!(!has_committed);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Effective-At Accuracy Test
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_effective_at_is_exactly_timelock_seconds_from_proposal() {
+    let (env, client, admin) = setup();
+    let staking_addr = Address::generate(&env);
+
+    // Set a known ledger timestamp
+    env.ledger().set_timestamp(1_700_000_000u64);
+    let expected_effective_at = 1_700_000_000u64 + FEE_TIMELOCK_SECONDS;
+
+    client.propose_staking_contract(&admin, &staking_addr, &1u64);
+
+    let pending = client.get_pending_staking_contract().unwrap();
+    assert_eq!(pending.effective_at, expected_effective_at);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Legacy Entrypoint Disabled
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+#[should_panic(
+    expected = "set_attestor_staking_contract is disabled: use propose_staking_contract + commit_staking_contract (24 h timelock)"
+)]
+fn test_legacy_set_attestor_staking_contract_panics() {
+    let (env, client, admin) = setup();
+    let staking_addr = Address::generate(&env);
+
+    // The old direct-write entrypoint must be disabled
+    client.set_attestor_staking_contract(&admin, &staking_addr);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Interaction with Live Attestor Staking Slot
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_propose_does_not_change_live_slot() {
+    let (env, client, admin) = setup();
+
+    // First: put a live address via the timelock flow
+    let first = Address::generate(&env);
+    client.propose_staking_contract(&admin, &first, &1u64);
+    advance_time(&env, FEE_TIMELOCK_SECONDS + 1);
+    client.commit_staking_contract(&admin, &2u64);
+    assert_eq!(client.get_attestor_staking_contract().unwrap(), first);
+
+    // Now propose a second address — live slot must remain `first`
+    let second = Address::generate(&env);
+    client.propose_staking_contract(&admin, &second, &3u64);
+    assert_eq!(client.get_attestor_staking_contract().unwrap(), first);
+}
+
+#[test]
+fn test_pending_and_live_addresses_are_independent() {
+    let (env, client, admin) = setup();
+
+    // Commit a live address
+    let live = Address::generate(&env);
+    client.propose_staking_contract(&admin, &live, &1u64);
+    advance_time(&env, FEE_TIMELOCK_SECONDS + 1);
+    client.commit_staking_contract(&admin, &2u64);
+
+    // Propose another — both should be independently readable
+    let pending_addr = Address::generate(&env);
+    client.propose_staking_contract(&admin, &pending_addr, &3u64);
+
+    assert_eq!(client.get_attestor_staking_contract().unwrap(), live);
+    assert_eq!(
+        client.get_pending_staking_contract().unwrap().new_contract,
+        pending_addr
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Security: Nonce Replay Prevention
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+#[should_panic]
+fn test_propose_replay_with_same_nonce_panics() {
+    let (env, client, admin) = setup();
+    let addr_a = Address::generate(&env);
+    let addr_b = Address::generate(&env);
+
+    // First proposal with nonce 1
+    client.propose_staking_contract(&admin, &addr_a, &1u64);
+    // Cancel it to clear the pending slot
+    client.cancel_pending_staking_contract(&admin, &2u64);
+
+    // Attempting to reuse nonce 1 must fail (replay protection)
+    client.propose_staking_contract(&admin, &addr_b, &1u64);
+}

--- a/docs/timelock-staking-binding.md
+++ b/docs/timelock-staking-binding.md
@@ -1,0 +1,227 @@
+# Attestor Staking Contract Time-Lock Rebinding
+
+This document specifies the 24-hour time-lock mechanism that governs changes to
+the attestor staking contract address in the Veritasor attestation protocol.
+
+## Background
+
+The attestor staking contract (`AttestorStakingContract`) is a critical
+pointer: every attestation submission validates attestor eligibility by
+calling `is_eligible` on this address.  Rebinding this pointer to a wrong or
+malicious address can instantly compromise the economic security layer for all
+businesses and lenders on the protocol.
+
+To mitigate this risk, any rebinding must go through a mandatory two-step,
+time-locked process that mirrors the fee-configuration time-lock and the
+multisig timing constraints described in
+[`attestation-multisig-timing.md`](attestation-multisig-timing.md).
+
+---
+
+## Two-Step Rebinding Flow
+
+### Step 1 — Propose
+
+```
+propose_staking_contract(caller: Address, new_contract: Address, nonce: u64)
+```
+
+- Requires ADMIN role.
+- Stores a `PendingStakingContract` record containing:
+  - `new_contract` — the proposed address.
+  - `effective_at` — `ledger.timestamp() + 86 400` (Unix seconds).
+  - `proposed_by` — the admin address.
+- **Does not** touch the live staking contract address.
+- Emits `StakingContractProposed` (`sk_prop`).
+- Panics if a proposal is already pending (cancel the existing proposal first).
+- Uses a monotonic admin nonce to prevent replay attacks.
+
+### Step 2 — Commit
+
+```
+commit_staking_contract(caller: Address, nonce: u64)
+```
+
+- Requires ADMIN role.
+- Panics with `"timelock not yet expired"` if
+  `ledger.timestamp() < pending.effective_at`.
+- Writes `pending.new_contract` to the live `AttestorStakingContract` slot.
+- Clears the pending record.
+- Emits `StakingContractCommitted` (`sk_com`).
+- Uses a monotonic admin nonce.
+
+---
+
+## Cancel
+
+```
+cancel_pending_staking_contract(caller: Address, nonce: u64)
+```
+
+- Requires ADMIN role.
+- Removes the pending record without altering the live address.
+- Emits `StakingContractCancelled` (`sk_canc`).
+- Panics if no proposal is pending.
+- Uses a monotonic admin nonce.
+
+---
+
+## Observer Accessor
+
+```
+get_pending_staking_contract() -> Option<PendingStakingContract>
+```
+
+Returns the pending proposal if one exists.  Off-chain monitoring systems and
+DAO tooling should poll or index this accessor to detect pending rebindings
+within the 24-hour observation window.
+
+Fields of `PendingStakingContract`:
+
+| Field          | Type      | Description                                       |
+|----------------|-----------|---------------------------------------------------|
+| `new_contract` | `Address` | Proposed staking contract address.                |
+| `effective_at` | `u64`     | Unix timestamp after which commit is allowed.     |
+| `proposed_by`  | `Address` | Admin address that created the proposal.          |
+
+---
+
+## Timing
+
+| Parameter              | Value      | Notes                              |
+|------------------------|------------|------------------------------------|
+| Delay                  | 86 400 s   | Exactly 24 hours in Unix time.     |
+| Enforce at commit      | `>=` check | `ledger.timestamp() >= effective_at` |
+| Maximum pending        | 1          | Only one proposal at a time.       |
+| Proposal expiry        | None       | Pending proposals do not expire.   |
+
+The `effective_at` boundary uses a `>=` (inclusive) check, consistent with the
+fee-configuration time-lock.  A commit at exactly `ledger.timestamp() ==
+effective_at` succeeds.
+
+---
+
+## Events
+
+All three operations emit structured, indexed events.
+
+### `StakingContractProposed` — topic `sk_prop`
+
+```rust
+pub struct StakingContractProposedEvent {
+    pub new_contract: Address,   // Proposed address
+    pub proposed_by:  Address,   // Admin who proposed
+    pub effective_at: u64,       // Timestamp after which commit is allowed
+}
+```
+
+### `StakingContractCommitted` — topic `sk_com`
+
+```rust
+pub struct StakingContractCommittedEvent {
+    pub new_contract: Address,   // Address now in effect
+    pub committed_by: Address,   // Admin who committed
+}
+```
+
+### `StakingContractCancelled` — topic `sk_canc`
+
+```rust
+pub struct StakingContractCancelledEvent {
+    pub cancelled_contract: Address,  // Proposed address that was cancelled
+    pub cancelled_by:       Address,  // Admin who cancelled
+}
+```
+
+Indexers should monitor `sk_prop` events to surface pending rebindings to the
+community before `effective_at` arrives.
+
+---
+
+## Legacy Entrypoint
+
+The former `set_attestor_staking_contract` function is **disabled** and will
+always panic with a descriptive message directing callers to the new flow:
+
+```
+set_attestor_staking_contract is disabled:
+use propose_staking_contract + commit_staking_contract (24 h timelock)
+```
+
+This is an intentional breaking change.  Any existing scripts or integrations
+that called `set_attestor_staking_contract` must migrate to the two-step flow.
+
+---
+
+## Security Invariants
+
+1. **No immediate write**: The live staking contract address can never be
+   changed in a single transaction.  There is always a minimum 86 400-second
+   gap between proposal and effect.
+
+2. **One pending proposal at a time**: A second `propose_staking_contract` call
+   panics while a proposal is pending.  This prevents a griefing attack where
+   an admin queues many proposals to confuse observers.
+
+3. **Replay protection**: Each of the three entrypoints consumes the next admin
+   nonce, making it impossible to replay a captured transaction.
+
+4. **Admin-only**: All three operations require the `ROLE_ADMIN` role.  The
+   access check is performed before the nonce is consumed, so failed attempts
+   do not advance the nonce counter.
+
+5. **Observation window**: The 24-hour delay gives off-chain systems (alerting,
+   DAO governance, community) a meaningful window to detect and react to a
+   hostile or accidental proposal.
+
+6. **Atomic commit**: The live address and the pending record are updated
+   in the same ledger transaction.  There is no intermediate state where both
+   the old and new contracts are simultaneously active.
+
+7. **Cancel is non-destructive**: Cancelling a proposal never modifies the live
+   address.  Rollback cost is minimal and always safe.
+
+---
+
+## Operational Runbook
+
+### Normal rebinding
+
+```bash
+# Step 1: Propose (admin key required)
+stellar contract invoke --id <CONTRACT> -- propose_staking_contract \
+  --caller <ADMIN> \
+  --new_contract <NEW_STAKING_CONTRACT> \
+  --nonce <NONCE>
+
+# Wait at least 86 400 seconds (24 hours) ...
+
+# Step 2: Verify pending before committing
+stellar contract invoke --id <CONTRACT> -- get_pending_staking_contract
+
+# Step 3: Commit
+stellar contract invoke --id <CONTRACT> -- commit_staking_contract \
+  --caller <ADMIN> \
+  --nonce <NEXT_NONCE>
+```
+
+### Emergency cancel
+
+```bash
+stellar contract invoke --id <CONTRACT> -- cancel_pending_staking_contract \
+  --caller <ADMIN> \
+  --nonce <NEXT_NONCE>
+```
+
+---
+
+## Relationship to Other Time-Locks
+
+| Feature                     | Mechanism                        | Delay     |
+|-----------------------------|----------------------------------|-----------|
+| Fee configuration change    | `propose_fee_config`             | 86 400 s  |
+| Staking contract rebinding  | `propose_staking_contract`       | 86 400 s  |
+| Revocation grace window     | `propose_revoke`                 | 86 400 s  |
+
+All three use the same `FEE_TIMELOCK_SECONDS = 86_400` constant defined in
+`contracts/attestation/src/dynamic_fees.rs`.


### PR DESCRIPTION
Rebinding the attestor staking contract is a high-blast-radius operation that must not be immediately executable even by an admin. This commit enforces a mandatory 24-hour delay between proposal and execution, mirroring the existing fee-configuration time-lock pattern.

Changes:
- dynamic_fees.rs: add DataKey::PendingStakingContract variant, PendingStakingContract struct, and get/set/clear helpers
- events.rs: add TOPIC_STAKING_CONTRACT_PROPOSED/COMMITTED/CANCELLED topic symbols, event structs, and emit functions
- lib.rs: disable set_attestor_staking_contract (panics with redirect message); add propose_staking_contract, commit_staking_contract, cancel_pending_staking_contract, get_pending_staking_contract; re-export new types and declare test module
- timelock_staking_test.rs: 26 tests covering happy path, timelock boundary enforcement, cancel, authorization, event emission, effective_at accuracy, legacy entrypoint guard, live/pending slot independence, double-proposal guard, and nonce replay prevention
- docs/timelock-staking-binding.md: full specification including background, two-step flow, event catalog, security invariants, operational runbook, and relation to other time-locks
- README.md: add Staking Contract Time-Lock section and doc link

Security invariants:
- No immediate write: live address cannot change in a single tx
- One pending proposal at a time prevents observer confusion
- Replay protection via monotonic admin nonce on all three entrypoints
- 24h observation window for monitoring systems and DAO governance
- Atomic commit: live address and pending record updated together
- closes #458