### PR TITLE
test: invariant fee collection equals event sum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,6 +833,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "kani"
+version = "0.57.0"
+source = "git+https://github.com/model-checking/kani?tag=kani-0.57.0#9fd39c0023bc31956fe77db6c4ece7a5cc24e5a8"
+dependencies = [
+ "kani_core",
+ "kani_macros",
+]
+
+[[package]]
+name = "kani_core"
+version = "0.57.0"
+source = "git+https://github.com/model-checking/kani?tag=kani-0.57.0#9fd39c0023bc31956fe77db6c4ece7a5cc24e5a8"
+dependencies = [
+ "kani_macros",
+]
+
+[[package]]
+name = "kani_macros"
+version = "0.57.0"
+source = "git+https://github.com/model-checking/kani?tag=kani-0.57.0#9fd39c0023bc31956fe77db6c4ece7a5cc24e5a8"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,6 +1032,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1742,6 +1792,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "hex",
+ "kani",
  "proptest",
  "serde",
  "serde_json",

--- a/contracts/attestation/src/events.rs
+++ b/contracts/attestation/src/events.rs
@@ -137,7 +137,7 @@ pub const TOPIC_KEY_ROTATION_CANCELLED: Symbol = symbol_short!("kr_canc");
 /// Topic: emergency key rotation executed
 pub const TOPIC_KEY_ROTATION_EMERGENCY: Symbol = symbol_short!("kr_emer");
 /// Topic: emergency pause triggered (dual-key bypass)
-pub const TOPIC_EMERGENCY_PAUSE_TRIGGERED: Symbol = symbol_short!("emer_pause");
+pub const TOPIC_EMERGENCY_PAUSE_TRIGGERED: Symbol = symbol_short!("emr_pse");
 /// Topic: business registered
 pub const TOPIC_BIZ_REGISTERED: Symbol = symbol_short!("biz_reg");
 /// Topic: business approved
@@ -160,8 +160,6 @@ pub const TOPIC_REVOCATION_COMMITTED: Symbol = symbol_short!("rv_cmmt");
 pub const TOPIC_APPROVAL_REVOKED: Symbol = symbol_short!("appr_rv");
 /// Topic: epoch checkpoint emitted after each submission (per-period)
 pub const TOPIC_EPOCH_CHECKPOINT: Symbol = symbol_short!("ep_ckpt");
-/// Topic: epoch advanced on fee-bucket window rollover
-pub const TOPIC_EPOCH_ADVANCED: Symbol = symbol_short!("ep_adv");
 /// Topic: backfill checkpoint emitted every N submissions (global counter)
 pub const TOPIC_BACKFILL_CHECKPOINT: Symbol = symbol_short!("bkf_chk");
 
@@ -1859,23 +1857,6 @@ pub struct EpochCheckpointEvent {
     pub fees_collected: i128,
     /// Ledger timestamp at checkpoint emission.
     pub checkpoint_timestamp: u64,
-}
-
-/// Normalized payload for `EpochAdvanced` events.
-///
-/// Emitted when the fee-bucket window rolls over, incrementing the
-/// monotonic epoch counter. One event is emitted per elapsed window.
-///
-/// | Event Catalog | Topic | Secondary topic |
-/// |---|---|--|
-/// | EpochAdvanced | `ep_adv` | *(none)* |
-#[contracttype]
-#[derive(Clone, Debug)]
-pub struct EpochAdvancedEvent {
-    /// New epoch value after the rollover.
-    pub epoch: u64,
-    /// Ledger timestamp at which the rollover was detected.
-    pub at_ts: u64,
 }
 
 /// Normalized payload for `BackfillCheckpoint` events.

--- a/contracts/attestation/src/fee_reconciliation_test.rs
+++ b/contracts/attestation/src/fee_reconciliation_test.rs
@@ -9,10 +9,12 @@ use std::format;
 
 use super::*;
 use crate::dynamic_fees::compute_fee;
+use crate::events::{AttestationSubmittedEvent, TOPIC_ATTESTATION_SUBMITTED};
 use proptest::prelude::*;
 use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::Events as _;
 use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
-use soroban_sdk::{vec, Address, Env, String};
+use soroban_sdk::{vec, Address, BytesN, Env, String, Symbol, TryFromVal};
 
 struct Ctx {
     env: Env,
@@ -263,5 +265,91 @@ proptest! {
             .get_attestation(&business, &String::from_str(&ctx.env, "2026-prop"))
             .unwrap();
         prop_assert_eq!(stored.3, quote);
+    }
+
+    /// Invariant: sum of collector balance deltas across all submissions equals
+    /// sum of `fee_paid` from all `AttestationSubmittedEvent` events.
+    ///
+    /// Guards against silent event drift where the actual fee transfer diverges
+    /// from what the event payload reports.
+    #[test]
+    fn prop_fee_collected_matches_event_sum(
+        base_fee in 0i128..=1_000_000i128,
+        tier_bps in 0u32..=10_000u32,
+        vol_bps in 0u32..=10_000u32,
+        flat_amount in 0i128..=10_000i128,
+        flat_enabled in proptest::bool::ANY,
+        num_submissions in 0u32..=10u32,
+    ) {
+        let ctx = fresh_ctx();
+        let business = Address::generate(&ctx.env);
+        let collector = Address::generate(&ctx.env);
+        let token = deploy_and_fund(&ctx.env, &business, 1_000_000_000_000);
+
+        ctx.client.configure_fees(&token, &collector, &base_fee, &true);
+        ctx.client.set_tier_discount(&1, &tier_bps);
+        ctx.client.set_business_tier(&business, &1);
+        if vol_bps > 0 {
+            let thresholds = vec![&ctx.env, 1u64];
+            let discounts = vec![&ctx.env, vol_bps];
+            ctx.client.set_volume_brackets(&thresholds, &discounts);
+        }
+        ctx.client.configure_flat_fee(&token, &collector, &flat_amount, &flat_enabled);
+
+        let contract_id = ctx.client.address.clone();
+        let token_client = TokenClient::new(&ctx.env, &token);
+        let mut cumulative_event_fee: i128 = 0;
+        let initial_collector_balance = token_client.balance(&collector);
+
+        for i in 0..num_submissions {
+            let fee_quote = ctx.client.get_fee_quote(&business);
+            let fund_needed = fee_quote.saturating_mul(2).saturating_add(10_000_000);
+            StellarAssetClient::new(&ctx.env, &token).mint(&business, &fund_needed);
+
+            let period_str = std::format!("pi-{i}");
+            let period = String::from_str(&ctx.env, &period_str);
+            let root = BytesN::from_array(&ctx.env, &[i as u8; 32]);
+            ctx.client.submit_attestation(
+                &business,
+                &period,
+                &root,
+                &1_700_000_000u64,
+                &1u32,
+                &0i128,
+                &None,
+                &None,
+            );
+
+            let last_fee = ctx
+                .env
+                .events()
+                .all()
+                .iter()
+                .rev()
+                .find_map(|(cid, topics, data)| {
+                    if &cid != &contract_id || topics.len() != 2 {
+                        return None;
+                    }
+                    let sym = Symbol::try_from_val(&ctx.env, &topics.get(0).unwrap()).ok()?;
+                    if sym != TOPIC_ATTESTATION_SUBMITTED {
+                        return None;
+                    }
+                    AttestationSubmittedEvent::try_from_val(&ctx.env, &data).ok()
+                })
+                .map(|ev| ev.fee_paid)
+                .unwrap_or(0);
+
+            let stored = ctx.client.get_attestation(&business, &period).unwrap();
+            prop_assert_eq!(stored.3, fee_quote, "stored fee_paid must match quote");
+
+            cumulative_event_fee += last_fee;
+            let collector_delta =
+                token_client.balance(&collector) - initial_collector_balance;
+            prop_assert_eq!(
+                collector_delta,
+                cumulative_event_fee,
+                "cumulative collector delta must equal cumulative event fee_paid after submission {i}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #505

## Description
Adds an invariant property test asserting that the sum of collected fees (via balance delta on the collector address) equals the sum of amounts emitted in `FeeCollected` events. Guards against silent event drift.

## Changes

### `contracts/attestation/src/fee_reconciliation_test.rs`
- Added `prop_fee_collected_matches_event_sum` proptest that generates randomized submission sequences
- Tracks cumulative collector balance delta and cumulative event `fee_paid` sum
- Asserts equality at each checkpoint

### `contracts/attestation/src/events.rs`
- Fixed compilation errors: shortened `symbol_short!("emer_pause")` to `"emr_pse"` (was 10 chars, max 9)
- Removed duplicate `TOPIC_EPOCH_ADVANCED` constant definition
- Removed duplicate `EpochAdvancedEvent` struct definition

## Testing
- Run `cargo test --all` to verify fee reconciliation tests