### PR TITLE
feat: per-epoch cleanup metrics counter

### DIFF
--- a/contracts/attestation/src/cleanup_metrics_test.rs
+++ b/contracts/attestation/src/cleanup_metrics_test.rs
@@ -1,0 +1,392 @@
+//! # Cleanup Metrics Counter Tests — Issue #531
+//!
+//! Verifies per-epoch cleanup counters (`CleanupCountForEpoch`) and the
+//! `CleanupSummary` event emitted at each fee-bucket epoch boundary.
+//!
+//! ## Coverage map
+//!
+//! | Test | Scenario |
+//! |------|----------|
+//! | `test_cleanup_count_starts_at_zero` | Uninitialized epoch reads as 0 |
+//! | `test_single_cleanup_increments_current_epoch` | One cleanup → count 1 |
+//! | `test_variable_cleanup_counts_in_epoch` | N cleanups → count N |
+//! | `test_cleanup_summary_zero_on_epoch_advance` | Boundary with 0 cleanups |
+//! | `test_cleanup_summary_reports_prior_epoch_count` | Boundary carries removed count |
+//! | `test_cleanup_counts_isolated_per_epoch` | Counts do not leak across epochs |
+//! | `test_revoke_and_cleanup_increments_counter` | Alternate cleanup path counted |
+//! | `test_failed_cleanup_does_not_increment` | Panic path leaves counter unchanged |
+//! | `test_cleanup_summary_event_schema` | Topic + payload fields |
+//! | `test_get_cleanup_count_matches_summary_event` | Getter == last summary |
+//!
+//! ## Security invariants validated
+//!
+//! - Counter increments only after a successful cleanup removes storage.
+//! - Unauthorized / not-found / not-expired cleanups do not change the counter
+//!   (asserted via `should_panic` + post-condition on sibling happy paths).
+//! - `CleanupSummary` is emitted only from the epoch-rollover path; external
+//!   callers cannot manufacture the event.
+//! - Per-epoch keys are isolated: advancing the epoch never mutates prior
+//!   epoch counters.
+//! - Zero-cleanup epochs still emit a summary so operators can distinguish
+//!   "no cleanup needed" from "cleanup path silent / broken".
+
+#![cfg(test)]
+
+extern crate std;
+
+use super::*;
+use crate::dynamic_fees::FEE_BUCKET_WINDOW_SECONDS;
+use crate::events::{CleanupSummaryEvent, TOPIC_CLEANUP_SUMMARY};
+use soroban_sdk::testutils::{Address as _, Events as _, Ledger as _};
+use soroban_sdk::{Address, BytesN, Env, String, Symbol, TryFromVal};
+
+// ════════════════════════════════════════════════════════════════════
+//  Helpers
+// ════════════════════════════════════════════════════════════════════
+
+fn setup() -> (Env, AttestationContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AttestationContract, ());
+    let client = AttestationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &0u64);
+    (env, client, admin)
+}
+
+fn submit_with_expiry(
+    client: &AttestationContractClient,
+    env: &Env,
+    business: &Address,
+    period: &str,
+    root_byte: u8,
+    expiry: u64,
+) {
+    let period = String::from_str(env, period);
+    let root = BytesN::from_array(env, &[root_byte; 32]);
+    client.submit_attestation(
+        business,
+        &period,
+        &root,
+        &(env.ledger().timestamp().saturating_add(1)),
+        &1u32,
+        &0i128,
+        &None,
+        &Some(expiry),
+    );
+}
+
+fn cleanup_one(
+    client: &AttestationContractClient,
+    env: &Env,
+    caller: &Address,
+    business: &Address,
+    period: &str,
+) {
+    let period = String::from_str(env, period);
+    client.cleanup_expired_attestation(caller, business, &period);
+}
+
+/// Collect all `CleanupSummary` events from the environment.
+fn cleanup_summary_events(env: &Env) -> std::vec::Vec<CleanupSummaryEvent> {
+    env.events()
+        .all()
+        .iter()
+        .filter_map(|(_cid, topics, data)| {
+            if topics.len() == 1 {
+                if let Ok(sym) = Symbol::try_from_val(env, &topics.get(0).unwrap()) {
+                    if sym == TOPIC_CLEANUP_SUMMARY {
+                        return CleanupSummaryEvent::try_from_val(env, &data).ok();
+                    }
+                }
+            }
+            None
+        })
+        .collect()
+}
+
+/// Expiry shortly after the current ledger timestamp.
+fn near_expiry(env: &Env) -> u64 {
+    env.ledger().timestamp().saturating_add(50)
+}
+
+/// Far-future expiry that will not elapse during the test.
+fn far_expiry(env: &Env) -> u64 {
+    env.ledger().timestamp().saturating_add(9_999_999)
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  1. Initial state
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_cleanup_count_starts_at_zero() {
+    let (_env, client, _admin) = setup();
+    assert_eq!(
+        client.get_cleanup_count_for_epoch(&0u64),
+        0,
+        "missing CleanupCountForEpoch must read as 0"
+    );
+    assert_eq!(client.get_cleanup_count_for_epoch(&1u64), 0);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  2. Increment on successful cleanup
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_single_cleanup_increments_current_epoch() {
+    let (env, client, admin) = setup();
+    env.ledger().set_timestamp(FEE_BUCKET_WINDOW_SECONDS);
+
+    let business = Address::generate(&env);
+    let expiry = near_expiry(&env);
+    submit_with_expiry(&client, &env, &business, "202601", 1, expiry);
+    // First submission advances epoch 0 → 1.
+    assert_eq!(client.get_epoch(), 1);
+
+    env.ledger().set_timestamp(expiry);
+    cleanup_one(&client, &env, &admin, &business, "202601");
+
+    assert_eq!(
+        client.get_cleanup_count_for_epoch(&1u64),
+        1,
+        "successful cleanup must increment current epoch counter"
+    );
+    assert_eq!(
+        client.get_cleanup_count_for_epoch(&0u64),
+        0,
+        "prior epoch counter must remain untouched"
+    );
+}
+
+#[test]
+fn test_variable_cleanup_counts_in_epoch() {
+    let (env, client, admin) = setup();
+    env.ledger().set_timestamp(FEE_BUCKET_WINDOW_SECONDS);
+
+    let business = Address::generate(&env);
+    let expiry = near_expiry(&env);
+    for i in 0..5u8 {
+        let period = match i {
+            0 => "p0",
+            1 => "p1",
+            2 => "p2",
+            3 => "p3",
+            _ => "p4",
+        };
+        submit_with_expiry(&client, &env, &business, period, i + 1, expiry);
+    }
+    assert_eq!(client.get_epoch(), 1);
+
+    env.ledger().set_timestamp(expiry);
+    for period in ["p0", "p1", "p2", "p3", "p4"] {
+        cleanup_one(&client, &env, &admin, &business, period);
+    }
+
+    assert_eq!(
+        client.get_cleanup_count_for_epoch(&1u64),
+        5,
+        "each successful cleanup must increment the counter"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  3. CleanupSummary on epoch advance
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_cleanup_summary_zero_on_epoch_advance() {
+    let (env, client, _admin) = setup();
+    env.ledger().set_timestamp(FEE_BUCKET_WINDOW_SECONDS);
+
+    let business = Address::generate(&env);
+    submit_with_expiry(
+        &client,
+        &env,
+        &business,
+        "202601",
+        1,
+        far_expiry(&env),
+    );
+
+    let summaries = cleanup_summary_events(&env);
+    assert!(
+        !summaries.is_empty(),
+        "epoch init must emit CleanupSummary for ending epoch 0"
+    );
+    let first = &summaries[0];
+    assert_eq!(first.epoch, 0);
+    assert_eq!(
+        first.removed_count, 0,
+        "epoch with zero cleanups must still emit removed_count = 0"
+    );
+}
+
+#[test]
+fn test_cleanup_summary_reports_prior_epoch_count() {
+    let (env, client, admin) = setup();
+    env.ledger().set_timestamp(FEE_BUCKET_WINDOW_SECONDS);
+
+    let business = Address::generate(&env);
+    let expiry = near_expiry(&env);
+    submit_with_expiry(&client, &env, &business, "p0", 1, expiry);
+    submit_with_expiry(&client, &env, &business, "p1", 2, expiry);
+    submit_with_expiry(&client, &env, &business, "p2", 3, expiry);
+    assert_eq!(client.get_epoch(), 1);
+
+    env.ledger().set_timestamp(expiry);
+    cleanup_one(&client, &env, &admin, &business, "p0");
+    cleanup_one(&client, &env, &admin, &business, "p1");
+    cleanup_one(&client, &env, &admin, &business, "p2");
+    assert_eq!(client.get_cleanup_count_for_epoch(&1u64), 3);
+
+    // Cross into the next fee-bucket window.
+    env.ledger().set_timestamp(FEE_BUCKET_WINDOW_SECONDS * 2);
+    submit_with_expiry(
+        &client,
+        &env,
+        &business,
+        "next",
+        9,
+        far_expiry(&env),
+    );
+    assert_eq!(client.get_epoch(), 2);
+
+    let summaries = cleanup_summary_events(&env);
+    let for_epoch_1: std::vec::Vec<_> = summaries.iter().filter(|s| s.epoch == 1).collect();
+    assert_eq!(
+        for_epoch_1.len(),
+        1,
+        "exactly one CleanupSummary for ending epoch 1"
+    );
+    assert_eq!(for_epoch_1[0].removed_count, 3);
+    assert_eq!(
+        for_epoch_1[0].at_ts,
+        FEE_BUCKET_WINDOW_SECONDS * 2,
+        "at_ts must match ledger timestamp at emission"
+    );
+}
+
+#[test]
+fn test_cleanup_counts_isolated_per_epoch() {
+    let (env, client, admin) = setup();
+    env.ledger().set_timestamp(FEE_BUCKET_WINDOW_SECONDS);
+
+    let business = Address::generate(&env);
+    let expiry_e1 = near_expiry(&env);
+    submit_with_expiry(&client, &env, &business, "e1a", 1, expiry_e1);
+    submit_with_expiry(&client, &env, &business, "e1b", 2, expiry_e1);
+
+    env.ledger().set_timestamp(expiry_e1);
+    cleanup_one(&client, &env, &admin, &business, "e1a");
+    cleanup_one(&client, &env, &admin, &business, "e1b");
+    assert_eq!(client.get_cleanup_count_for_epoch(&1u64), 2);
+
+    // Advance to epoch 2 and clean one more attestation submitted in the new window.
+    env.ledger().set_timestamp(FEE_BUCKET_WINDOW_SECONDS * 2);
+    let expiry_e2 = near_expiry(&env);
+    submit_with_expiry(&client, &env, &business, "e2a", 3, expiry_e2);
+    assert_eq!(client.get_epoch(), 2);
+
+    env.ledger().set_timestamp(expiry_e2);
+    cleanup_one(&client, &env, &admin, &business, "e2a");
+
+    assert_eq!(client.get_cleanup_count_for_epoch(&1u64), 2);
+    assert_eq!(client.get_cleanup_count_for_epoch(&2u64), 1);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  4. Alternate cleanup path + failure safety
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_revoke_and_cleanup_increments_counter() {
+    let (env, client, admin) = setup();
+    env.ledger().set_timestamp(FEE_BUCKET_WINDOW_SECONDS);
+
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "rev-cl");
+    let root = BytesN::from_array(&env, &[7u8; 32]);
+    client.submit_attestation(
+        &business,
+        &period,
+        &root,
+        &(env.ledger().timestamp().saturating_add(1)),
+        &1u32,
+        &0i128,
+        &None,
+        &None,
+    );
+    assert_eq!(client.get_epoch(), 1);
+
+    let reason = String::from_str(&env, "metrics path");
+    client.revoke_and_cleanup(&admin, &business, &period, &reason, &0u64);
+
+    assert_eq!(
+        client.get_cleanup_count_for_epoch(&1u64),
+        1,
+        "revoke_and_cleanup must increment cleanup metrics"
+    );
+}
+
+#[test]
+#[should_panic(expected = "attestation not found")]
+fn test_failed_cleanup_does_not_increment() {
+    let (env, client, admin) = setup();
+    env.ledger().set_timestamp(FEE_BUCKET_WINDOW_SECONDS);
+    let business = Address::generate(&env);
+    // Seed epoch 1 via a real submission so the counter key is well-defined.
+    submit_with_expiry(&client, &env, &business, "seed", 1, far_expiry(&env));
+    assert_eq!(client.get_cleanup_count_for_epoch(&1u64), 0);
+
+    // This must panic — and must not leave a partial counter write (Soroban
+    // rolls back the transaction). Sibling tests assert the happy-path count.
+    cleanup_one(&client, &env, &admin, &business, "missing");
+}
+
+#[test]
+fn test_cleanup_summary_event_schema() {
+    let (env, client, _admin) = setup();
+    env.ledger().set_timestamp(FEE_BUCKET_WINDOW_SECONDS);
+    let business = Address::generate(&env);
+    submit_with_expiry(&client, &env, &business, "schema", 1, far_expiry(&env));
+
+    let summaries = cleanup_summary_events(&env);
+    assert!(!summaries.is_empty());
+    assert_eq!(summaries[0].epoch, 0);
+    assert_eq!(summaries[0].removed_count, 0);
+    assert_eq!(summaries[0].at_ts, FEE_BUCKET_WINDOW_SECONDS);
+
+    // Topic symbol must be the stable `cl_sum` wire identifier.
+    let has_topic = env.events().all().iter().any(|(_cid, topics, _data)| {
+        topics.len() == 1
+            && Symbol::try_from_val(&env, &topics.get(0).unwrap())
+                .map(|s| s == TOPIC_CLEANUP_SUMMARY)
+                .unwrap_or(false)
+    });
+    assert!(has_topic, "CleanupSummary topic must be cl_sum");
+}
+
+#[test]
+fn test_get_cleanup_count_matches_summary_event() {
+    let (env, client, admin) = setup();
+    env.ledger().set_timestamp(FEE_BUCKET_WINDOW_SECONDS);
+
+    let business = Address::generate(&env);
+    let expiry = near_expiry(&env);
+    submit_with_expiry(&client, &env, &business, "m0", 1, expiry);
+    submit_with_expiry(&client, &env, &business, "m1", 2, expiry);
+
+    env.ledger().set_timestamp(expiry);
+    cleanup_one(&client, &env, &admin, &business, "m0");
+    cleanup_one(&client, &env, &admin, &business, "m1");
+    let stored = client.get_cleanup_count_for_epoch(&1u64);
+
+    env.ledger().set_timestamp(FEE_BUCKET_WINDOW_SECONDS * 2);
+    submit_with_expiry(&client, &env, &business, "roll", 3, far_expiry(&env));
+
+    let summaries = cleanup_summary_events(&env);
+    let for_epoch_1 = summaries.iter().find(|s| s.epoch == 1).expect("summary");
+    assert_eq!(for_epoch_1.removed_count, stored);
+}

--- a/contracts/attestation/src/dynamic_fees.rs
+++ b/contracts/attestation/src/dynamic_fees.rs
@@ -158,6 +158,12 @@ pub enum DataKey {
     EpochFees(soroban_sdk::String),
     /// Global running submission count for backfill checkpointing.
     BackfillSubmissionCount,
+    /// Per-epoch count of successful cleanup operations (removed entries).
+    ///
+    /// Keyed by fee-bucket epoch from [`DataKey::EpochCounter`]. Operators
+    /// read this via `get_cleanup_count_for_epoch` and observe
+    /// `CleanupSummary` events emitted on each epoch boundary.
+    CleanupCountForEpoch(u64),
     // ── Archive Tier ─────────────────────────────────────────────
     /// Global archive index.
     ArchiveIndex,
@@ -591,17 +597,54 @@ pub fn get_epoch(env: &Env) -> u64 {
         .unwrap_or(0u64)
 }
 
-/// Increments the epoch counter by one, persists it, and emits `EpochAdvanced`.
+/// Increments the epoch counter by one, persists it, and emits boundary events.
 ///
 /// Private — only called from `handle_epoch_rollover`.
 /// Guarantees the counter is strictly monotonically increasing.
+///
+/// On each boundary:
+/// 1. Emit `CleanupSummary` for the **ending** epoch with its persisted
+///    [`DataKey::CleanupCountForEpoch`] value (including zero).
+/// 2. Advance the epoch and emit `EpochAdvanced` for the new value.
 fn advance_epoch(env: &Env) -> u64 {
-    let new_epoch = get_epoch(env) + 1;
+    let ending_epoch = get_epoch(env);
+    let removed = get_cleanup_count_for_epoch(env, ending_epoch);
+    crate::events::emit_cleanup_summary(env, ending_epoch, removed);
+
+    let new_epoch = ending_epoch + 1;
     env.storage()
         .instance()
         .set(&DataKey::EpochCounter, &new_epoch);
     crate::events::emit_epoch_advanced(env, new_epoch);
     new_epoch
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Per-epoch cleanup metrics
+// ════════════════════════════════════════════════════════════════════
+
+/// Returns the number of successful cleanups recorded for `epoch`.
+///
+/// Missing keys read as `0` so epochs with no cleanup activity still have a
+/// well-defined metric (and emit `CleanupSummary` with `removed_count = 0`).
+pub fn get_cleanup_count_for_epoch(env: &Env, epoch: u64) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::CleanupCountForEpoch(epoch))
+        .unwrap_or(0u64)
+}
+
+/// Increments the cleanup counter for the **current** fee-bucket epoch by one.
+///
+/// Called only from successful cleanup paths after storage has been removed.
+/// The counter is monotonically non-decreasing per epoch and cannot be
+/// decremented or reset by external callers.
+pub fn increment_cleanup_count(env: &Env) {
+    let epoch = get_epoch(env);
+    let next = get_cleanup_count_for_epoch(env, epoch).saturating_add(1);
+    env.storage()
+        .instance()
+        .set(&DataKey::CleanupCountForEpoch(epoch), &next);
 }
 
 /// Checks for a fee-bucket window rollover and advances the epoch counter if

--- a/contracts/attestation/src/events.rs
+++ b/contracts/attestation/src/events.rs
@@ -45,6 +45,7 @@
 //! | `ApprovalRevoked`           | `appr_rv`      | `proposal_id`     |
 //! | `EpochCheckpoint`           | `ep_ckpt`      | *(none)*          |
 //! | `EpochAdvanced`             | `ep_adv`       | *(none)*          |
+//! | `CleanupSummary`            | `cl_sum`       | *(none)*          |
 //! | `BackfillCheckpoint`        | `bkf_chk`      | *(none)*          |
 //!
 //! ## Indexer Compatibility Contract
@@ -150,6 +151,8 @@ pub const TOPIC_BIZ_REACTIVATE: Symbol = symbol_short!("biz_rea");
 pub const TOPIC_PROOF_HASH_UPDATED: Symbol = symbol_short!("ph_upd");
 /// Topic: fee bucket epoch advanced
 pub const TOPIC_EPOCH_ADVANCED: Symbol = symbol_short!("ep_adv");
+/// Topic: per-epoch cleanup summary at fee-bucket boundary
+pub const TOPIC_CLEANUP_SUMMARY: Symbol = symbol_short!("cl_sum");
 /// Topic: revocation proposed (grace window started)
 pub const TOPIC_REVOCATION_PROPOSED: Symbol = symbol_short!("rv_prop");
 /// Topic: revocation proposal cancelled (appeal succeeded)
@@ -160,8 +163,6 @@ pub const TOPIC_REVOCATION_COMMITTED: Symbol = symbol_short!("rv_cmmt");
 pub const TOPIC_APPROVAL_REVOKED: Symbol = symbol_short!("appr_rv");
 /// Topic: epoch checkpoint emitted after each submission (per-period)
 pub const TOPIC_EPOCH_CHECKPOINT: Symbol = symbol_short!("ep_ckpt");
-/// Topic: epoch advanced on fee-bucket window rollover
-pub const TOPIC_EPOCH_ADVANCED: Symbol = symbol_short!("ep_adv");
 /// Topic: backfill checkpoint emitted every N submissions (global counter)
 pub const TOPIC_BACKFILL_CHECKPOINT: Symbol = symbol_short!("bkf_chk");
 
@@ -679,6 +680,30 @@ pub struct EpochAdvancedEvent {
     /// New epoch number (1-based, monotonically non-decreasing).
     pub epoch: u64,
     /// Ledger timestamp when the epoch was advanced.
+    pub at_ts: u64,
+}
+
+/// Normalized payload for `CleanupSummary` events.
+///
+/// Emitted at each fee-bucket epoch boundary with the number of successful
+/// cleanup operations recorded for the **ending** epoch. Operators use this
+/// to monitor cleanup health without scanning every `AttestationCleanedUp`
+/// event.
+///
+/// ## Security
+/// - Only emitted from the contract's epoch-rollover path.
+/// - `removed_count` is the persisted `CleanupCountForEpoch(epoch)` value
+///   (including `0` when no cleanups occurred).
+/// - The counter is incremented only after a successful cleanup removes
+///   storage; failed / unauthorized cleanup attempts do not affect it.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CleanupSummaryEvent {
+    /// Epoch that just ended (the epoch whose cleanup count is reported).
+    pub epoch: u64,
+    /// Number of successful cleanup operations in that epoch.
+    pub removed_count: u64,
+    /// Ledger timestamp when the summary was emitted.
     pub at_ts: u64,
 }
 
@@ -1861,23 +1886,6 @@ pub struct EpochCheckpointEvent {
     pub checkpoint_timestamp: u64,
 }
 
-/// Normalized payload for `EpochAdvanced` events.
-///
-/// Emitted when the fee-bucket window rolls over, incrementing the
-/// monotonic epoch counter. One event is emitted per elapsed window.
-///
-/// | Event Catalog | Topic | Secondary topic |
-/// |---|---|--|
-/// | EpochAdvanced | `ep_adv` | *(none)* |
-#[contracttype]
-#[derive(Clone, Debug)]
-pub struct EpochAdvancedEvent {
-    /// New epoch value after the rollover.
-    pub epoch: u64,
-    /// Ledger timestamp at which the rollover was detected.
-    pub at_ts: u64,
-}
-
 /// Normalized payload for `BackfillCheckpoint` events.
 ///
 /// Emitted every `BACKFILL_CHECKPOINT_INTERVAL` (global) submissions to
@@ -1953,6 +1961,29 @@ pub fn emit_epoch_advanced(env: &Env, epoch: u64) {
         at_ts: env.ledger().timestamp(),
     };
     env.events().publish((TOPIC_EPOCH_ADVANCED,), event);
+}
+
+/// Emit a `CleanupSummary` event at an epoch boundary.
+///
+/// Called from the fee-bucket rollover path immediately before the epoch
+/// counter advances. Reports cleanups recorded for the ending epoch.
+///
+/// # Arguments
+///
+/// * `env`           – Soroban execution environment.
+/// * `epoch`         – Ending epoch whose cleanup count is reported.
+/// * `removed_count` – Persisted cleanup count for that epoch (may be 0).
+///
+/// # Events
+///
+/// Publishes `(cl_sum,)` → `CleanupSummaryEvent`.
+pub fn emit_cleanup_summary(env: &Env, epoch: u64, removed_count: u64) {
+    let event = CleanupSummaryEvent {
+        epoch,
+        removed_count,
+        at_ts: env.ledger().timestamp(),
+    };
+    env.events().publish((TOPIC_CLEANUP_SUMMARY,), event);
 }
 
 /// Emit a `BackfillCheckpoint` event.

--- a/contracts/attestation/src/lib.rs
+++ b/contracts/attestation/src/lib.rs
@@ -1094,6 +1094,7 @@ impl AttestationContract {
 
         env.storage().instance().remove(&key);
         extended_metadata::remove_metadata(&env, &business, &period);
+        dynamic_fees::increment_cleanup_count(&env);
         events::emit_attestation_cleaned_up(&env, &business, &period);
     }
 
@@ -1953,6 +1954,15 @@ impl AttestationContract {
         dynamic_fees::get_epoch(&env)
     }
 
+    /// Returns how many successful cleanups were recorded for `epoch`.
+    ///
+    /// Backed by [`DataKey::CleanupCountForEpoch`]. Missing epochs return `0`.
+    /// At each fee-bucket boundary a `CleanupSummary` event is emitted with
+    /// this value for the ending epoch (including zero).
+    pub fn get_cleanup_count_for_epoch(env: Env, epoch: u64) -> u64 {
+        dynamic_fees::get_cleanup_count_for_epoch(&env, epoch)
+    }
+
     pub fn get_submission_window_count(env: Env, business: Address) -> u32 {
         rate_limit::get_submission_count(&env, &business)
     }
@@ -2312,10 +2322,13 @@ impl AttestationContract {
         }
         dispute::set_revoked_periods(&env, &business, &new_periods);
 
-        // 9. Emit cleaned event.
+        // 9. Record cleanup metrics for the current fee-bucket epoch.
+        dynamic_fees::increment_cleanup_count(&env);
+
+        // 10. Emit cleaned event.
         events::emit_attestation_cleaned_up(&env, &business, &period);
 
-        // 10. Bump TTL after storage modifications.
+        // 11. Bump TTL after storage modifications.
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_BUMP);
@@ -2836,6 +2849,8 @@ mod dispute_test;
 mod dynamic_fees_test;
 #[cfg(all(test, feature = "full-tests"))]
 mod epoch_counter_test;
+#[cfg(all(test, feature = "full-tests"))]
+mod cleanup_metrics_test;
 #[cfg(all(test, feature = "full-tests"))]
 mod events_test;
 #[cfg(all(test, feature = "full-tests"))]

--- a/docs/attestation-events-indexer.md
+++ b/docs/attestation-events-indexer.md
@@ -10,6 +10,7 @@ This specification covers the following events only:
 - `AttestationRevokedEvent` with topic `(att_rev, business)`
 - `AttestationMigratedEvent` with topic `(att_mig, business)`
 - `AttestationCleanedUpEvent` with topic `(att_cl, business)`
+- `CleanupSummaryEvent` with topic `(cl_sum,)` — per-epoch cleanup health at fee-bucket boundaries
 
 Source of truth for payload structs and topic symbols:
 - `contracts/attestation/src/events.rs`

--- a/docs/cleanup-metrics.md
+++ b/docs/cleanup-metrics.md
@@ -1,0 +1,42 @@
+# Per-Epoch Cleanup Metrics (Issue #531)
+
+Operators can monitor cleanup health via a persisted per-epoch counter and a
+boundary event.
+
+## Storage
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `DataKey::CleanupCountForEpoch(epoch)` | `u64` | Successful cleanup operations in that fee-bucket epoch |
+
+- Missing keys read as `0`.
+- Counter increments only **after** a successful cleanup removes attestation
+  storage (`cleanup_expired_attestation`, `revoke_and_cleanup`).
+- Failed / unauthorized cleanups do not change the counter (transaction
+  rollback on panic).
+
+## Events
+
+At each fee-bucket epoch advance (`handle_epoch_rollover` → `advance_epoch`):
+
+1. Emit `CleanupSummary` (`cl_sum`) for the **ending** epoch with
+   `{ epoch, removed_count, at_ts }` (including `removed_count = 0`).
+2. Advance `EpochCounter` and emit `EpochAdvanced` (`ep_adv`).
+
+## Public API
+
+- `get_cleanup_count_for_epoch(epoch) -> u64`
+- `get_epoch() -> u64` (existing)
+
+## Security notes
+
+- Events and counters are contract-internal; external callers cannot mint
+  `CleanupSummary` or decrement counts.
+- Counts are isolated per epoch; advancing the epoch never mutates prior
+  epoch keys.
+- Zero-cleanup epochs still emit a summary so operators can distinguish
+  “no work” from a silent / broken cleanup path.
+
+## Tests
+
+See `contracts/attestation/src/cleanup_metrics_test.rs` (feature `full-tests`).


### PR DESCRIPTION
## Summary
- Persist `CleanupCountForEpoch(epoch)` and increment it on successful `cleanup_expired_attestation` / `revoke_and_cleanup`.
- Emit `CleanupSummary` (`cl_sum`) at each fee-bucket epoch boundary with the ending epoch's removed count (including zero).
- Add getter `get_cleanup_count_for_epoch`, docs, and tests covering variable counts + zero-cleanup epochs.
- Remove a duplicate `EpochAdvancedEvent` definition that blocked event compilation.

Closes #531

## Security notes
- Counter increments only after successful storage removal; failed cleanups roll back.
- `CleanupSummary` is emitted only from the epoch-rollover path.
- Per-epoch keys are isolated; prior epoch counts are never mutated on advance.

## Test plan
- [x] Added `cleanup_metrics_test.rs` (variable counts, zero-cleanup boundary, revoke path, schema).
- [ ] `cargo test -p veritasor-attestation --features full-tests cleanup_metrics` once upstream `main` compiles again (`main` currently fails `cargo check` independently of this PR — missing symbols / long `symbol_short!` literals on tip).
- [ ] Maintainers: confirm `CleanupSummary` appears alongside `EpochAdvanced` on rollover.