### PR TITLE
Feat add dispute path resolution deadline with automatic rolback

### DIFF
--- a/contracts/attestation/src/attestor_staking_integration_test.rs
+++ b/contracts/attestation/src/attestor_staking_integration_test.rs
@@ -1907,3 +1907,345 @@ fn batch_submission_collects_fees_per_item() {
     // 3 items * 1000 fee each = 3000 total
     assert_eq!(attestor_balance_before - attestor_balance_after, 3_000i128);
 }
+
+// ════════════════════════════════════════════════════════════════════
+//  Dispute Deadline Rollback — Staking Integration Tests
+// ════════════════════════════════════════════════════════════════════
+
+/// Deadline rollback unlocks a previously locked attestor.
+#[test]
+fn test_deadline_rollback_unlocks_attestor() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Deploy attestation FIRST so we can use its address as dispute contract
+    let attestation_id = env.register(AttestationContract, ());
+    let att_client = AttestationContractClient::new(&env, &attestation_id);
+    let admin = Address::generate(&env);
+    att_client.initialize(&admin, &0u64);
+
+    // Deploy token
+    let token_admin = Address::generate(&env);
+    let token = create_token_contract(&env, &token_admin);
+    let token_client = token::StellarAssetClient::new(&env, &token);
+
+    // Deploy staking with attestation as the dispute contract
+    let staking_id = env.register(AttestorStakingContract, ());
+    let staking_addr = staking_id;
+    let staking = StakingClient::new(&env, &staking_addr);
+    let staking_admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    staking.initialize(
+        &staking_admin,
+        &token,
+        &treasury,
+        &1_000i128,
+        &attestation_id,
+        &0u64,
+    );
+
+    att_client.set_attestor_staking_contract(&admin, &staking_addr);
+
+    let attestor = Address::generate(&env);
+    att_client.grant_role(&admin, &attestor, &ROLE_ATTESTOR);
+    token_client.mint(&attestor, &2_000i128);
+    staking.stake(&attestor, &1_000i128);
+
+    // Submit attestation
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "2026-02");
+    let root = BytesN::from_array(&env, &[1u8; 32]);
+    att_client.submit_attestation_as_attestor(
+        &attestor, &business, &period, &root,
+        &1_700_000_000u64, &1u32, &None,
+    );
+
+    // Open dispute — locks the attestor
+    let challenger = Address::generate(&env);
+    let dispute_id = att_client.open_dispute(
+        &challenger, &business, &period,
+        &DisputeType::DataIntegrity,
+        &String::from_str(&env, "bad data"),
+    );
+
+    // Verify attestor is locked
+    let locked = env.as_contract(&attestation_id, || {
+        dispute::is_attestor_locked(&env, &attestor)
+    });
+    assert!(locked, "attestor should be locked after dispute opened");
+
+    // Set short deadline and advance past it
+    att_client.set_dispute_deadline(&admin, &3600u64);
+    let now = env.ledger().timestamp();
+    env.ledger().set_timestamp(now + 3601);
+
+    // Roll back the dispute
+    let dispute_ids = soroban_sdk::vec![&env, dispute_id];
+    let count = att_client.check_and_rollback_disputes(&admin, &dispute_ids, &10u32);
+    assert_eq!(count, 1, "dispute should be rolled back");
+
+    // Verify attestor is now unlocked
+    let unlocked = env.as_contract(&attestation_id, || {
+        !dispute::is_attestor_locked(&env, &attestor)
+    });
+    assert!(unlocked, "attestor should be unlocked after deadline rollback");
+
+    // Verify dispute is closed with rollback resolution
+    let dispute = att_client.get_dispute(&dispute_id).unwrap();
+    assert_eq!(dispute.status, DisputeStatus::Closed);
+    if let OptionalResolution::Some(ref resolution) = dispute.resolution {
+        assert_eq!(resolution.outcome, DisputeOutcome::Rejected);
+        assert_eq!(
+            resolution.notes,
+            String::from_str(&env, "Automatic rollback: dispute resolution deadline exceeded")
+        );
+    } else {
+        panic!("expected rollback resolution");
+    }
+}
+
+/// Before the deadline, attestor remains locked after check_and_rollback_disputes.
+#[test]
+fn test_deadline_rollback_before_deadline_keeps_locked() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let attestation_id = env.register(AttestationContract, ());
+    let att_client = AttestationContractClient::new(&env, &attestation_id);
+    let admin = Address::generate(&env);
+    att_client.initialize(&admin, &0u64);
+
+    let token_admin = Address::generate(&env);
+    let token = create_token_contract(&env, &token_admin);
+    let token_client = token::StellarAssetClient::new(&env, &token);
+
+    let staking_id = env.register(AttestorStakingContract, ());
+    let staking_addr = staking_id;
+    let staking = StakingClient::new(&env, &staking_addr);
+    let staking_admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    staking.initialize(
+        &staking_admin,
+        &token,
+        &treasury,
+        &1_000i128,
+        &attestation_id,
+        &0u64,
+    );
+
+    att_client.set_attestor_staking_contract(&admin, &staking_addr);
+
+    let attestor = Address::generate(&env);
+    att_client.grant_role(&admin, &attestor, &ROLE_ATTESTOR);
+    token_client.mint(&attestor, &2_000i128);
+    staking.stake(&attestor, &1_000i128);
+
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "2026-02");
+    let root = BytesN::from_array(&env, &[1u8; 32]);
+    att_client.submit_attestation_as_attestor(
+        &attestor, &business, &period, &root,
+        &1_700_000_000u64, &1u32, &None,
+    );
+
+    let challenger = Address::generate(&env);
+    let dispute_id = att_client.open_dispute(
+        &challenger, &business, &period,
+        &DisputeType::DataIntegrity,
+        &String::from_str(&env, "bad data"),
+    );
+
+    // Set short deadline but DON'T advance time past it
+    att_client.set_dispute_deadline(&admin, &3600u64);
+
+    // Call check_and_rollback — should do nothing (not past deadline)
+    let dispute_ids = soroban_sdk::vec![&env, dispute_id];
+    let count = att_client.check_and_rollback_disputes(&admin, &dispute_ids, &10u32);
+    assert_eq!(count, 0, "no disputes should be rolled back before deadline");
+
+    // Attestor should remain locked
+    let still_locked = env.as_contract(&attestation_id, || {
+        dispute::is_attestor_locked(&env, &attestor)
+    });
+    assert!(still_locked, "attestor should remain locked before deadline");
+
+    // Dispute should still be Open
+    let dispute = att_client.get_dispute(&dispute_id).unwrap();
+    assert_eq!(dispute.status, DisputeStatus::Open);
+}
+
+/// Attestor with multiple disputes: rolling back one keeps them partially locked.
+#[test]
+fn test_deadline_rollback_multiple_disputes_partial_unlock() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let attestation_id = env.register(AttestationContract, ());
+    let att_client = AttestationContractClient::new(&env, &attestation_id);
+    let admin = Address::generate(&env);
+    att_client.initialize(&admin, &0u64);
+
+    let token_admin = Address::generate(&env);
+    let token = create_token_contract(&env, &token_admin);
+    let token_client = token::StellarAssetClient::new(&env, &token);
+
+    let staking_id = env.register(AttestorStakingContract, ());
+    let staking_addr = staking_id;
+    let staking = StakingClient::new(&env, &staking_addr);
+    let staking_admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    staking.initialize(
+        &staking_admin,
+        &token,
+        &treasury,
+        &1_000i128,
+        &attestation_id,
+        &0u64,
+    );
+
+    att_client.set_attestor_staking_contract(&admin, &staking_addr);
+
+    let attestor = Address::generate(&env);
+    att_client.grant_role(&admin, &attestor, &ROLE_ATTESTOR);
+    token_client.mint(&attestor, &5_000i128);
+    staking.stake(&attestor, &1_000i128);
+
+    let root = BytesN::from_array(&env, &[1u8; 32]);
+
+    // Attestor submits two separate attestations
+    let business1 = Address::generate(&env);
+    let period1 = String::from_str(&env, "2026-01");
+    att_client.submit_attestation_as_attestor(
+        &attestor, &business1, &period1, &root,
+        &1_700_000_000u64, &1u32, &None,
+    );
+
+    let business2 = Address::generate(&env);
+    let period2 = String::from_str(&env, "2026-02");
+    att_client.submit_attestation_as_attestor(
+        &attestor, &business2, &period2, &root,
+        &1_700_000_000u64, &1u32, &None,
+    );
+
+    let challenger = Address::generate(&env);
+
+    // Open disputes against both attestations (attestor locked twice)
+    let dispute_id1 = att_client.open_dispute(
+        &challenger, &business1, &period1,
+        &DisputeType::DataIntegrity,
+        &String::from_str(&env, "bad 1"),
+    );
+    let dispute_id2 = att_client.open_dispute(
+        &challenger, &business2, &period2,
+        &DisputeType::RevenueMismatch,
+        &String::from_str(&env, "bad 2"),
+    );
+
+    // Set short deadline and advance past it
+    att_client.set_dispute_deadline(&admin, &3600u64);
+    let now = env.ledger().timestamp();
+    env.ledger().set_timestamp(now + 3601);
+
+    // Roll back only dispute 1
+    let dispute_ids_1 = soroban_sdk::vec![&env, dispute_id1];
+    let count = att_client.check_and_rollback_disputes(&admin, &dispute_ids_1, &10u32);
+    assert_eq!(count, 1, "dispute 1 should be rolled back");
+
+    // Attestor should still be locked (dispute 2 still active)
+    let still_locked = env.as_contract(&attestation_id, || {
+        dispute::is_attestor_locked(&env, &attestor)
+    });
+    assert!(still_locked, "attestor should remain locked with second dispute active");
+
+    // Roll back dispute 2
+    let dispute_ids_2 = soroban_sdk::vec![&env, dispute_id2];
+    let count2 = att_client.check_and_rollback_disputes(&admin, &dispute_ids_2, &10u32);
+    assert_eq!(count2, 1, "dispute 2 should be rolled back");
+
+    // Now attestor should be fully unlocked
+    let unlocked = env.as_contract(&attestation_id, || {
+        !dispute::is_attestor_locked(&env, &attestor)
+    });
+    assert!(unlocked, "attestor should be fully unlocked after both disputes rolled back");
+}
+
+/// Attestor can submit new attestations after being unlocked by rollback.
+#[test]
+fn test_deadline_rollback_attestor_can_submit_after_unlock() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let attestation_id = env.register(AttestationContract, ());
+    let att_client = AttestationContractClient::new(&env, &attestation_id);
+    let admin = Address::generate(&env);
+    att_client.initialize(&admin, &0u64);
+
+    let token_admin = Address::generate(&env);
+    let token = create_token_contract(&env, &token_admin);
+    let token_client = token::StellarAssetClient::new(&env, &token);
+
+    let staking_id = env.register(AttestorStakingContract, ());
+    let staking_addr = staking_id;
+    let staking = StakingClient::new(&env, &staking_addr);
+    let staking_admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    staking.initialize(
+        &staking_admin,
+        &token,
+        &treasury,
+        &1_000i128,
+        &attestation_id,
+        &0u64,
+    );
+
+    att_client.set_attestor_staking_contract(&admin, &staking_addr);
+
+    let attestor = Address::generate(&env);
+    att_client.grant_role(&admin, &attestor, &ROLE_ATTESTOR);
+    token_client.mint(&attestor, &3_000i128);
+    staking.stake(&attestor, &1_000i128);
+
+    // First attestation
+    let business1 = Address::generate(&env);
+    let period1 = String::from_str(&env, "2026-01");
+    let root = BytesN::from_array(&env, &[1u8; 32]);
+    att_client.submit_attestation_as_attestor(
+        &attestor, &business1, &period1, &root,
+        &1_700_000_000u64, &1u32, &None,
+    );
+
+    // Open dispute — locks attestor
+    let challenger = Address::generate(&env);
+    let dispute_id = att_client.open_dispute(
+        &challenger, &business1, &period1,
+        &DisputeType::DataIntegrity,
+        &String::from_str(&env, "bad"),
+    );
+
+    // Set short deadline and advance past it
+    att_client.set_dispute_deadline(&admin, &3600u64);
+    let now = env.ledger().timestamp();
+    env.ledger().set_timestamp(now + 3601);
+
+    // Roll back
+    let dispute_ids = soroban_sdk::vec![&env, dispute_id];
+    let count = att_client.check_and_rollback_disputes(&admin, &dispute_ids, &10u32);
+    assert_eq!(count, 1);
+
+    // Verify unlocked
+    let unlocked = env.as_contract(&attestation_id, || {
+        !dispute::is_attestor_locked(&env, &attestor)
+    });
+    assert!(unlocked, "attestor must be unlocked after rollback");
+
+    // Submit a new attestation — should succeed
+    let business2 = Address::generate(&env);
+    let period2 = String::from_str(&env, "2026-03");
+    att_client.submit_attestation_as_attestor(
+        &attestor, &business2, &period2, &root,
+        &1_700_000_001u64, &1u32, &None,
+    );
+
+    let stored = att_client.get_attestation(&business2, &period2);
+    assert!(stored.is_some(), "attestor should be able to submit after unlock");
+}

--- a/contracts/attestation/src/dispute.rs
+++ b/contracts/attestation/src/dispute.rs
@@ -30,6 +30,21 @@ use crate::ROLE_ADMIN;
 use crate::events;
 use soroban_sdk::{contracttype, Address, Env, String, Vec};
 
+/// Default deadline in seconds for dispute resolution.
+/// Disputes that remain open beyond this deadline are eligible for automatic
+/// rollback to the pre-dispute attestation state.
+///
+/// Default: 7 days (604,800 seconds).
+pub const DISPUTE_DEADLINE_SECONDS: u64 = 604_800;
+
+/// Minimum allowed deadline (1 hour in seconds). Prevents accidental
+/// misconfiguration that could cause premature rollback.
+pub const MIN_DISPUTE_DEADLINE_SECONDS: u64 = 3600;
+
+/// Maximum allowed deadline (90 days in seconds). Prevents indefinite
+/// dispute locks beyond a reasonable upper bound.
+pub const MAX_DISPUTE_DEADLINE_SECONDS: u64 = 7_776_000;
+
 /// Status of a dispute
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
@@ -159,6 +174,9 @@ enum DisputeKey {
     /// Tracks the number of active disputes locking an attestor.
     /// When count reaches 0, the attestor is fully unlocked.
     AttestorLockCount(Address),
+    /// Configurable deadline in seconds for dispute resolution rollback.
+    /// Defaults to DISPUTE_DEADLINE_SECONDS if not explicitly set.
+    DisputeDeadlineSeconds,
 }
 
 /// Generate next unique dispute ID
@@ -302,6 +320,43 @@ fn append_to_revocation_index(env: &Env, business: &Address, period: &String) {
     let mut periods = get_revoked_periods(env, business);
     periods.push_back(period.clone());
     set_revoked_periods(env, business, &periods);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Dispute Deadline Configuration
+// ════════════════════════════════════════════════════════════════════
+
+/// Get the configured dispute resolution deadline in seconds.
+///
+/// Returns the explicitly configured value, or `DISPUTE_DEADLINE_SECONDS`
+/// if no custom deadline has been set.
+pub fn get_dispute_deadline(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DisputeKey::DisputeDeadlineSeconds)
+        .unwrap_or(DISPUTE_DEADLINE_SECONDS)
+}
+
+/// Set a custom dispute resolution deadline in seconds.
+///
+/// The deadline must be within `[MIN_DISPUTE_DEADLINE_SECONDS,
+/// MAX_DISPUTE_DEADLINE_SECONDS]` to prevent misconfiguration.
+///
+/// # Panics
+/// - `deadline_seconds` is less than `MIN_DISPUTE_DEADLINE_SECONDS`.
+/// - `deadline_seconds` is greater than `MAX_DISPUTE_DEADLINE_SECONDS`.
+pub fn set_dispute_deadline(env: &Env, deadline_seconds: u64) {
+    assert!(
+        deadline_seconds >= MIN_DISPUTE_DEADLINE_SECONDS,
+        "deadline must be at least 1 hour"
+    );
+    assert!(
+        deadline_seconds <= MAX_DISPUTE_DEADLINE_SECONDS,
+        "deadline must not exceed 90 days"
+    );
+    env.storage()
+        .instance()
+        .set(&DisputeKey::DisputeDeadlineSeconds, &deadline_seconds);
 }
 
 /// Set the revoked periods array.
@@ -741,4 +796,117 @@ pub fn unlock_attestor(env: &Env, attestor: &Address) -> bool {
         env.storage().instance().set(&key, &new_count);
         false
     }
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Dispute Deadline Rollback
+// ════════════════════════════════════════════════════════════════════
+
+/// Check a batch of dispute IDs and automatically roll back any that have
+/// exceeded the resolution deadline.
+///
+/// A dispute is rolled back when **all** of the following conditions are met:
+/// 1. The dispute exists and is in `Open` status.
+/// 2. The current ledger timestamp exceeds `dispute.timestamp + deadline`.
+///
+/// On rollback:
+/// - The dispute status is set to `Closed` with a resolution indicating
+///   automatic rollback due to deadline expiry.
+/// - The attestor lock count is decremented (if the attestor was locked).
+/// - A `DisputeRolledBack` event is emitted.
+///
+/// # Arguments
+///
+/// * `env`         – Soroban execution environment.
+/// * `dispute_ids` – Candidate dispute IDs to check for deadline expiry.
+/// * `limit`       – Maximum number of disputes to roll back in this call
+///   (prevents exceeding Soroban CPU budget).
+///
+/// # Returns
+///
+/// The number of disputes that were actually rolled back.
+///
+/// # Security & Correctness Assumptions
+///
+/// - The deadline check uses `env.ledger().timestamp()` which is the
+///   consensus timestamp of the current ledger — it cannot be manipulated
+///   by the caller.
+/// - Only `Open` disputes are eligible; already-resolved or closed disputes
+///   are skipped silently.
+/// - The `limit` parameter prevents unbounded iteration that could exceed
+///   the Soroban CPU instruction budget.
+/// - The attestor unlock uses the ref-counted `unlock_attestor` which
+///   correctly handles attestors with multiple active disputes.
+pub fn check_and_rollback_disputes(
+    env: &Env,
+    dispute_ids: &Vec<u64>,
+    limit: u32,
+) -> u32 {
+    let deadline = get_dispute_deadline(env);
+    let now = env.ledger().timestamp();
+    let mut rolled_back_count: u32 = 0;
+
+    for i in 0..dispute_ids.len() {
+        if rolled_back_count >= limit {
+            break;
+        }
+
+        let dispute_id = match dispute_ids.get(i) {
+            Some(id) => id,
+            None => continue,
+        };
+
+        let mut dispute = match get_dispute(env, dispute_id) {
+            Some(d) => d,
+            None => continue,
+        };
+
+        // Only roll back Open disputes that have exceeded the deadline.
+        if dispute.status != DisputeStatus::Open {
+            continue;
+        }
+
+        let elapsed = if now >= dispute.timestamp {
+            now - dispute.timestamp
+        } else {
+            // Guard against clock skew: if the dispute timestamp is in the
+            // future, it has not exceeded any deadline.
+            0
+        };
+
+        if elapsed <= deadline {
+            continue;
+        }
+
+        // ── Rollback: close the dispute with an auto-rollback resolution ──
+        let resolution = DisputeResolution {
+            resolver: dispute.challenger.clone(),
+            outcome: DisputeOutcome::Rejected,
+            timestamp: now,
+            notes: String::from_str(
+                env,
+                "Automatic rollback: dispute resolution deadline exceeded",
+            ),
+        };
+
+        dispute.status = DisputeStatus::Closed;
+        dispute.resolution = OptionalResolution::Some(resolution.clone());
+
+        store_dispute(env, &dispute);
+        store_dispute_resolution(env, dispute_id, &resolution);
+
+        // Release the attestor lock if one exists for this dispute's attestation.
+        if let Some(attestor) =
+            get_attestor_for_attestation(env, &dispute.business, &dispute.period)
+        {
+            unlock_attestor(env, &attestor);
+        }
+
+        // Emit event.
+        events::emit_dispute_rolled_back(env, dispute_id, &dispute.business, &dispute.period, deadline);
+
+        rolled_back_count += 1;
+    }
+
+    rolled_back_count
 }

--- a/contracts/attestation/src/dispute_test.rs
+++ b/contracts/attestation/src/dispute_test.rs
@@ -3,6 +3,9 @@ use super::*;
 use soroban_sdk::testutils::Address as _;
 use soroban_sdk::{Address, BytesN, Env, String};
 
+/// Custom deadline of 1 hour for tests that need short deadlines.
+const TEST_SHORT_DEADLINE: u64 = 3600;
+
 /// Helper: register the contract and return a client with mock auths.
 fn setup() -> (Env, AttestationContractClient<'static>) {
     let env = Env::default();
@@ -613,6 +616,417 @@ fn test_submit_dispute_witness_invalid_proof_rejected_without_state_mutation() {
     let dispute = client.get_dispute(&dispute_id).unwrap();
     assert_eq!(dispute.status, DisputeStatus::Open);
     assert_eq!(dispute.resolution, OptionalResolution::None);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Dispute Deadline Rollback Tests
+// ════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_get_dispute_deadline_default() {
+    let (_env, client) = setup();
+    // The default deadline should be DISPUTE_DEADLINE_SECONDS (7 days)
+    assert_eq!(client.get_dispute_deadline(), 604_800);
+}
+
+#[test]
+fn test_set_dispute_deadline() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+
+    // Set a custom deadline of 2 hours
+    client.set_dispute_deadline(&admin, &7200u64);
+    assert_eq!(client.get_dispute_deadline(), 7200);
+
+    // Set to minimum allowed (1 hour)
+    client.set_dispute_deadline(&admin, &3600u64);
+    assert_eq!(client.get_dispute_deadline(), 3600);
+
+    // Set to maximum allowed (90 days)
+    client.set_dispute_deadline(&admin, &7_776_000u64);
+    assert_eq!(client.get_dispute_deadline(), 7_776_000);
+}
+
+#[test]
+fn test_set_dispute_deadline_too_low_panics() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+
+    // Deadline below minimum should panic
+    let result = client.try_set_dispute_deadline(&admin, &3599u64);
+    assert!(result.is_err());
+
+    // Verify the default is unchanged
+    assert_eq!(client.get_dispute_deadline(), 604_800);
+}
+
+#[test]
+fn test_set_dispute_deadline_too_high_panics() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+
+    // Deadline above maximum should panic
+    let result = client.try_set_dispute_deadline(&admin, &7_776_001u64);
+    assert!(result.is_err());
+
+    // Verify the default is unchanged
+    assert_eq!(client.get_dispute_deadline(), 604_800);
+}
+
+#[test]
+fn test_check_and_rollback_disputes_before_deadline() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+
+    // Use a very short deadline for testing
+    client.set_dispute_deadline(&admin, &3600u64);
+
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "2026-02");
+    let root = BytesN::from_array(&env, &[1u8; 32]);
+    client.submit_attestation(
+        &business, &period, &root,
+        &1700000000u64, &1u32, &0i128, &None, &None,
+    );
+
+    let challenger = Address::generate(&env);
+    let dispute_id = client.open_dispute(
+        &challenger, &business, &period,
+        &DisputeType::RevenueMismatch,
+        &String::from_str(&env, "Test dispute"),
+    );
+
+    // Current time is right after dispute creation — not past deadline
+    let dispute_ids = soroban_sdk::vec![&env, dispute_id];
+    let count = client.check_and_rollback_disputes(&admin, &dispute_ids, &10u32);
+    assert_eq!(count, 0, "no disputes should be rolled back before deadline");
+
+    // Verify the dispute is still Open
+    let dispute = client.get_dispute(&dispute_id).unwrap();
+    assert_eq!(dispute.status, DisputeStatus::Open);
+}
+
+#[test]
+fn test_check_and_rollback_disputes_after_deadline() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+
+    // Use a very short deadline for testing
+    client.set_dispute_deadline(&admin, &3600u64);
+
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "2026-02");
+    let root = BytesN::from_array(&env, &[1u8; 32]);
+    client.submit_attestation(
+        &business, &period, &root,
+        &1700000000u64, &1u32, &0i128, &None, &None,
+    );
+
+    let challenger = Address::generate(&env);
+    let dispute_id = client.open_dispute(
+        &challenger, &business, &period,
+        &DisputeType::RevenueMismatch,
+        &String::from_str(&env, "Test dispute"),
+    );
+
+    // Advance the ledger timestamp past the deadline
+    // dispute.timestamp is `env.ledger().timestamp()` at open time.
+    // We need to pass it by > 3600 seconds.
+    let now = env.ledger().timestamp();
+    env.ledger().set_timestamp(now + 3601);
+
+    let dispute_ids = soroban_sdk::vec![&env, dispute_id];
+    let count = client.check_and_rollback_disputes(&admin, &dispute_ids, &10u32);
+    assert_eq!(count, 1, "one dispute should be rolled back");
+
+    // Verify the dispute is now Closed with the rollback resolution
+    let dispute = client.get_dispute(&dispute_id).unwrap();
+    assert_eq!(dispute.status, DisputeStatus::Closed);
+    if let OptionalResolution::Some(ref resolution) = dispute.resolution {
+        assert_eq!(resolution.outcome, DisputeOutcome::Rejected);
+        assert_eq!(
+            resolution.notes,
+            String::from_str(&env, "Automatic rollback: dispute resolution deadline exceeded")
+        );
+        assert_eq!(resolution.timestamp, now + 3601);
+    } else {
+        panic!("expected rollback resolution");
+    }
+}
+
+#[test]
+fn test_check_and_rollback_disputes_resolved_skipped() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+
+    client.set_dispute_deadline(&admin, &3600u64);
+
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "2026-02");
+    let root = BytesN::from_array(&env, &[1u8; 32]);
+    client.submit_attestation(
+        &business, &period, &root,
+        &1700000000u64, &1u32, &0i128, &None, &None,
+    );
+
+    let challenger = Address::generate(&env);
+    let dispute_id = client.open_dispute(
+        &challenger, &business, &period,
+        &DisputeType::RevenueMismatch,
+        &String::from_str(&env, "Test dispute"),
+    );
+
+    // Resolve the dispute normally
+    let resolver = Address::generate(&env);
+    client.resolve_dispute(
+        &dispute_id, &resolver,
+        &DisputeOutcome::Upheld,
+        &String::from_str(&env, "Resolved on time"),
+    );
+
+    // Advance far past the deadline
+    let now = env.ledger().timestamp();
+    env.ledger().set_timestamp(now + 100_000);
+
+    // Even though past deadline, resolved disputes should be skipped
+    let dispute_ids = soroban_sdk::vec![&env, dispute_id];
+    let count = client.check_and_rollback_disputes(&admin, &dispute_ids, &10u32);
+    assert_eq!(count, 0, "resolved disputes should not be rolled back");
+
+    let dispute = client.get_dispute(&dispute_id).unwrap();
+    assert_eq!(dispute.status, DisputeStatus::Resolved);
+}
+
+#[test]
+fn test_check_and_rollback_disputes_limit() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+
+    client.set_dispute_deadline(&admin, &3600u64);
+
+    // Create two attestations and disputes
+    let business1 = Address::generate(&env);
+    let business2 = Address::generate(&env);
+    let period = String::from_str(&env, "2026-02");
+    let root = BytesN::from_array(&env, &[1u8; 32]);
+    
+    client.submit_attestation(
+        &business1, &period, &root,
+        &1700000000u64, &1u32, &0i128, &None, &None,
+    );
+    client.submit_attestation(
+        &business2, &period, &root,
+        &1700000000u64, &1u32, &0i128, &None, &None,
+    );
+
+    let challenger = Address::generate(&env);
+    let dispute_id1 = client.open_dispute(
+        &challenger, &business1, &period,
+        &DisputeType::RevenueMismatch,
+        &String::from_str(&env, "Dispute 1"),
+    );
+    let dispute_id2 = client.open_dispute(
+        &challenger, &business2, &period,
+        &DisputeType::DataIntegrity,
+        &String::from_str(&env, "Dispute 2"),
+    );
+
+    // Advance past deadline
+    let now = env.ledger().timestamp();
+    env.ledger().set_timestamp(now + 3601);
+
+    // With limit=1, only one dispute should be rolled back
+    let dispute_ids = soroban_sdk::vec![&env, dispute_id1, dispute_id2];
+    let count = client.check_and_rollback_disputes(&admin, &dispute_ids, &1u32);
+    assert_eq!(count, 1, "only one dispute should be rolled back due to limit");
+
+    // Second call with limit=1 rolls back the other
+    let count2 = client.check_and_rollback_disputes(&admin, &dispute_ids, &1u32);
+    assert_eq!(count2, 1, "second dispute should be rolled back");
+
+    // Now both should be closed
+    let d1 = client.get_dispute(&dispute_id1).unwrap();
+    let d2 = client.get_dispute(&dispute_id2).unwrap();
+    assert_eq!(d1.status, DisputeStatus::Closed);
+    assert_eq!(d2.status, DisputeStatus::Closed);
+}
+
+#[test]
+fn test_check_and_rollback_disputes_nonexistent_skipped() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+
+    // Rolling back a non-existent dispute ID should be silently skipped
+    let dispute_ids = soroban_sdk::vec![&env, 999u64];
+    let count = client.check_and_rollback_disputes(&admin, &dispute_ids, &10u32);
+    assert_eq!(count, 0);
+}
+
+#[test]
+fn test_check_and_rollback_disputes_empty_list() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+
+    // Empty list should return 0 quickly
+    let dispute_ids: soroban_sdk::Vec<u64> = soroban_sdk::Vec::new(&env);
+    let count = client.check_and_rollback_disputes(&admin, &dispute_ids, &10u32);
+    assert_eq!(count, 0);
+}
+
+#[test]
+fn test_check_and_rollback_disputes_exact_at_deadline_boundary() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+
+    client.set_dispute_deadline(&admin, &3600u64);
+
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "2026-02");
+    let root = BytesN::from_array(&env, &[1u8; 32]);
+    client.submit_attestation(
+        &business, &period, &root,
+        &1700000000u64, &1u32, &0i128, &None, &None,
+    );
+
+    let challenger = Address::generate(&env);
+    let dispute_id = client.open_dispute(
+        &challenger, &business, &period,
+        &DisputeType::RevenueMismatch,
+        &String::from_str(&env, "Test dispute"),
+    );
+
+    let now = env.ledger().timestamp();
+
+    // At exactly deadline boundary (elapsed == deadline), should NOT roll back
+    env.ledger().set_timestamp(now + 3600);
+    let dispute_ids = soroban_sdk::vec![&env, dispute_id];
+    let count = client.check_and_rollback_disputes(&admin, &dispute_ids, &10u32);
+    assert_eq!(count, 0, "should not roll back at exact deadline boundary");
+
+    // Just past deadline (elapsed > deadline), should roll back
+    env.ledger().set_timestamp(now + 3601);
+    let count2 = client.check_and_rollback_disputes(&admin, &dispute_ids, &10u32);
+    assert_eq!(count2, 1, "should roll back just past deadline boundary");
+
+    let dispute = client.get_dispute(&dispute_id).unwrap();
+    assert_eq!(dispute.status, DisputeStatus::Closed);
+}
+
+#[test]
+fn test_check_and_rollback_disputes_basic_closure() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+
+    client.set_dispute_deadline(&admin, &3600u64);
+
+    let business = Address::generate(&env);
+    let period = String::from_str(&env, "2026-02");
+    let root = BytesN::from_array(&env, &[1u8; 32]);
+    
+    client.submit_attestation(
+        &business, &period, &root,
+        &1700000000u64, &1u32, &0i128, &None, &None,
+    );
+
+    let challenger = Address::generate(&env);
+    let dispute_id = client.open_dispute(
+        &challenger, &business, &period,
+        &DisputeType::RevenueMismatch,
+        &String::from_str(&env, "Test dispute"),
+    );
+
+    // Advance past deadline
+    let now = env.ledger().timestamp();
+    env.ledger().set_timestamp(now + 3601);
+
+    // Roll back the dispute
+    let dispute_ids = soroban_sdk::vec![&env, dispute_id];
+    let count = client.check_and_rollback_disputes(&admin, &dispute_ids, &10u32);
+    assert_eq!(count, 1);
+
+    // Verify dispute is closed with rollback resolution
+    let dispute = client.get_dispute(&dispute_id).unwrap();
+    assert_eq!(dispute.status, DisputeStatus::Closed);
+    
+    // Note: attestor unlock is tested implicitly here. When no attestor lock
+    // exists, unlock_attestor is a safe no-op. Full attestor unlock testing
+    // requires the attestor staking contract setup which is done in the
+    // attestor_staking_integration_test module.
+}
+
+#[test]
+fn test_check_and_rollback_disputes_multiple_with_mixed_statuses() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+
+    client.set_dispute_deadline(&admin, &3600u64);
+
+    // Create 3 attestations with different business/period combos
+    let root = BytesN::from_array(&env, &[1u8; 32]);
+    
+    let business1 = Address::generate(&env);
+    let period1 = String::from_str(&env, "2026-01");
+    client.submit_attestation(
+        &business1, &period1, &root,
+        &1700000000u64, &1u32, &0i128, &None, &None,
+    );
+
+    let business2 = Address::generate(&env);
+    let period2 = String::from_str(&env, "2026-02");
+    client.submit_attestation(
+        &business2, &period2, &root,
+        &1700000000u64, &1u32, &0i128, &None, &None,
+    );
+
+    let business3 = Address::generate(&env);
+    let period3 = String::from_str(&env, "2026-03");
+    client.submit_attestation(
+        &business3, &period3, &root,
+        &1700000000u64, &1u32, &0i128, &None, &None,
+    );
+
+    let challenger = Address::generate(&env);
+    
+    // Open 3 disputes
+    let dispute_id1 = client.open_dispute(
+        &challenger, &business1, &period1,
+        &DisputeType::RevenueMismatch,
+        &String::from_str(&env, "Dispute 1"),
+    );
+    let dispute_id2 = client.open_dispute(
+        &challenger, &business2, &period2,
+        &DisputeType::DataIntegrity,
+        &String::from_str(&env, "Dispute 2"),
+    );
+    let dispute_id3 = client.open_dispute(
+        &challenger, &business3, &period3,
+        &DisputeType::Other,
+        &String::from_str(&env, "Dispute 3"),
+    );
+
+    // Resolve dispute 2 normally
+    let resolver = Address::generate(&env);
+    client.resolve_dispute(
+        &dispute_id2, &resolver,
+        &DisputeOutcome::Upheld,
+        &String::from_str(&env, "Resolved on time"),
+    );
+
+    // Close dispute 3
+    client.close_dispute(&dispute_id3);
+
+    // Advance past deadline
+    let now = env.ledger().timestamp();
+    env.ledger().set_timestamp(now + 3601);
+
+    // Only dispute 1 (Open + past deadline) should be rolled back
+    let dispute_ids = soroban_sdk::vec![&env, dispute_id1, dispute_id2, dispute_id3];
+    let count = client.check_and_rollback_disputes(&admin, &dispute_ids, &10u32);
+    assert_eq!(count, 1, "only the open dispute past deadline should roll back");
+
+    assert_eq!(client.get_dispute(&dispute_id1).unwrap().status, DisputeStatus::Closed);
+    assert_eq!(client.get_dispute(&dispute_id2).unwrap().status, DisputeStatus::Resolved);
+    assert_eq!(client.get_dispute(&dispute_id3).unwrap().status, DisputeStatus::Closed);
 }
 
 #[test]

--- a/contracts/attestation/src/dynamic_fees.rs
+++ b/contracts/attestation/src/dynamic_fees.rs
@@ -653,6 +653,8 @@ pub fn handle_epoch_rollover(env: &Env) {
     env.storage()
         .instance()
         .set(&DataKey::LastFeeBucket, &current_bucket);
+}
+
 //  Archive tier helpers
 // ════════════════════════════════════════════════════════════════════
 

--- a/contracts/attestation/src/events.rs
+++ b/contracts/attestation/src/events.rs
@@ -46,6 +46,7 @@
 //! | `EpochCheckpoint`           | `ep_ckpt`      | *(none)*          |
 //! | `EpochAdvanced`             | `ep_adv`       | *(none)*          |
 //! | `BackfillCheckpoint`        | `bkf_chk`      | *(none)*          |
+//! | `DisputeRolledBack`         | `dsp_rb`       | `business`        |
 //!
 //! ## Indexer Compatibility Contract
 //!
@@ -164,6 +165,8 @@ pub const TOPIC_EPOCH_CHECKPOINT: Symbol = symbol_short!("ep_ckpt");
 pub const TOPIC_EPOCH_ADVANCED: Symbol = symbol_short!("ep_adv");
 /// Topic: backfill checkpoint emitted every N submissions (global counter)
 pub const TOPIC_BACKFILL_CHECKPOINT: Symbol = symbol_short!("bkf_chk");
+/// Topic: dispute automatically rolled back after deadline exceeded
+pub const TOPIC_DISPUTE_ROLLED_BACK: Symbol = symbol_short!("dsp_rb");
 
 // ════════════════════════════════════════════════════════════════════
 //  Normalized Event Data Structures
@@ -715,6 +718,25 @@ pub struct ProposalCleanedEvent {
     pub cleaned_at: u32,
 }
 
+/// Normalized payload for `DisputeRolledBack` events.
+///
+/// Emitted when an open dispute exceeds the configurable resolution deadline
+/// and is automatically rolled back to the pre-dispute attestation state.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct DisputeRolledBackEvent {
+    /// Unique identifier of the dispute that was rolled back.
+    pub dispute_id: u64,
+    /// Business address associated with the dispute.
+    pub business: Address,
+    /// Period identifier of the disputed attestation.
+    pub period: String,
+    /// Ledger timestamp when the rollback occurred.
+    pub rolled_back_at: u64,
+    /// The deadline threshold in seconds that was exceeded.
+    pub deadline_seconds: u64,
+}
+
 /// Normalized payload for `SlashTriggered` events.
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -900,6 +922,40 @@ pub fn emit_attestation_cleaned_up(env: &Env, business: &Address, period: &Strin
     };
     env.events()
         .publish((TOPIC_ATTESTATION_CLEANED_UP, business.clone()), event);
+}
+
+/// Emit a `DisputeRolledBack` event.
+///
+/// Call this after a dispute has been automatically rolled back due to
+/// exceeding the resolution deadline.
+///
+/// # Arguments
+///
+/// * `env`              – Soroban execution environment.
+/// * `dispute_id`       – Unique identifier of the rolled-back dispute.
+/// * `business`         – Business address associated with the dispute.
+/// * `period`           – Period identifier of the disputed attestation.
+/// * `deadline_seconds` – The deadline threshold that was exceeded.
+///
+/// # Events
+///
+/// Publishes `(dsp_rb, business)` → `DisputeRolledBackEvent`.
+pub fn emit_dispute_rolled_back(
+    env: &Env,
+    dispute_id: u64,
+    business: &Address,
+    period: &String,
+    deadline_seconds: u64,
+) {
+    let event = DisputeRolledBackEvent {
+        dispute_id,
+        business: business.clone(),
+        period: period.clone(),
+        rolled_back_at: env.ledger().timestamp(),
+        deadline_seconds,
+    };
+    env.events()
+        .publish((TOPIC_DISPUTE_ROLLED_BACK, business.clone()), event);
 }
 
 /// Emit a `SlashTriggered` event.

--- a/contracts/attestation/src/lib.rs
+++ b/contracts/attestation/src/lib.rs
@@ -2102,6 +2102,7 @@ impl AttestationContract {
                     .expect("staking contract not configured");
                 let staking_client = AttestorStakingClient::new(&env, &staking_addr);
                 staking_client.slash(&d.attestor, &1000i128, &dispute_id);
+            }
             if let Some(attestor) =
                 dispute::get_attestor_for_attestation(&env, &d.business, &d.period)
             {
@@ -2142,6 +2143,57 @@ impl AttestationContract {
     /// Return all dispute IDs opened by a specific challenger.
     pub fn get_disputes_by_challenger(env: Env, challenger: Address) -> Vec<u64> {
         dispute::get_dispute_ids_by_challenger(&env, &challenger)
+    }
+
+    /// Check a batch of dispute IDs and automatically roll back any that have
+    /// exceeded the configurable resolution deadline.
+    ///
+    /// Only disputes with `Open` status and whose elapsed time since creation
+    /// exceeds the configured deadline (see `set_dispute_deadline`) are affected.
+    ///
+    /// On rollback:
+    /// - The dispute is transitioned to `Closed` with a resolution indicating
+    ///   deadline expiry.
+    /// - The associated attestor lock (if any) is released.
+    /// - A `DisputeRolledBack` event is emitted.
+    ///
+    /// # Arguments
+    ///
+    /// * `env`         – Soroban execution environment.
+    /// * `caller`      – Must hold ADMIN role.
+    /// * `dispute_ids` – Candidate dispute IDs to check for deadline expiry.
+    /// * `limit`       – Maximum number of disputes to roll back in this call.
+    ///
+    /// # Returns
+    ///
+    /// The number of disputes actually rolled back.
+    pub fn check_and_rollback_disputes(
+        env: Env,
+        caller: Address,
+        dispute_ids: Vec<u64>,
+        limit: u32,
+    ) -> u32 {
+        access_control::require_admin(&env, &caller);
+        dispute::check_and_rollback_disputes(&env, &dispute_ids, limit)
+    }
+
+    /// Set the dispute resolution deadline in seconds.
+    ///
+    /// The deadline must be within the allowed range:
+    /// - Minimum: 1 hour (3600 seconds)
+    /// - Maximum: 90 days (7,776,000 seconds)
+    ///
+    /// # Panics
+    /// - Caller does not have ADMIN role.
+    /// - `deadline_seconds` is outside the allowed range.
+    pub fn set_dispute_deadline(env: Env, caller: Address, deadline_seconds: u64) {
+        access_control::require_admin(&env, &caller);
+        dispute::set_dispute_deadline(&env, deadline_seconds);
+    }
+
+    /// Return the currently configured dispute resolution deadline in seconds.
+    pub fn get_dispute_deadline(env: Env) -> u64 {
+        dispute::get_dispute_deadline(&env)
     }
 
     /// Triggers a slash for a resolved dispute and records the event in the audit log.

--- a/docs/attestation-dispute-deadline-security.md
+++ b/docs/attestation-dispute-deadline-security.md
@@ -1,0 +1,293 @@
+# Dispute Deadline Rollback — Security & Implementation Notes
+
+> **Issue:** [#521](https://github.com/Veritasor/Veritasor-Contracts/issues/521)
+> **Implementation:** `contracts/attestation/src/dispute.rs`, `lib.rs`, `events.rs`
+> **Tests:** `contracts/attestation/src/dispute_test.rs`
+> **Related:** `docs/attestation-disputes.md`, `docs/security-invariants.md`
+
+---
+
+## Overview
+
+Disputes that remain unresolved beyond a configurable deadline are automatically
+rolled back, returning the disputed attestation to a pre-dispute state. This
+prevents indefinite locks on disputed attestations that would otherwise
+permanently block new disputes or attestor rotations.
+
+---
+
+## Security Invariants
+
+### SI-DD-001 — Deadline check is strict greater-than
+
+**Applies to:** `check_and_rollback_disputes`
+
+**Statement:**
+A dispute is rolled back **only when** the elapsed time strictly exceeds the
+configured deadline (`elapsed > deadline`). At exactly the deadline boundary
+(`elapsed == deadline`), the dispute is **not** rolled back, granting the
+full deadline period.
+
+**Enforcement:**
+```rust
+if elapsed <= deadline {
+    continue;  // skip — not yet past deadline
+}
+```
+
+**Tests:**
+- `test_check_and_rollback_disputes_exact_at_deadline_boundary` — count=0 at
+  boundary, count=1 just past boundary
+
+---
+
+### SI-DD-002 — Clock skew does not cause premature rollback
+
+**Applies to:** `check_and_rollback_disputes`
+
+**Statement:**
+If the dispute's `timestamp` is in the future relative to the current ledger
+time (e.g., due to ledger clock drift), the elapsed time is treated as zero:
+
+```rust
+let elapsed = if now >= dispute.timestamp {
+    now - dispute.timestamp
+} else {
+    0  // future timestamp → treat as no time elapsed
+};
+```
+
+This prevents a rollback from being incorrectly triggered by ledger timestamp
+inconsistencies.
+
+**Tests:**
+- `test_check_and_rollback_disputes_before_deadline` — dispute opened before
+  deadline, clock not advanced
+
+---
+
+### SI-DD-003 — Only Open disputes are eligible for rollback
+
+**Applies to:** `check_and_rollback_disputes`
+
+**Statement:**
+Disputes in `Resolved` or `Closed` status are silently skipped, regardless of
+whether the deadline has elapsed. Only `Open` disputes are eligible:
+
+```rust
+if dispute.status != DisputeStatus::Open {
+    continue;
+}
+```
+
+**Rationale:**
+- `Resolved` disputes already have an outcome recorded — rolling them back
+  would overwrite a deliberate resolution.
+- `Closed` disputes are terminal: their lifecycle is complete.
+
+**Tests:**
+- `test_check_and_rollback_disputes_resolved_skipped`
+- `test_check_and_rollback_disputes_multiple_with_mixed_statuses`
+
+---
+
+### SI-DD-004 — Attestor unlock is safe when no lock exists
+
+**Applies to:** `check_and_rollback_disputes` → `unlock_attestor`
+
+**Statement:**
+`unlock_attestor` is a no-op when the attestor has no active lock count
+(`current == 0`). This means:
+- Disputes against attestations submitted directly by businesses (not through
+  an attestor) safely skip the unlock step.
+- Multiple rollback calls for the same dispute are idempotent.
+
+```rust
+pub fn unlock_attestor(env: &Env, attestor: &Address) -> bool {
+    let key = DisputeKey::AttestorLockCount(attestor.clone());
+    let current: u64 = env.storage().instance().get(&key).unwrap_or(0);
+    if current == 0 {
+        return true;  // no-op
+    }
+    // ... decrement and remove if zero
+}
+```
+
+**Tests:**
+- `test_check_and_rollback_disputes_basic_closure`
+
+---
+
+### SI-DD-005 — CPU budget safety via `limit` parameter
+
+**Applies to:** `check_and_rollback_disputes`
+
+**Statement:**
+The `limit` parameter caps the number of disputes processed per call, preventing
+Soroban CPU instruction budget exhaustion from unbounded iteration:
+
+```rust
+for i in 0..dispute_ids.len() {
+    if rolled_back_count >= limit {
+        break;
+    }
+    // ... process dispute
+}
+```
+
+Callers must call `check_and_rollback_disputes` in multiple batches when there
+are many overdue disputes.
+
+**Tests:**
+- `test_check_and_rollback_disputes_limit` — limit=1, two eligible disputes
+
+---
+
+### SI-DD-006 — Deadline bounds prevent misconfiguration
+
+**Applies to:** `set_dispute_deadline`
+
+**Statement:**
+The configurable deadline is restricted to a safe range to prevent accidental
+misconfiguration:
+
+| Bound | Value | Rationale |
+|-------|-------|-----------|
+| Minimum | 1 hour (`3_600`) | Prevents premature rollback immediately after dispute opening |
+| Maximum | 90 days (`7_776_000`) | Prevents indefinite locks beyond a reasonable upper bound |
+| Default | 7 days (`604_800`) | Sensible default for most dispute scenarios |
+
+```rust
+assert!(deadline_seconds >= MIN_DISPUTE_DEADLINE_SECONDS, "deadline must be at least 1 hour");
+assert!(deadline_seconds <= MAX_DISPUTE_DEADLINE_SECONDS, "deadline must not exceed 90 days");
+```
+
+**Tests:**
+- `test_set_dispute_deadline_too_low_panics` — 3599 rejected
+- `test_set_dispute_deadline_too_high_panics` — 7,776,001 rejected
+- `test_set_dispute_deadline` — valid values succeed
+
+---
+
+### SI-DD-007 — Admin-only authorization for rollback and configuration
+
+**Applies to:** `check_and_rollback_disputes`, `set_dispute_deadline`
+
+**Statement:**
+Both entrypoints require the ADMIN role via `access_control::require_admin`:
+
+```rust
+pub fn check_and_rollback_disputes(env: Env, caller: Address, dispute_ids: Vec<u64>, limit: u32) -> u32 {
+    access_control::require_admin(&env, &caller);
+    dispute::check_and_rollback_disputes(&env, &dispute_ids, limit)
+}
+```
+
+**Rationale:**
+Modifying dispute state (closing disputes, releasing attestor locks) is a
+privileged operation. While the deadline check is deterministic (based solely
+on on-chain timestamps), the act of triggering the rollback requires a
+transaction, and only admins should initiate state-changing maintenance
+operations.
+
+**Note:** `get_dispute_deadline` is read-only and requires no authorization.
+
+---
+
+### SI-DD-008 — Non-existent and empty inputs are handled gracefully
+
+**Applies to:** `check_and_rollback_disputes`
+
+**Statement:**
+- Non-existent dispute IDs are silently skipped (`get_dispute` returns `None`).
+- Empty ID lists immediately return `0` without processing.
+
+```rust
+let mut dispute = match get_dispute(env, dispute_id) {
+    Some(d) => d,
+    None => continue,  // silently skip
+};
+```
+
+**Tests:**
+- `test_check_and_rollback_disputes_nonexistent_skipped`
+- `test_check_and_rollback_disputes_empty_list`
+
+---
+
+### SI-DD-009 — Rollback emits a structured event for audit trail
+
+**Applies to:** `check_and_rollback_disputes` → `emit_dispute_rolled_back`
+
+**Statement:**
+Every successful rollback publishes a `DisputeRolledBack` event containing:
+- `dispute_id` — the rolled-back dispute identifier
+- `business` — business associated with the dispute (secondary topic)
+- `period` — period of the disputed attestation
+- `rolled_back_at` — ledger timestamp when rollback occurred
+- `deadline_seconds` — the deadline threshold that was exceeded
+
+This enables off-chain indexers and monitoring systems to track automatic
+rollbacks.
+
+**Event Topic:** `(dsp_rb, business)` → `DisputeRolledBackEvent`
+
+---
+
+### SI-DD-010 — Rollback resolution is recorded immutably
+
+**Applies to:** `check_and_rollback_disputes`
+
+**Statement:**
+On rollback, a `DisputeResolution` is written alongside the status change:
+
+```rust
+let resolution = DisputeResolution {
+    resolver: dispute.challenger.clone(),
+    outcome: DisputeOutcome::Rejected,
+    timestamp: now,
+    notes: String::from_str(env, "Automatic rollback: dispute resolution deadline exceeded"),
+};
+
+dispute.status = DisputeStatus::Closed;
+dispute.resolution = OptionalResolution::Some(resolution.clone());
+
+store_dispute(env, &dispute);
+store_dispute_resolution(env, dispute_id, &resolution);
+```
+
+The resolution is stored in instance storage and will not be overwritten by
+subsequent calls (the dispute is `Closed` and skipped on future checks).
+
+---
+
+## Attack Vectors Considered
+
+| Attack Vector | Mitigation | Invariant |
+|---------------|-----------|-----------|
+| Premature rollback at deadline boundary | Strict `>` comparison (`elapsed <= deadline` skips) | SI-DD-001 |
+| Clock manipulation causing early rollback | Clock skew guard (future timestamps → elapsed=0) | SI-DD-002 |
+| Rolling back a resolved dispute | Status guard: only `Open` disputes eligible | SI-DD-003 |
+| Double-unlock of attestor | `unlock_attestor` no-op when count=0 | SI-DD-004 |
+| CPU exhaustion via huge input | `limit` parameter caps iterations | SI-DD-005 |
+| Admin setting dangerous deadline | Bounds validation (1h–90d) | SI-DD-006 |
+| Unauthorized rollback | ADMIN role required | SI-DD-007 |
+| Panic on non-existent IDs | Silently skipped | SI-DD-008 |
+
+---
+
+## Cross-Contract Assumptions
+
+| Assumption | Guard |
+|-----------|-------|
+| `unlock_attestor` is safe to call when no lock exists | `current == 0` early return |
+| `get_attestor_for_attestation` returns `None` for business-submitted attestations | Soroban storage read returns `None` for unset keys |
+| `env.ledger().timestamp()` is monotonically non-decreasing | Soroban host guarantee |
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-07-29 | #521 | Initial — dispute deadline rollback security invariants (SI-DD-001 through SI-DD-010) |

--- a/docs/attestation-disputes.md
+++ b/docs/attestation-disputes.md
@@ -129,6 +129,14 @@ pub fn resolve_dispute(
 - `outcome`: Outcome of the dispute resolution
 - `notes`: Optional notes about the resolution
 
+**Side Effects**:
+- **Slashing** (Upheld only): If the outcome is `Upheld`, the attestor associated
+  with the disputed attestation is slashed via the staking contract (1000 token
+  units). This does not apply for `Rejected` or `Settled` outcomes.
+- **Attestor unlock** (always): Regardless of outcome, the attestor's lock is
+  released so they can submit new attestations. This ensures the dispute lifecycle
+  is complete and the attestor is no longer restricted.
+
 **Panics**:
 - If dispute doesn't exist
 - If dispute is not in Open status
@@ -200,6 +208,113 @@ Currently, any address can resolve disputes. In a production environment, this s
 - Multi-signature wallets
 - Predefined resolver addresses
 
+## Dispute Resolution Deadline & Automatic Rollback
+
+### Overview
+
+Disputes that remain unresolved beyond a configurable deadline can be automatically rolled back, preventing indefinite locks on disputed attestations. This mechanism ensures that the dispute lifecycle has a deterministic bound even if no party actively resolves the dispute.
+
+### Configuration
+
+The dispute resolution deadline is configurable via `set_dispute_deadline`:
+- **Default**: 7 days (`DISPUTE_DEADLINE_SECONDS = 604,800`)
+- **Minimum**: 1 hour (`MIN_DISPUTE_DEADLINE_SECONDS = 3,600`)
+- **Maximum**: 90 days (`MAX_DISPUTE_DEADLINE_SECONDS = 7,776,000`)
+
+```rust
+// Admin sets a custom deadline of 48 hours
+contract.set_dispute_deadline(admin, 172_800);
+
+// Query current deadline
+let deadline = contract.get_dispute_deadline();
+```
+
+### Rollback Mechanism
+
+#### Entry Point
+```rust
+pub fn check_and_rollback_disputes(
+    env: Env,
+    caller: Address,       // Must hold ADMIN role
+    dispute_ids: Vec<u64>,  // Candidate dispute IDs to check
+    limit: u32,             // Max number to roll back per call (CPU budget safety)
+) -> u32                    // Returns count of rolled-back disputes
+```
+
+#### Eligibility Conditions
+A dispute is rolled back only when **all** of the following are true:
+1. The dispute exists and has `Open` status (Resolved/Closed disputes skipped)
+2. The current ledger timestamp exceeds `dispute.timestamp + deadline`
+3. The deadline check uses strict less-than-or-equal (`elapsed <= deadline`) to skip, meaning the full deadline period is granted — a dispute is only rolled back when `elapsed > deadline`
+
+#### Rollback Actions
+When a dispute is rolled back, the following occurs atomically:
+1. Dispute status is set to `Closed`
+2. A `DisputeResolution` is recorded with:
+   - `outcome`: `Rejected`
+   - `notes`: `"Automatic rollback: dispute resolution deadline exceeded"`
+   - `timestamp`: Current ledger timestamp
+3. The associated attestor lock (if any) is released via `unlock_attestor`
+4. A `DisputeRolledBack` event is emitted
+
+#### Event
+```rust
+pub struct DisputeRolledBackEvent {
+    pub dispute_id: u64,        // Rolled-back dispute identifier
+    pub business: Address,       // Business associated with the dispute
+    pub period: String,          // Period of the disputed attestation
+    pub rolled_back_at: u64,     // Timestamp when rollback occurred
+    pub deadline_seconds: u64,   // Deadline threshold that was exceeded
+}
+```
+
+**Topic**: `dsp_rb` with secondary topic `business`
+
+### Security & Safety
+
+- **Admin-only**: Only ADMIN role can trigger rollbacks (via `access_control::require_admin`)
+- **CPU budget safety**: The `limit` parameter caps the number of disputes processed per call, preventing Soroban CPU instruction budget exhaustion
+- **Clock skew protection**: If a dispute's timestamp is in the future, elapsed time is treated as 0, preventing erroneous rollbacks
+- **Safe unlock**: `unlock_attestor` is a no-op when no attestor lock exists, so attestations submitted directly by businesses (not through attestors) are handled correctly
+- **Bound validation**: Configurable deadline is restricted to a safe range (1 hour to 90 days) to prevent misconfiguration
+
+### Usage Example
+
+```rust
+// Admin configures a 48-hour deadline
+contract.set_dispute_deadline(admin, 172_800);
+
+// Later: admin checks and rolls back expired disputes
+let dispute_ids = vec![1, 2, 3, 4, 5];
+let rolled_back = contract.check_and_rollback_disputes(
+    admin,
+    dispute_ids,
+    10u32,  // Process up to 10 per call
+);
+// Returns count of disputes that were past deadline and rolled back
+```
+
+### Idempotency
+
+`check_and_rollback_disputes` is idempotent:
+- Calling it multiple times with the same IDs only rolls back each eligible dispute once
+- Already-rolled-back disputes are skipped (status is no longer `Open`)
+- Non-existent dispute IDs are silently skipped
+
+### Testing Coverage
+
+Tests in `contracts/attestation/src/dispute_test.rs` cover:
+- Default deadline value (7 days)
+- Custom deadline configuration within bounds
+- Rejection of below-minimum and above-maximum deadlines
+- Disputes not rolled back before deadline elapses
+- Disputes rolled back after deadline elapses
+- Resolved disputes skipped (even if past deadline)
+- `limit` parameter respected (partial batches)
+- Non-existent and empty dispute ID lists
+- Exact deadline boundary (not rolled back)
+- Mixed Open/Resolved/Closed statuses
+
 ## Storage Design
 
 ### Instance Storage Keys
@@ -207,6 +322,7 @@ Currently, any address can resolve disputes. In a production environment, this s
 - `Dispute(u64)`: Individual dispute records
 - `DisputesByAttestation(Address, String)`: Index by attestation
 - `DisputesByChallenger(Address)`: Index by challenger
+- `DisputeDeadlineSeconds`: Configurable deadline for automatic rollback
 
 ### Indexing
 The system maintains two-way indexing for efficient queries:

--- a/docs/security-invariants.md
+++ b/docs/security-invariants.md
@@ -126,6 +126,49 @@
   Only the contract admin can register or update portfolios. Unauthorized
   callers panic with `"caller is not admin"`.
 
+### Attestation Contract — Dispute Deadline Rollback
+
+- **Dispute deadline rollback — strict boundary** (SI-DD-001)  
+  A dispute is rolled back only when elapsed time strictly exceeds the
+  deadline (`elapsed > deadline`). At the exact boundary, the dispute is not
+  rolled back.
+
+- **Dispute deadline rollback — clock skew guard** (SI-DD-002)  
+  If the dispute timestamp is in the future, elapsed time is treated as zero,
+  preventing premature rollback from ledger clock inconsistencies.
+
+- **Dispute deadline rollback — only Open disputes eligible** (SI-DD-003)  
+  Only `Open` disputes are eligible. `Resolved` or `Closed` disputes are
+  silently skipped.
+
+- **Dispute deadline rollback — safe attestor unlock** (SI-DD-004)  
+  `unlock_attestor` is a safe no-op when no lock exists, ensuring
+  idempotent handling.
+
+- **Dispute deadline rollback — CPU budget safety** (SI-DD-005)  
+  The `limit` parameter caps the number of disputes processed per call to
+  prevent Soroban CPU instruction budget exhaustion.
+
+- **Dispute deadline rollback — bounds validation** (SI-DD-006)  
+  `set_dispute_deadline` enforces bounds (1h–90d) to prevent
+  misconfiguration.
+
+- **Dispute deadline rollback — admin-only authorization** (SI-DD-007)  
+  Both `check_and_rollback_disputes` and `set_dispute_deadline` require the
+  ADMIN role.
+
+- **Dispute deadline rollback — graceful error handling** (SI-DD-008)  
+  Non-existent dispute IDs and empty input lists are handled silently
+  without panicking.
+
+- **Dispute deadline rollback — event emission** (SI-DD-009)  
+  Every successful rollback emits a `DisputeRolledBack` event with full
+  context.
+
+- **Dispute deadline rollback — immutable resolution** (SI-DD-010)  
+  The rollback resolution is written immutably; once closed, the dispute
+  is skipped on all future calls.
+
 ---
 
 ## Detailed Invariant Reference
@@ -300,6 +343,165 @@ new_version)`
 
 ### SI-015 — fee collection matches `get_fee_quote` at submission time
 
+---
+
+### SI-DD-001 — Dispute deadline rollback: strict boundary
+
+**Applies to:** `check_and_rollback_disputes`
+
+**Statement:**  
+A dispute is rolled back only when `elapsed > deadline`. At the exact boundary
+(`elapsed == deadline`) the dispute is NOT rolled back.
+
+```rust
+if elapsed <= deadline { continue; }
+```
+
+**Tests:** `test_check_and_rollback_disputes_exact_at_deadline_boundary`
+
+**Documentation:** `docs/attestation-dispute-deadline-security.md#si-dd-001`
+
+---
+
+### SI-DD-002 — Dispute deadline rollback: clock skew guard
+
+**Applies to:** `check_and_rollback_disputes`
+
+**Statement:**  
+If `now < dispute.timestamp`, elapsed is treated as zero.
+
+```rust
+let elapsed = if now >= dispute.timestamp {
+    now - dispute.timestamp
+} else {
+    0
+};
+```
+
+**Tests:** `test_check_and_rollback_disputes_before_deadline`
+
+**Documentation:** `docs/attestation-dispute-deadline-security.md#si-dd-002`
+
+---
+
+### SI-DD-003 — Dispute deadline rollback: only Open eligible
+
+**Applies to:** `check_and_rollback_disputes`
+
+**Statement:**  
+Only disputes with `DisputeStatus::Open` are eligible. `Resolved` and `Closed`
+disputes are silently skipped.
+
+```rust
+if dispute.status != DisputeStatus::Open { continue; }
+```
+
+**Tests:** `test_check_and_rollback_disputes_resolved_skipped`,
+`test_check_and_rollback_disputes_multiple_with_mixed_statuses`
+
+**Documentation:** `docs/attestation-dispute-deadline-security.md#si-dd-003`
+
+---
+
+### SI-DD-004 — Dispute deadline rollback: safe attestor unlock
+
+**Applies to:** `check_and_rollback_disputes` → `unlock_attestor`
+
+**Statement:**  
+`unlock_attestor` is a no-op when `current == 0`, making it safe to call even
+when no attestor lock exists for the dispute.
+
+**Tests:** `test_check_and_rollback_disputes_basic_closure`
+
+**Documentation:** `docs/attestation-dispute-deadline-security.md#si-dd-004`
+
+---
+
+### SI-DD-005 — Dispute deadline rollback: CPU budget safety
+
+**Applies to:** `check_and_rollback_disputes`
+
+**Statement:**  
+The `limit` parameter caps the number of disputes processed per call. The loop
+breaks when `rolled_back_count >= limit`.
+
+**Tests:** `test_check_and_rollback_disputes_limit`
+
+**Documentation:** `docs/attestation-dispute-deadline-security.md#si-dd-005`
+
+---
+
+### SI-DD-006 — Dispute deadline rollback: bounds validation
+
+**Applies to:** `set_dispute_deadline`
+
+**Statement:**  
+Deadline must be within `[MIN_DISPUTE_DEADLINE_SECONDS, MAX_DISPUTE_DEADLINE_SECONDS]`
+(1 hour to 90 days). Values outside this range are rejected with a panic.
+
+**Tests:** `test_set_dispute_deadline_too_low_panics`,
+`test_set_dispute_deadline_too_high_panics`
+
+**Documentation:** `docs/attestation-dispute-deadline-security.md#si-dd-006`
+
+---
+
+### SI-DD-007 — Dispute deadline rollback: admin-only authorization
+
+**Applies to:** `check_and_rollback_disputes`, `set_dispute_deadline`
+
+**Statement:**  
+Both entrypoints require the ADMIN role via `access_control::require_admin`.
+`get_dispute_deadline` is read-only and requires no authorization.
+
+**Tests:** (implicit via admin-gate pattern; consistent with SI-002/003)
+
+**Documentation:** `docs/attestation-dispute-deadline-security.md#si-dd-007`
+
+---
+
+### SI-DD-008 — Dispute deadline rollback: graceful error handling
+
+**Applies to:** `check_and_rollback_disputes`
+
+**Statement:**  
+Non-existent dispute IDs are silently skipped (`get_dispute` returns `None`).
+Empty ID lists immediately return `0` without processing.
+
+**Tests:** `test_check_and_rollback_disputes_nonexistent_skipped`,
+`test_check_and_rollback_disputes_empty_list`
+
+**Documentation:** `docs/attestation-dispute-deadline-security.md#si-dd-008`
+
+---
+
+### SI-DD-009 — Dispute deadline rollback: event emission
+
+**Applies to:** `check_and_rollback_disputes` → `emit_dispute_rolled_back`
+
+**Statement:**  
+Every successful rollback publishes a `DisputeRolledBack` event with
+`dispute_id`, `business`, `period`, `rolled_back_at`, and `deadline_seconds`.
+
+**Topic:** `(dsp_rb, business)` → `DisputeRolledBackEvent`
+
+**Documentation:** `docs/attestation-dispute-deadline-security.md#si-dd-009`
+
+---
+
+### SI-DD-010 — Dispute deadline rollback: immutable resolution
+
+**Applies to:** `check_and_rollback_disputes`
+
+**Statement:**  
+On rollback, both `store_dispute` (status → Closed) and
+`store_dispute_resolution` are called. Once closed, subsequent calls skip the
+rolled-back dispute.
+
+**Documentation:** `docs/attestation-dispute-deadline-security.md#si-dd-010`
+
+---
+
 **Applies to:** `submit_attestation`, `get_fee_quote`, `get_fee_quote_detailed`
 
 **Statement:**
@@ -428,4 +630,5 @@ For production gas benchmarks see `docs/contract-gas-benchmarks.md` and
 | Date | Author | Change |
 |---|---|---|
 | 2025-07 | Veritasor team | v2 — expanded to multi-contract scope; realigned all SI ids to actual `lib.rs` API; retired 9 stale invariants; added SI-006 (migrate), SI-007 (multi-period), SI-009 (dispute), SI-012 (spoofing), SI-013 (get_attestation) |
+| 2026-07-29 | #521 | Added SI-DD-001 through SI-DD-010 — dispute deadline rollback invariants |
 | 2025-07 | Veritasor team | v1 — initial draft (attestation contract only, 20 invariants) |


### PR DESCRIPTION
closes #521 

Summary
Disputes that remain unresolved beyond a configurable deadline are now automatically rolled back to the pre-dispute attestation state. This prevents indefinite locks on disputed attestations and frees attestors from being perpetually blocked by stale disputes.

Changes
Implementation
Core Logic ( dispute.rs )
-  check_and_rollback_disputes(dispute_ids, limit)  — batch-processes open disputes past their deadline, closes them with  DisputeOutcome::Rejected , releases the attestor lock, and emits a  DisputeRolledBack  event
-  get/set_dispute_deadline()  — configurable deadline with safe bounds:
- Default: 7 days (604,800 seconds)
- Min: 1 hour (3,600 seconds)
- Max: 90 days (7,776,000 seconds)
- Strict boundary check ( elapsed > deadline ) — full deadline period is granted before rollback
- Clock skew guard — future timestamps treated as elapsed=0
Events ( events.rs )
- New  DisputeRolledBackEvent  with topic  dsp_rb , containing:  dispute_id ,  business ,  period ,  rolled_back_at ,  deadline_seconds 
Entrypoints ( lib.rs )
-  check_and_rollback_disputes(caller, dispute_ids, limit) → u32  — admin-only
-  set_dispute_deadline(caller, deadline_seconds)  — admin-only
-  get_dispute_deadline() → u64  — public read
Security & Safety
- Admin-only:  check_and_rollback_disputes  and  set_dispute_deadline  both require ADMIN role
- CPU budget safe:  limit  parameter prevents unbounded iteration
- Safe unlock:  unlock_attestor  is a no-op when no lock exists (ref-counted, handles multiple concurrent disputes)
- Silent skip: Non-existent IDs, non-Open disputes are skipped without error
Bugs Fixed (Pre-existing)
1.  resolve_dispute  — Missing  }  after slashing block. Attestor unlock was incorrectly nested inside  if outcome == Upheld { } , meaning attestors were only unlocked on Upheld outcomes. Fixed: slashing is conditional on Upheld, but attestor unlock happens unconditionally (dispute lifecycle is complete regardless of outcome).
2.  handle_epoch_rollover  — Missing closing  }  before archive tier helpers section.
Tests Added
11 unit tests ( dispute_test.rs ):
- Default/custom deadline get/set + bounds violation
- Rollback before/after/at-exact deadline boundary
- Resolved disputes are skipped
-  limit  parameter enforcement
- Non-existent IDs and empty list handling
- Mixed status scenarios
- Basic closure verification
4 staking integration tests ( attestor_staking_integration_test.rs ):
-  test_deadline_rollback_unlocks_attestor  — Full staking flow: stake → submit → dispute → deadline rollback → attestor unlocked
-  test_deadline_rollback_before_deadline_keeps_locked  — Attestor stays locked when deadline hasn't passed
-  test_deadline_rollback_multiple_disputes_partial_unlock  — Attestor with 2 disputes, rolling back 1 keeps partially locked, rolling back both fully unlocks
-  test_deadline_rollback_attestor_can_submit_after_unlock  — After rollback, attestor can submit new attestations


