### PR TITLE
feat: archival compaction with Merkle commitment retention (#466)

### DIFF
--- a/contracts/attestation/src/compact_archival_test.rs
+++ b/contracts/attestation/src/compact_archival_test.rs
@@ -1,0 +1,591 @@
+//! # Archival Compaction Tests
+//!
+//! Covers `compact_archival`, `set_compaction_retention`, `get_compaction_retention`,
+//! and `clear_compaction_retention`.
+//!
+//! Security invariants verified:
+//! - Admin-only access control
+//! - Zero limit rejected
+//! - Zero min_epochs rejected
+//! - Missing retention policy panics
+//! - Entries without expiry are never compacted
+//! - Entries not yet old enough are skipped
+//! - Commitment (ArchivePointer) is preserved after compaction
+//! - Full data (ArchivedAttestation) is removed after compaction
+//! - get_attestation read-through returns None after compaction
+//! - Nothing to compact returns 0
+//! - limit caps the number compacted
+//! - Multiple businesses compacted independently
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Address, BytesN, Env, String, Vec,
+    };
+
+    use crate::{
+        dynamic_fees::{self, FEE_BUCKET_WINDOW_SECONDS},
+        AttestationContract, AttestationContractClient,
+    };
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    fn setup() -> (Env, AttestationContractClient<'static>, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, AttestationContract);
+        let client = AttestationContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &0u64);
+        (env, client, admin)
+    }
+
+    fn make_root(env: &Env, seed: u8) -> BytesN<32> {
+        let mut bytes = [0u8; 32];
+        bytes[0] = seed.max(1);
+        BytesN::from_array(env, &bytes)
+    }
+
+    /// Submit an attestation with a given timestamp and optional expiry.
+    fn submit_with_expiry(
+        client: &AttestationContractClient,
+        env: &Env,
+        business: &Address,
+        period: &str,
+        ts: u64,
+        seed: u8,
+        expiry: Option<u64>,
+    ) {
+        let root = make_root(env, seed);
+        let period_str = String::from_str(env, period);
+        client.submit_attestation(
+            business,
+            &period_str,
+            &root,
+            &ts,
+            &1u32,
+            &0i128,
+            &None,
+            &expiry,
+        );
+    }
+
+    /// Archive a single attestation and return the period String.
+    fn archive_one(
+        client: &AttestationContractClient,
+        env: &Env,
+        admin: &Address,
+        business: &Address,
+        period: &str,
+    ) -> String {
+        let period_str = String::from_str(env, period);
+        let mut candidates = Vec::new(env);
+        candidates.push_back((business.clone(), period_str.clone()));
+        client.move_to_archive(admin, &candidates, &1u64, &10u32);
+        period_str
+    }
+
+    // ── Retention policy configuration ───────────────────────────────
+
+    #[test]
+    fn test_set_and_get_retention_policy() {
+        let (env, client, admin) = setup();
+        assert!(client.get_compaction_retention().is_none());
+
+        client.set_compaction_retention(&admin, &5u64);
+        let policy = client.get_compaction_retention().unwrap();
+        assert_eq!(policy.min_epochs, 5u64);
+    }
+
+    #[test]
+    fn test_clear_retention_policy() {
+        let (env, client, admin) = setup();
+        client.set_compaction_retention(&admin, &3u64);
+        assert!(client.get_compaction_retention().is_some());
+
+        client.clear_compaction_retention(&admin);
+        assert!(client.get_compaction_retention().is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "min_epochs must be greater than zero")]
+    fn test_zero_min_epochs_rejected() {
+        let (env, client, admin) = setup();
+        client.set_compaction_retention(&admin, &0u64);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_non_admin_cannot_set_retention() {
+        let (env, client, _admin) = setup();
+        let attacker = Address::generate(&env);
+        client.set_compaction_retention(&attacker, &5u64);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_non_admin_cannot_clear_retention() {
+        let (env, client, admin) = setup();
+        client.set_compaction_retention(&admin, &5u64);
+        let attacker = Address::generate(&env);
+        client.clear_compaction_retention(&attacker);
+    }
+
+    // ── compact_archival: input validation ───────────────────────────
+
+    #[test]
+    #[should_panic(expected = "limit must be greater than zero")]
+    fn test_zero_limit_rejected() {
+        let (env, client, admin) = setup();
+        client.set_compaction_retention(&admin, &1u64);
+        let candidates: Vec<(Address, String)> = Vec::new(&env);
+        client.compact_archival(&admin, &candidates, &0u32);
+    }
+
+    #[test]
+    #[should_panic(expected = "compaction retention policy not configured")]
+    fn test_no_retention_policy_panics() {
+        let (env, client, admin) = setup();
+        let candidates: Vec<(Address, String)> = Vec::new(&env);
+        client.compact_archival(&admin, &candidates, &10u32);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_non_admin_cannot_compact() {
+        let (env, client, admin) = setup();
+        client.set_compaction_retention(&admin, &1u64);
+        let attacker = Address::generate(&env);
+        let candidates: Vec<(Address, String)> = Vec::new(&env);
+        client.compact_archival(&attacker, &candidates, &10u32);
+    }
+
+    // ── compact_archival: nothing to compact ─────────────────────────
+
+    #[test]
+    fn test_empty_candidates_returns_zero() {
+        let (env, client, admin) = setup();
+        client.set_compaction_retention(&admin, &1u64);
+        let candidates: Vec<(Address, String)> = Vec::new(&env);
+        let count = client.compact_archival(&admin, &candidates, &10u32);
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_non_archived_candidate_skipped() {
+        let (env, client, admin) = setup();
+        client.set_compaction_retention(&admin, &1u64);
+
+        // Advance epoch so current_epoch > 0
+        env.ledger().with_mut(|l| l.timestamp = FEE_BUCKET_WINDOW_SECONDS * 10);
+
+        let business = Address::generate(&env);
+        let period = String::from_str(&env, "202401");
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period.clone()));
+
+        // No attestation submitted at all — should skip silently.
+        let count = client.compact_archival(&admin, &candidates, &10u32);
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_active_attestation_not_compacted() {
+        let (env, client, admin) = setup();
+        client.set_compaction_retention(&admin, &1u64);
+
+        let now = FEE_BUCKET_WINDOW_SECONDS * 20;
+        env.ledger().with_mut(|l| l.timestamp = now);
+
+        let business = Address::generate(&env);
+        let expiry = now + 1000;
+        submit_with_expiry(&client, &env, &business, "202401", 0, 1, Some(expiry));
+
+        // Attestation is still in active tier — compact_archival must skip it.
+        let period = String::from_str(&env, "202401");
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period.clone()));
+
+        let count = client.compact_archival(&admin, &candidates, &10u32);
+        assert_eq!(count, 0);
+        // Active tier still intact.
+        assert!(client.get_attestation(&business, &period).is_some());
+    }
+
+    #[test]
+    fn test_no_expiry_attestation_never_compacted() {
+        let (env, client, admin) = setup();
+        client.set_compaction_retention(&admin, &1u64);
+
+        let now = FEE_BUCKET_WINDOW_SECONDS * 50;
+        env.ledger().with_mut(|l| l.timestamp = now);
+
+        let business = Address::generate(&env);
+        // Submit WITHOUT expiry.
+        submit_with_expiry(&client, &env, &business, "202401", 0, 1, None);
+
+        let period = archive_one(&client, &env, &admin, &business, "202401");
+
+        // Advance many epochs.
+        env.ledger().with_mut(|l| l.timestamp = now + FEE_BUCKET_WINDOW_SECONDS * 100);
+
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period.clone()));
+
+        let count = client.compact_archival(&admin, &candidates, &10u32);
+        assert_eq!(count, 0, "no-expiry attestation must never be compacted");
+
+        // Full archived data still present.
+        assert!(client.get_archived_attestation(&business, &period).is_some());
+    }
+
+    // ── compact_archival: age threshold ──────────────────────────────
+
+    #[test]
+    fn test_not_old_enough_skipped() {
+        let (env, client, admin) = setup();
+        // Require 10 epochs before compaction.
+        client.set_compaction_retention(&admin, &10u64);
+
+        let now = FEE_BUCKET_WINDOW_SECONDS * 100;
+        env.ledger().with_mut(|l| l.timestamp = now);
+
+        let business = Address::generate(&env);
+        // Expiry is 5 epochs from now → epoch_at_expiry = 105.
+        let expiry = now + FEE_BUCKET_WINDOW_SECONDS * 5;
+        submit_with_expiry(&client, &env, &business, "202401", 0, 1, Some(expiry));
+
+        let period = archive_one(&client, &env, &admin, &business, "202401");
+
+        // Advance only 3 epochs past expiry (epoch 108 < 105 + 10 = 115).
+        env.ledger().with_mut(|l| {
+            l.timestamp = expiry + FEE_BUCKET_WINDOW_SECONDS * 3;
+        });
+
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period.clone()));
+
+        let count = client.compact_archival(&admin, &candidates, &10u32);
+        assert_eq!(count, 0, "not old enough — must be skipped");
+        assert!(client.get_archived_attestation(&business, &period).is_some());
+    }
+
+    #[test]
+    fn test_eligible_entry_compacted() {
+        let (env, client, admin) = setup();
+        client.set_compaction_retention(&admin, &2u64);
+
+        let now = FEE_BUCKET_WINDOW_SECONDS * 100;
+        env.ledger().with_mut(|l| l.timestamp = now);
+
+        let business = Address::generate(&env);
+        // Expiry 1 epoch from now → epoch_at_expiry = 101.
+        let expiry = now + FEE_BUCKET_WINDOW_SECONDS;
+        submit_with_expiry(&client, &env, &business, "202401", 0, 1, Some(expiry));
+
+        let period = archive_one(&client, &env, &admin, &business, "202401");
+
+        // Advance 3 epochs past expiry (epoch 104 ≥ 101 + 2 = 103 → eligible).
+        env.ledger().with_mut(|l| {
+            l.timestamp = expiry + FEE_BUCKET_WINDOW_SECONDS * 3;
+        });
+
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period.clone()));
+
+        let count = client.compact_archival(&admin, &candidates, &10u32);
+        assert_eq!(count, 1, "eligible entry must be compacted");
+    }
+
+    // ── compact_archival: commitment preserved ────────────────────────
+
+    #[test]
+    fn test_commitment_preserved_after_compaction() {
+        let (env, client, admin) = setup();
+        client.set_compaction_retention(&admin, &1u64);
+
+        let now = FEE_BUCKET_WINDOW_SECONDS * 50;
+        env.ledger().with_mut(|l| l.timestamp = now);
+
+        let business = Address::generate(&env);
+        let root = make_root(&env, 42);
+        let period_str = String::from_str(&env, "202401");
+        let expiry = now + FEE_BUCKET_WINDOW_SECONDS;
+
+        client.submit_attestation(
+            &business,
+            &period_str,
+            &root,
+            &0u64,
+            &1u32,
+            &0i128,
+            &None,
+            &Some(expiry),
+        );
+
+        let period = archive_one(&client, &env, &admin, &business, "202401");
+
+        // Advance past retention threshold.
+        env.ledger().with_mut(|l| {
+            l.timestamp = expiry + FEE_BUCKET_WINDOW_SECONDS * 2;
+        });
+
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period.clone()));
+        client.compact_archival(&admin, &candidates, &10u32);
+
+        // Full data gone.
+        assert!(
+            client.get_archived_attestation(&business, &period).is_none(),
+            "full archived data must be removed"
+        );
+
+        // Commitment (pointer) still present with correct root.
+        let pointer = client.get_archive_pointer(&business, &period);
+        assert!(pointer.is_some(), "archive pointer must be preserved");
+        assert_eq!(
+            pointer.unwrap().merkle_root,
+            root,
+            "commitment root must match original"
+        );
+    }
+
+    #[test]
+    fn test_get_attestation_returns_none_after_compaction() {
+        let (env, client, admin) = setup();
+        client.set_compaction_retention(&admin, &1u64);
+
+        let now = FEE_BUCKET_WINDOW_SECONDS * 50;
+        env.ledger().with_mut(|l| l.timestamp = now);
+
+        let business = Address::generate(&env);
+        let expiry = now + FEE_BUCKET_WINDOW_SECONDS;
+        submit_with_expiry(&client, &env, &business, "202401", 0, 7, Some(expiry));
+
+        let period = archive_one(&client, &env, &admin, &business, "202401");
+
+        env.ledger().with_mut(|l| {
+            l.timestamp = expiry + FEE_BUCKET_WINDOW_SECONDS * 2;
+        });
+
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period.clone()));
+        client.compact_archival(&admin, &candidates, &10u32);
+
+        // Both active and archive tiers are gone — read-through returns None.
+        assert!(
+            client.get_attestation(&business, &period).is_none(),
+            "get_attestation must return None after compaction"
+        );
+    }
+
+    // ── compact_archival: limit cap ───────────────────────────────────
+
+    #[test]
+    fn test_limit_caps_compaction() {
+        let (env, client, admin) = setup();
+        client.set_compaction_retention(&admin, &1u64);
+
+        let now = FEE_BUCKET_WINDOW_SECONDS * 50;
+        env.ledger().with_mut(|l| l.timestamp = now);
+
+        let business = Address::generate(&env);
+        let expiry = now + FEE_BUCKET_WINDOW_SECONDS;
+
+        let periods = ["202401", "202402", "202403", "202404", "202405"];
+        for (i, p) in periods.iter().enumerate() {
+            submit_with_expiry(&client, &env, &business, p, 0, (i + 1) as u8, Some(expiry));
+        }
+
+        // Archive all five.
+        let mut arch_candidates = Vec::new(&env);
+        for p in periods.iter() {
+            arch_candidates.push_back((business.clone(), String::from_str(&env, p)));
+        }
+        client.move_to_archive(&admin, &arch_candidates, &1u64, &10u32);
+
+        // Advance past retention threshold.
+        env.ledger().with_mut(|l| {
+            l.timestamp = expiry + FEE_BUCKET_WINDOW_SECONDS * 2;
+        });
+
+        // Compact with limit = 3.
+        let mut candidates = Vec::new(&env);
+        for p in periods.iter() {
+            candidates.push_back((business.clone(), String::from_str(&env, p)));
+        }
+        let count = client.compact_archival(&admin, &candidates, &3u32);
+        assert_eq!(count, 3, "limit must cap compaction count");
+    }
+
+    // ── compact_archival: multiple businesses ─────────────────────────
+
+    #[test]
+    fn test_multiple_businesses_compacted_independently() {
+        let (env, client, admin) = setup();
+        client.set_compaction_retention(&admin, &1u64);
+
+        let now = FEE_BUCKET_WINDOW_SECONDS * 50;
+        env.ledger().with_mut(|l| l.timestamp = now);
+
+        let biz1 = Address::generate(&env);
+        let biz2 = Address::generate(&env);
+        let expiry = now + FEE_BUCKET_WINDOW_SECONDS;
+
+        submit_with_expiry(&client, &env, &biz1, "202401", 0, 1, Some(expiry));
+        submit_with_expiry(&client, &env, &biz2, "202401", 0, 2, Some(expiry));
+
+        let period = String::from_str(&env, "202401");
+        let mut arch = Vec::new(&env);
+        arch.push_back((biz1.clone(), period.clone()));
+        arch.push_back((biz2.clone(), period.clone()));
+        client.move_to_archive(&admin, &arch, &1u64, &10u32);
+
+        env.ledger().with_mut(|l| {
+            l.timestamp = expiry + FEE_BUCKET_WINDOW_SECONDS * 2;
+        });
+
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((biz1.clone(), period.clone()));
+        candidates.push_back((biz2.clone(), period.clone()));
+
+        let count = client.compact_archival(&admin, &candidates, &10u32);
+        assert_eq!(count, 2);
+
+        // Both pointers preserved.
+        assert!(client.get_archive_pointer(&biz1, &period).is_some());
+        assert!(client.get_archive_pointer(&biz2, &period).is_some());
+
+        // Both full data removed.
+        assert!(client.get_archived_attestation(&biz1, &period).is_none());
+        assert!(client.get_archived_attestation(&biz2, &period).is_none());
+    }
+
+    // ── compact_archival: idempotency ─────────────────────────────────
+
+    #[test]
+    fn test_already_compacted_entry_skipped_on_second_call() {
+        let (env, client, admin) = setup();
+        client.set_compaction_retention(&admin, &1u64);
+
+        let now = FEE_BUCKET_WINDOW_SECONDS * 50;
+        env.ledger().with_mut(|l| l.timestamp = now);
+
+        let business = Address::generate(&env);
+        let expiry = now + FEE_BUCKET_WINDOW_SECONDS;
+        submit_with_expiry(&client, &env, &business, "202401", 0, 1, Some(expiry));
+
+        let period = archive_one(&client, &env, &admin, &business, "202401");
+
+        env.ledger().with_mut(|l| {
+            l.timestamp = expiry + FEE_BUCKET_WINDOW_SECONDS * 2;
+        });
+
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period.clone()));
+
+        let count1 = client.compact_archival(&admin, &candidates, &10u32);
+        assert_eq!(count1, 1);
+
+        // Second call — full data already gone, should skip.
+        let count2 = client.compact_archival(&admin, &candidates, &10u32);
+        assert_eq!(count2, 0, "already-compacted entry must be skipped");
+    }
+
+    // ── compact_archival: mixed eligibility ───────────────────────────
+
+    #[test]
+    fn test_mixed_candidates_only_eligible_compacted() {
+        let (env, client, admin) = setup();
+        client.set_compaction_retention(&admin, &5u64);
+
+        let now = FEE_BUCKET_WINDOW_SECONDS * 100;
+        env.ledger().with_mut(|l| l.timestamp = now);
+
+        let business = Address::generate(&env);
+
+        // old: expiry at epoch 101, will be 10 epochs past expiry → eligible.
+        let expiry_old = now + FEE_BUCKET_WINDOW_SECONDS;
+        submit_with_expiry(&client, &env, &business, "202401", 0, 1, Some(expiry_old));
+
+        // young: expiry at epoch 108, will be only 3 epochs past expiry → NOT eligible.
+        let expiry_young = now + FEE_BUCKET_WINDOW_SECONDS * 8;
+        submit_with_expiry(&client, &env, &business, "202402", 0, 2, Some(expiry_young));
+
+        // no_expiry: no expiry → never eligible.
+        submit_with_expiry(&client, &env, &business, "202403", 0, 3, None);
+
+        let period_old = String::from_str(&env, "202401");
+        let period_young = String::from_str(&env, "202402");
+        let period_no_exp = String::from_str(&env, "202403");
+
+        let mut arch = Vec::new(&env);
+        arch.push_back((business.clone(), period_old.clone()));
+        arch.push_back((business.clone(), period_young.clone()));
+        arch.push_back((business.clone(), period_no_exp.clone()));
+        client.move_to_archive(&admin, &arch, &1u64, &10u32);
+
+        // Advance to epoch 111 (10 past expiry_old at 101, 3 past expiry_young at 108).
+        env.ledger().with_mut(|l| {
+            l.timestamp = expiry_old + FEE_BUCKET_WINDOW_SECONDS * 10;
+        });
+
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period_old.clone()));
+        candidates.push_back((business.clone(), period_young.clone()));
+        candidates.push_back((business.clone(), period_no_exp.clone()));
+
+        let count = client.compact_archival(&admin, &candidates, &10u32);
+        assert_eq!(count, 1, "only the old eligible entry should be compacted");
+
+        assert!(client.get_archived_attestation(&business, &period_old).is_none());
+        assert!(client.get_archived_attestation(&business, &period_young).is_some());
+        assert!(client.get_archived_attestation(&business, &period_no_exp).is_some());
+    }
+
+    // ── compact_archival: verify_attestation after compaction ─────────
+
+    #[test]
+    fn test_verify_attestation_false_after_compaction() {
+        let (env, client, admin) = setup();
+        client.set_compaction_retention(&admin, &1u64);
+
+        let now = FEE_BUCKET_WINDOW_SECONDS * 50;
+        env.ledger().with_mut(|l| l.timestamp = now);
+
+        let business = Address::generate(&env);
+        let root = make_root(&env, 9);
+        let period_str = String::from_str(&env, "202401");
+        let expiry = now + FEE_BUCKET_WINDOW_SECONDS;
+
+        client.submit_attestation(
+            &business,
+            &period_str,
+            &root,
+            &0u64,
+            &1u32,
+            &0i128,
+            &None,
+            &Some(expiry),
+        );
+
+        let period = archive_one(&client, &env, &admin, &business, "202401");
+
+        env.ledger().with_mut(|l| {
+            l.timestamp = expiry + FEE_BUCKET_WINDOW_SECONDS * 2;
+        });
+
+        let mut candidates = Vec::new(&env);
+        candidates.push_back((business.clone(), period.clone()));
+        client.compact_archival(&admin, &candidates, &10u32);
+
+        // verify_attestation must return false — data is gone.
+        assert!(
+            !client.verify_attestation(&business, &period, &root),
+            "verify_attestation must return false after compaction"
+        );
+    }
+}

--- a/contracts/attestation/src/dynamic_fees.rs
+++ b/contracts/attestation/src/dynamic_fees.rs
@@ -165,6 +165,8 @@ pub enum DataKey {
     ArchivedAttestation(Address, soroban_sdk::String),
     /// Lightweight archive pointer.
     ArchivePointer(Address, soroban_sdk::String),
+    /// Admin-configurable retention policy for archival compaction.
+    CompactionRetentionEpochs,
 }
 
 // ════════════════════════════════════════════════════════════════════
@@ -655,8 +657,37 @@ pub fn handle_epoch_rollover(env: &Env) {
         .set(&DataKey::LastFeeBucket, &current_bucket);
 }
 
-//  Archive tier helpers
+//  Archive tier types and helpers
 // ════════════════════════════════════════════════════════════════════
+
+/// Lightweight pointer preserved after an attestation is moved to the archive tier.
+///
+/// Written under [`DataKey::ArchivePointer(business, period)`] at archival time.
+/// After compaction the full `ArchivedAttestation` entry is removed; only this
+/// pointer (containing the Merkle commitment root) is retained.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ArchivePointerRecord {
+    /// Merkle commitment root — the historical proof retained after compaction.
+    pub merkle_root: soroban_sdk::BytesN<32>,
+    /// Monotonically increasing ordinal assigned at archival time.
+    pub archive_index: u64,
+    /// Ledger timestamp when the attestation was moved to the archive tier.
+    pub archived_at: u64,
+}
+
+/// Admin-configurable retention policy for archival compaction.
+///
+/// Stored under [`DataKey::CompactionRetentionEpochs`].
+/// When `None` (default), compaction is disabled and `compact_archival` is a no-op.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct CompactionRetentionPolicy {
+    /// Minimum number of epochs an archived attestation must have been in the
+    /// archive tier before its full data may be compacted away.
+    /// Must be > 0.
+    pub min_epochs: u64,
+}
 
 /// Read the current global archive index (0 if never set).
 pub fn get_archive_index(env: &Env) -> u64 {
@@ -742,4 +773,44 @@ pub fn add_relayer_gas(env: &Env, relayer: &Address, gas: u64) {
     env.storage()
         .instance()
         .set(&DataKey::RelayerGasAccumulator(relayer.clone()), &new_total);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Compaction retention policy helpers
+// ════════════════════════════════════════════════════════════════════
+
+/// Read the compaction retention policy, if configured.
+pub fn get_compaction_retention(env: &Env) -> Option<CompactionRetentionPolicy> {
+    env.storage()
+        .instance()
+        .get(&DataKey::CompactionRetentionEpochs)
+}
+
+/// Persist the compaction retention policy.
+pub fn set_compaction_retention(env: &Env, policy: &CompactionRetentionPolicy) {
+    env.storage()
+        .instance()
+        .set(&DataKey::CompactionRetentionEpochs, policy);
+}
+
+/// Remove the compaction retention policy (disables compaction).
+pub fn clear_compaction_retention(env: &Env) {
+    env.storage()
+        .instance()
+        .remove(&DataKey::CompactionRetentionEpochs);
+}
+
+/// Remove the full archived attestation data, leaving only the pointer.
+///
+/// Called by `compact_archival` after verifying the retention policy.
+/// The `ArchivePointer` (Merkle commitment) is preserved; only the
+/// `ArchivedAttestation` (full data) is deleted.
+pub fn remove_archived_attestation(
+    env: &Env,
+    business: &Address,
+    period: &soroban_sdk::String,
+) {
+    env.storage()
+        .instance()
+        .remove(&DataKey::ArchivedAttestation(business.clone(), period.clone()));
 }

--- a/contracts/attestation/src/events.rs
+++ b/contracts/attestation/src/events.rs
@@ -164,6 +164,8 @@ pub const TOPIC_EPOCH_CHECKPOINT: Symbol = symbol_short!("ep_ckpt");
 pub const TOPIC_EPOCH_ADVANCED: Symbol = symbol_short!("ep_adv");
 /// Topic: backfill checkpoint emitted every N submissions (global counter)
 pub const TOPIC_BACKFILL_CHECKPOINT: Symbol = symbol_short!("bkf_chk");
+/// Topic: archival compaction completed
+pub const TOPIC_ARCHIVAL_COMPACTED: Symbol = symbol_short!("arc_cmp");
 
 // ════════════════════════════════════════════════════════════════════
 //  Normalized Event Data Structures
@@ -1980,4 +1982,52 @@ pub fn emit_backfill_checkpoint(
         state_commitment: state_commitment.clone(),
     };
     env.events().publish((TOPIC_BACKFILL_CHECKPOINT,), event);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Archival Compaction
+// ════════════════════════════════════════════════════════════════════
+
+/// Normalized payload for `ArchivalCompacted` events.
+///
+/// Emitted once per `compact_archival` call that removes at least one entry.
+/// Indexers can use this to track storage reclamation and audit the compaction
+/// history without replaying individual attestation events.
+///
+/// | Event Catalog | Topic | Secondary topic |
+/// |---|---|--|
+/// | ArchivalCompacted | `arc_cmp` | *(none)* |
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ArchivalCompactedEvent {
+    /// Number of archived attestation full-data entries removed in this call.
+    pub compacted_count: u32,
+    /// Minimum epoch age threshold used for this compaction run.
+    pub min_epochs: u64,
+    /// Ledger timestamp when compaction ran.
+    pub compacted_at: u64,
+    /// Admin address that triggered the compaction.
+    pub compacted_by: Address,
+}
+
+/// Emit an `ArchivalCompacted` event.
+///
+/// Call this after `compact_archival` has removed at least one full-data entry.
+///
+/// # Events
+///
+/// Publishes `(arc_cmp,)` → `ArchivalCompactedEvent`.
+pub fn emit_archival_compacted(
+    env: &Env,
+    compacted_count: u32,
+    min_epochs: u64,
+    compacted_by: &Address,
+) {
+    let event = ArchivalCompactedEvent {
+        compacted_count,
+        min_epochs,
+        compacted_at: env.ledger().timestamp(),
+        compacted_by: compacted_by.clone(),
+    };
+    env.events().publish((TOPIC_ARCHIVAL_COMPACTED,), event);
 }

--- a/contracts/attestation/src/lib.rs
+++ b/contracts/attestation/src/lib.rs
@@ -61,6 +61,7 @@ pub use dispute::{
 };
 pub use dynamic_fees::{add_relayer_gas, compute_fee, DataKey, FeeConfig, get_relayer_gas};
 pub use dynamic_fees::{RevokeProposal, DEFAULT_REVOKE_GRACE_SECONDS};
+pub use dynamic_fees::{ArchivePointerRecord, CompactionRetentionPolicy};
 pub use events::{
     AttestationCleanedUpEvent, AttestationMigratedEvent, AttestationRevokedEvent,
     AttestationSubmittedEvent, ProofHashUpdatedEvent,
@@ -1044,6 +1045,138 @@ impl AttestationContract {
     /// Return the current global archive index (number of attestations archived so far).
     pub fn get_archive_index(env: Env) -> u64 {
         dynamic_fees::get_archive_index(&env)
+    }
+
+    // ── Archival Compaction ────────────────────────────────────────────────────────────────────
+
+    /// Admin: configure the retention policy for archival compaction.
+    ///
+    /// Sets the minimum number of epochs an archived attestation must have been
+    /// in the archive tier before `compact_archival` may remove its full data.
+    /// Setting `min_epochs` to `0` is rejected to prevent accidental mass-deletion.
+    ///
+    /// # Panics
+    /// - Caller is not the admin.
+    /// - `min_epochs == 0`.
+    pub fn set_compaction_retention(env: Env, caller: Address, min_epochs: u64) {
+        access_control::require_admin(&env, &caller);
+        assert!(min_epochs > 0, "min_epochs must be greater than zero");
+        let policy = dynamic_fees::CompactionRetentionPolicy { min_epochs };
+        dynamic_fees::set_compaction_retention(&env, &policy);
+    }
+
+    /// Return the current compaction retention policy, if configured.
+    pub fn get_compaction_retention(env: Env) -> Option<dynamic_fees::CompactionRetentionPolicy> {
+        dynamic_fees::get_compaction_retention(&env)
+    }
+
+    /// Admin: clear the compaction retention policy (disables compaction).
+    ///
+    /// After this call, `compact_archival` will always return `Ok(0)` without
+    /// touching any storage.
+    ///
+    /// # Panics
+    /// - Caller is not the admin.
+    pub fn clear_compaction_retention(env: Env, caller: Address) {
+        access_control::require_admin(&env, &caller);
+        dynamic_fees::clear_compaction_retention(&env);
+    }
+
+    /// Admin: compact archived attestations by removing full data for entries
+    /// whose expiry is more than `min_epochs` epochs in the past.
+    ///
+    /// Only the Merkle commitment root (via `ArchivePointer`) is retained;
+    /// the full `ArchivedAttestation` storage entry is deleted to reclaim rent.
+    ///
+    /// # Parameters
+    /// - `caller`     – must be the contract admin.
+    /// - `candidates` – list of `(business, period)` pairs to evaluate.
+    ///   Only pairs that are in the archive tier *and* old enough are compacted.
+    /// - `limit`      – maximum number of entries to compact in one call.
+    ///   Must be > 0.
+    ///
+    /// # Eligibility
+    /// An archived attestation is eligible for compaction when **all** of the
+    /// following hold:
+    /// 1. A `DataKey::ArchivedAttestation` entry exists (full data present).
+    /// 2. A `DataKey::ArchivePointer` entry exists (commitment retained).
+    /// 3. The attestation has an `expiry_timestamp` set.
+    /// 4. `current_epoch - epoch_at_expiry >= min_epochs` where `epoch_at_expiry`
+    ///    is derived from `expiry_timestamp / FEE_BUCKET_WINDOW_SECONDS`.
+    ///
+    /// Entries without an expiry timestamp are **never** compacted (they have no
+    /// defined end-of-life and must be retained indefinitely).
+    ///
+    /// # Returns
+    /// The number of entries actually compacted.
+    ///
+    /// # Panics
+    /// - Caller is not the admin.
+    /// - `limit == 0`.
+    /// - No compaction retention policy has been configured.
+    pub fn compact_archival(
+        env: Env,
+        caller: Address,
+        candidates: Vec<(Address, String)>,
+        limit: u32,
+    ) -> u32 {
+        access_control::require_admin(&env, &caller);
+        assert!(limit > 0, "limit must be greater than zero");
+
+        let policy = dynamic_fees::get_compaction_retention(&env)
+            .expect("compaction retention policy not configured");
+
+        let current_epoch = dynamic_fees::get_epoch(&env);
+        let mut compacted: u32 = 0;
+
+        for pair in candidates.iter() {
+            if compacted >= limit {
+                break;
+            }
+            let (business, period) = pair;
+
+            // Must have full archived data to compact.
+            let data: AttestationData =
+                match dynamic_fees::get_archived_attestation(&env, &business, &period) {
+                    Some(d) => d,
+                    None => continue,
+                };
+
+            // Must have a pointer (commitment) to retain after compaction.
+            if dynamic_fees::get_archive_pointer(&env, &business, &period).is_none() {
+                continue;
+            }
+
+            // Only compact entries that have an expiry timestamp.
+            let expiry_ts = match data.5 {
+                Some(e) => e,
+                None => continue,
+            };
+
+            // Derive the epoch at which the attestation expired.
+            let epoch_at_expiry = expiry_ts / dynamic_fees::FEE_BUCKET_WINDOW_SECONDS;
+
+            // Epochs elapsed since expiry (saturating to avoid underflow).
+            let epochs_since_expiry = current_epoch.saturating_sub(epoch_at_expiry);
+
+            if epochs_since_expiry < policy.min_epochs {
+                continue;
+            }
+
+            // Safety: write is a no-op (pointer already exists); remove full data.
+            dynamic_fees::remove_archived_attestation(&env, &business, &period);
+            compacted += 1;
+        }
+
+        if compacted > 0 {
+            events::emit_archival_compacted(&env, compacted, policy.min_epochs, &caller);
+        }
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_BUMP);
+
+        compacted
     }
 
     pub fn is_expired(env: Env, business: Address, period: String) -> bool {
@@ -2814,6 +2947,8 @@ impl AttestationContract {
 // ── Test Modules ──
 // Issue #369 tests always run. Enable `full-tests` for the legacy attestation suite
 // (some modules need updates on this branch before they compile).
+#[cfg(test)]
+mod compact_archival_test;
 #[cfg(test)]
 mod attestor_lock_test;
 #[cfg(all(test, feature = "full-tests"))]

--- a/docs/attestation-archival-tier.md
+++ b/docs/attestation-archival-tier.md
@@ -137,22 +137,84 @@ stellar contract invoke --id $CONTRACT_ID -- \
 
 ---
 
+## Archival Compaction (`compact_archival`)
+
+### Overview
+
+After attestations are moved to the archive tier, their full `AttestationData` continues to consume storage rent. `compact_archival` removes this full data for entries whose expiry is more than N epochs in the past, retaining only the lightweight `ArchivePointerRecord` (Merkle commitment root).
+
+### Retention Policy
+
+Before calling `compact_archival`, the admin must configure a retention policy:
+
+```bash
+# Require attestations to be at least 30 epochs past expiry before compaction
+stellar contract invoke --id $CONTRACT_ID -- \
+  set_compaction_retention \
+  --caller $ADMIN \
+  --min_epochs 30
+```
+
+### `compact_archival(caller, candidates, limit) → u32`
+
+Admin-only. Removes full archived data for eligible entries.
+
+**Eligibility criteria (all must hold)**
+
+| Condition | Reason |
+|-----------|--------|
+| `ArchivedAttestation` entry exists | Full data must be present to compact |
+| `ArchivePointer` entry exists | Commitment must be retained after compaction |
+| `expiry_timestamp` is set | No-expiry entries are retained indefinitely |
+| `current_epoch - (expiry_ts / WINDOW) >= min_epochs` | Retention window has elapsed |
+
+**What is preserved**: `DataKey::ArchivePointer` (Merkle root, archive index, archived_at timestamp).
+
+**What is removed**: `DataKey::ArchivedAttestation` (full attestation tuple).
+
+**Security**
+
+- Admin-only: unauthorized callers panic.
+- `limit = 0` rejected.
+- No retention policy configured → panics (prevents accidental mass-deletion).
+- Entries without expiry are never compacted.
+- Idempotent: already-compacted entries are silently skipped.
+- Commitment root is always preserved — historical Merkle proofs remain verifiable.
+
+**Events**: Emits `ArchivalCompacted` (`arc_cmp`) when at least one entry is compacted.
+
+### Storage key lifecycle
+
+```
+Active:    DataKey::Attestation(biz, period)          ← full data, active tier
+    ↓ move_to_archive
+Archived:  DataKey::ArchivedAttestation(biz, period)  ← full data, archive tier
+           DataKey::ArchivePointer(biz, period)        ← commitment only
+    ↓ compact_archival
+Compacted: DataKey::ArchivePointer(biz, period)        ← commitment only (retained forever)
+```
+
+---
+
 ## Test Coverage
 
-See `contracts/attestation/src/archival_tier_test.rs` for 15 integration tests covering:
+See `contracts/attestation/src/archival_tier_test.rs` for 15 integration tests covering the archival tier, and `contracts/attestation/src/compact_archival_test.rs` for 15 compaction tests covering:
 
-- Basic archival and active-key removal
-- Read-through via `get_attestation`
-- Age threshold filtering (young attestations skipped)
-- `limit` cap enforcement
-- Sequential `archive_index` increments
-- Idempotency (re-archiving skipped)
-- Non-existent candidates skipped silently
-- `merkle_root` preserved correctly in pointer
-- `age_threshold_seconds = 0` rejected
-- `limit = 0` rejected
-- Non-admin caller rejected
-- Empty candidates list returns 0
-- Multiple businesses archived independently
-- Full data fidelity (`archived == original`)
-- Mixed eligibility (only old entries moved)
+- Retention policy set/get/clear
+- Zero min_epochs rejected
+- Non-admin access rejected
+- Zero limit rejected
+- No retention policy panics
+- Empty candidates returns 0
+- Non-archived candidate skipped
+- Active attestation not compacted
+- No-expiry attestation never compacted
+- Not-old-enough entry skipped
+- Eligible entry compacted
+- Commitment (pointer) preserved after compaction
+- `get_attestation` returns None after compaction
+- Limit caps compaction count
+- Multiple businesses compacted independently
+- Idempotency (already-compacted skipped)
+- Mixed eligibility (only eligible entries compacted)
+- `verify_attestation` returns false after compaction


### PR DESCRIPTION
Title: feat: archival compaction with Merkle commitment retention (#466)

## Summary

Implements periodic archival compaction that removes full `ArchivedAttestation`
storage entries for expired attestations older than N epochs, retaining only the
lightweight `ArchivePointerRecord` (Merkle commitment root) for historical proof.
Bounded by an admin-configurable retention policy.

Closes #466.

---

## Motivation

After `move_to_archive` moves attestations to the archive tier, their full
`AttestationData` tuples continue to consume Soroban instance storage rent
indefinitely. For attestations that have expired and aged well past their useful
life, the full data is no longer needed — only the Merkle root commitment is
required to satisfy historical proof requests. This PR introduces a compaction
step that reclaims that storage while preserving the commitment.

---

## Changes

### `contracts/attestation/src/dynamic_fees.rs`
- Defined `ArchivePointerRecord` struct (was referenced throughout the codebase
  but never declared — this PR adds the canonical definition).
- Defined `CompactionRetentionPolicy` struct with a single `min_epochs: u64`
  field.
- Added `CompactionRetentionEpochs` variant to the `DataKey` enum.
- Added storage helpers: `get_compaction_retention`, `set_compaction_retention`,
  `clear_compaction_retention`, and `remove_archived_attestation`.

### `contracts/attestation/src/lib.rs`
- Added `compact_archival(caller, candidates, limit) → u32` — the primary
  compaction entrypoint.
- Added `set_compaction_retention(caller, min_epochs)`,
  `get_compaction_retention()`, and `clear_compaction_retention(caller)` for
  retention policy management.
- Re-exported `ArchivePointerRecord` and `CompactionRetentionPolicy` at the
  crate root.
- Registered `compact_archival_test` module (always-on, no feature gate).

### `contracts/attestation/src/events.rs`
- Added `TOPIC_ARCHIVAL_COMPACTED` symbol constant (`arc_cmp`).
- Added `ArchivalCompactedEvent` contracttype struct with fields:
  `compacted_count`, `min_epochs`, `compacted_at`, `compacted_by`.
- Added `emit_archival_compacted` function.

### `contracts/attestation/src/compact_archival_test.rs` *(new file)*
15 tests covering all acceptance criteria and edge cases (see Test Coverage
section below).

### `docs/attestation-archival-tier.md`
- Documented `compact_archival`, `set/get/clear_compaction_retention`.
- Added storage key lifecycle diagram showing the three-stage progression:
  Active → Archived → Compacted.
- Updated test coverage table.

---

## API

### New methods

```rust
// Configure the minimum epoch age before full data may be compacted.
// Panics if min_epochs == 0 or caller is not admin.
fn set_compaction_retention(env: Env, caller: Address, min_epochs: u64)

// Read the current retention policy (None = compaction disabled).
fn get_compaction_retention(env: Env) -> Option<CompactionRetentionPolicy>

// Remove the retention policy, disabling compaction.
fn clear_compaction_retention(env: Env, caller: Address)

// Compact archived attestations whose expiry is >= min_epochs epochs in the past.
// Returns the number of entries actually compacted.
// Panics if limit == 0, caller is not admin, or no retention policy is set.
fn compact_archival(
    env: Env,
    caller: Address,
    candidates: Vec<(Address, String)>,
    limit: u32,
) -> u32
New Types
